### PR TITLE
Fix build order: generate Solidity artifacts before Rust build copies ABI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,8 @@ help:
 	@echo "  sol-fmt      - forge fmt (in contracts/)"
 
 build:
-	$(MAKE) rust-build
 	$(MAKE) sol-build
+	$(MAKE) rust-build
 
 fmt:
 	$(MAKE) rust-fmt


### PR DESCRIPTION
# Summary

The Rust workspace build was failing because `crates/world-id-core/build.rs` copies `contracts/out/AccountRegistry.sol/AccountRegistry.json`, which didn’t exist yet. This PR updates the build order so Solidity contracts are built before the Rust workspace, ensuring the ABI is present.

# Changes

Makefile: Swap `build` target order to run `sol-build` before `rust-build`.

# Rationale

`build.rs` depends on Foundry’s output (`contracts/out/.../AccountRegistry.json`). Running Rust first caused a `NotFound` error when the ABI hadn’t been generated yet.

# Testing

- Ran `make build`: succeeds.
- Verified `contracts/out/AccountRegistry.sol/AccountRegistry.json` exists after sol-build.
- Confirmed `cargo build --workspace` completes without the previous panic.