### PR TITLE
feat: make AccountRegistry tree depth configurable

### DIFF
--- a/contracts/script/AccountRegistry.s.sol
+++ b/contracts/script/AccountRegistry.s.sol
@@ -12,7 +12,7 @@ contract CounterScript is Script {
     function run() public {
         vm.startBroadcast();
 
-        accountRegistry = new AccountRegistry();
+        accountRegistry = new AccountRegistry(30);
 
         vm.stopBroadcast();
 

--- a/contracts/src/AccountRegistry.sol
+++ b/contracts/src/AccountRegistry.sol
@@ -98,8 +98,8 @@ contract AccountRegistry is EIP712, Ownable2Step {
     //                        Constructor                     //
     ////////////////////////////////////////////////////////////
 
-    constructor() EIP712(EIP712_NAME, EIP712_VERSION) Ownable(msg.sender) {
-        tree.initWithDefaultZeroes(30);
+    constructor(uint256 depth) EIP712(EIP712_NAME, EIP712_VERSION) Ownable(msg.sender) {
+        tree.initWithDefaultZeroes(depth);
     }
 
     ////////////////////////////////////////////////////////////

--- a/contracts/test/AccountRegistry.t.sol
+++ b/contracts/test/AccountRegistry.t.sol
@@ -25,7 +25,7 @@ contract AccountRegistryTest is Test {
 
     function setUp() public {
         recoveryAddress = vm.addr(RECOVERY_PRIVATE_KEY);
-        accountRegistry = new AccountRegistry();
+        accountRegistry = new AccountRegistry(30);
         alternateRecoveryAddress = vm.addr(RECOVERY_PRIVATE_KEY_ALT);
         AUTHENTICATOR_ADDRESS1 = vm.addr(AUTH1_PRIVATE_KEY);
         AUTHENTICATOR_ADDRESS2 = vm.addr(AUTH2_PRIVATE_KEY);


### PR DESCRIPTION
we use the authtree-indexer + the AccountRegistry in our integration tests, therefore we need to be able to change the tree depth in the contract.