### PR TITLE
feat: change pubkey id to u64

### DIFF
--- a/contracts/src/AbstractSignerPubkeyRegistry.sol
+++ b/contracts/src/AbstractSignerPubkeyRegistry.sol
@@ -18,11 +18,11 @@ abstract contract AbstractSignerPubkeyRegistry is EIP712, Ownable {
     }
 
     // Storage
-    mapping(uint256 => Pubkey) internal _idToPubkey;
+    mapping(uint64 => Pubkey) internal _idToPubkey;
     mapping(address => uint256) internal _addressToId;
-    uint256 internal _nextId = 1;
+    uint64 internal _nextId = 1;
     // Per-id EIP-712 nonce to prevent signature replay across updates
-    mapping(uint256 => uint256) internal _nonces;
+    mapping(uint64 => uint256) internal _nonces;
 
     /**
      * @dev Initializes the EIP-712 domain and sets the deployer as the initial owner.
@@ -59,7 +59,7 @@ abstract contract AbstractSignerPubkeyRegistry is EIP712, Ownable {
      * @param pubkey The registered pubkey.
      * @param signer The authorized signer for this id.
      */
-    function _emitRegistered(uint256 id, Pubkey memory pubkey, address signer) internal virtual;
+    function _emitRegistered(uint64 id, Pubkey memory pubkey, address signer) internal virtual;
 
     /**
      * @dev Hook for children to emit a domain-specific "removed" event.
@@ -67,7 +67,7 @@ abstract contract AbstractSignerPubkeyRegistry is EIP712, Ownable {
      * @param pubkey The pubkey that was associated with the id.
      * @param signer The signer that authorized the removal.
      */
-    function _emitRemoved(uint256 id, Pubkey memory pubkey, address signer) internal virtual;
+    function _emitRemoved(uint64 id, Pubkey memory pubkey, address signer) internal virtual;
 
     /**
      * @dev Hook for children to emit a domain-specific "pubkey updated" event.
@@ -76,7 +76,7 @@ abstract contract AbstractSignerPubkeyRegistry is EIP712, Ownable {
      * @param newPubkey The new pubkey.
      * @param signer The signer that authorized the change.
      */
-    function _emitPubkeyUpdated(uint256 id, Pubkey memory oldPubkey, Pubkey memory newPubkey, address signer)
+    function _emitPubkeyUpdated(uint64 id, Pubkey memory oldPubkey, Pubkey memory newPubkey, address signer)
         internal
         virtual;
 
@@ -86,7 +86,7 @@ abstract contract AbstractSignerPubkeyRegistry is EIP712, Ownable {
      * @param oldSigner The previous signer.
      * @param newSigner The new signer.
      */
-    function _emitSignerUpdated(uint256 id, address oldSigner, address newSigner) internal virtual;
+    function _emitSignerUpdated(uint64 id, address oldSigner, address newSigner) internal virtual;
 
     /**
      * @dev Registers a new id with `pubkey` and `signer`.
@@ -105,7 +105,7 @@ abstract contract AbstractSignerPubkeyRegistry is EIP712, Ownable {
         require(signer != address(0), "Registry: signer cannot be zero address");
         require(_addressToId[signer] == 0, "Registry: signer already registered");
 
-        uint256 id = _nextId;
+        uint64 id = _nextId;
         _idToPubkey[id] = pubkey;
         _addressToId[signer] = id;
         _emitRegistered(id, pubkey, signer);
@@ -123,7 +123,7 @@ abstract contract AbstractSignerPubkeyRegistry is EIP712, Ownable {
      * @param id The id to remove.
      * @param signature The EIP-712 signature authorizing the removal.
      */
-    function remove(uint256 id, bytes calldata signature) public onlyOwner {
+    function remove(uint64 id, bytes calldata signature) public onlyOwner {
         require(!_isEmptyPubkey(_idToPubkey[id]), "Registry: id not registered");
         bytes32 hash = _hashTypedDataV4(keccak256(abi.encode(_typehashRemove(), id, _nonces[id])));
         address signer = ECDSA.recover(hash, signature);
@@ -150,7 +150,7 @@ abstract contract AbstractSignerPubkeyRegistry is EIP712, Ownable {
      * @param newPubkey The new pubkey to associate with `id`.
      * @param signature The EIP-712 signature authorizing the pubkey change.
      */
-    function updatePubkey(uint256 id, Pubkey memory newPubkey, bytes calldata signature) public onlyOwner {
+    function updatePubkey(uint64 id, Pubkey memory newPubkey, bytes calldata signature) public onlyOwner {
         Pubkey memory oldPubkey = _idToPubkey[id];
         require(!_isEmptyPubkey(oldPubkey), "Registry: id not registered");
         require(!_isEmptyPubkey(newPubkey), "Registry: newPubkey cannot be zero");
@@ -179,7 +179,7 @@ abstract contract AbstractSignerPubkeyRegistry is EIP712, Ownable {
      * @param newSigner The address to set as the new signer for `id`.
      * @param signature The EIP-712 signature authorizing the signer change.
      */
-    function updateSigner(uint256 id, address newSigner, bytes calldata signature) public onlyOwner {
+    function updateSigner(uint64 id, address newSigner, bytes calldata signature) public onlyOwner {
         require(!_isEmptyPubkey(_idToPubkey[id]), "Registry: id not registered");
         require(newSigner != address(0), "Registry: newSigner cannot be zero address");
         require(_addressToId[newSigner] == 0, "Registry: newSigner already registered");
@@ -198,7 +198,7 @@ abstract contract AbstractSignerPubkeyRegistry is EIP712, Ownable {
     /**
      * @dev Returns the current nonce for the given id.
      */
-    function nonceOf(uint256 id) public view returns (uint256) {
+    function nonceOf(uint64 id) public view returns (uint256) {
         return _nonces[id];
     }
 

--- a/contracts/src/CredentialSchemaIssuerRegistry.sol
+++ b/contracts/src/CredentialSchemaIssuerRegistry.sol
@@ -15,7 +15,7 @@ contract CredentialSchemaIssuerRegistry is AbstractSignerPubkeyRegistry {
     ////////////////////////////////////////////////////////////
 
     // Stores the schema URI that contains the schema definition for each issuerSchemaId.
-    mapping(uint256 => string) public idToSchemaUri;
+    mapping(uint64 => string) public idToSchemaUri;
 
     ////////////////////////////////////////////////////////////
     //                        Constants                       //
@@ -24,13 +24,13 @@ contract CredentialSchemaIssuerRegistry is AbstractSignerPubkeyRegistry {
     string public constant EIP712_NAME = "CredentialSchemaIssuerRegistry";
     string public constant EIP712_VERSION = "1.0";
 
-    string public constant REMOVE_ISSUER_SCHEMA_TYPEDEF = "RemoveIssuerSchema(uint256 issuerSchemaId,uint256 nonce)";
+    string public constant REMOVE_ISSUER_SCHEMA_TYPEDEF = "RemoveIssuerSchema(uint64 issuerSchemaId,uint256 nonce)";
     string public constant UPDATE_PUBKEY_TYPEDEF =
-        "UpdateIssuerSchemaPubkey(uint256 issuerSchemaId,Pubkey newPubkey,Pubkey oldPubkey,uint256 nonce)";
+        "UpdateIssuerSchemaPubkey(uint64 issuerSchemaId,Pubkey newPubkey,Pubkey oldPubkey,uint256 nonce)";
     string public constant UPDATE_SIGNER_TYPEDEF =
-        "UpdateIssuerSchemaSigner(uint256 issuerSchemaId,address newSigner,uint256 nonce)";
+        "UpdateIssuerSchemaSigner(uint64 issuerSchemaId,address newSigner,uint256 nonce)";
     string public constant UPDATE_ISSUER_SCHEMA_URI_TYPEDEF =
-        "UpdateIssuerSchemaUri(uint256 issuerSchemaId,string schemaUri)";
+        "UpdateIssuerSchemaUri(uint64 issuerSchemaId,string schemaUri)";
 
     bytes32 public constant REMOVE_ISSUER_SCHEMA_TYPEHASH = keccak256(abi.encodePacked(REMOVE_ISSUER_SCHEMA_TYPEDEF));
     bytes32 public constant UPDATE_PUBKEY_TYPEHASH = keccak256(abi.encodePacked(UPDATE_PUBKEY_TYPEDEF));
@@ -42,11 +42,11 @@ contract CredentialSchemaIssuerRegistry is AbstractSignerPubkeyRegistry {
     //                        Events                          //
     ////////////////////////////////////////////////////////////
 
-    event IssuerSchemaRegistered(uint256 indexed issuerSchemaId, Pubkey pubkey, address signer);
-    event IssuerSchemaRemoved(uint256 indexed issuerSchemaId, Pubkey pubkey, address signer);
-    event IssuerSchemaPubkeyUpdated(uint256 indexed issuerSchemaId, Pubkey oldPubkey, Pubkey newPubkey, address signer);
-    event IssuerSchemaSignerUpdated(uint256 indexed issuerSchemaId, address oldSigner, address newSigner);
-    event IssuerSchemaUpdated(uint256 indexed issuerSchemaId, string oldSchemaUri, string newSchemaUri);
+    event IssuerSchemaRegistered(uint64 indexed issuerSchemaId, Pubkey pubkey, address signer);
+    event IssuerSchemaRemoved(uint64 indexed issuerSchemaId, Pubkey pubkey, address signer);
+    event IssuerSchemaPubkeyUpdated(uint64 indexed issuerSchemaId, Pubkey oldPubkey, Pubkey newPubkey, address signer);
+    event IssuerSchemaSignerUpdated(uint64 indexed issuerSchemaId, address oldSigner, address newSigner);
+    event IssuerSchemaUpdated(uint64 indexed issuerSchemaId, string oldSchemaUri, string newSchemaUri);
 
     ////////////////////////////////////////////////////////////
     //                        Constructor                     //
@@ -58,15 +58,15 @@ contract CredentialSchemaIssuerRegistry is AbstractSignerPubkeyRegistry {
     //                        Functions                       //
     ////////////////////////////////////////////////////////////
 
-    function issuerSchemaIdToPubkey(uint256 issuerSchemaId) public view returns (Pubkey memory) {
+    function issuerSchemaIdToPubkey(uint64 issuerSchemaId) public view returns (Pubkey memory) {
         return _idToPubkey[issuerSchemaId];
     }
 
-    function addressToIssuerSchemaId(address signer) public view returns (uint256) {
-        return _addressToId[signer];
+    function addressToIssuerSchemaId(address signer) public view returns (uint64) {
+        return uint64(_addressToId[signer]);
     }
 
-    function nextIssuerSchemaId() public view returns (uint256) {
+    function nextIssuerSchemaId() public view returns (uint64) {
         return _nextId;
     }
 
@@ -82,22 +82,22 @@ contract CredentialSchemaIssuerRegistry is AbstractSignerPubkeyRegistry {
         return UPDATE_SIGNER_TYPEHASH;
     }
 
-    function _emitRegistered(uint256 id, Pubkey memory pubkey, address signer) internal override {
+    function _emitRegistered(uint64 id, Pubkey memory pubkey, address signer) internal override {
         emit IssuerSchemaRegistered(id, pubkey, signer);
     }
 
-    function _emitRemoved(uint256 id, Pubkey memory pubkey, address signer) internal override {
+    function _emitRemoved(uint64 id, Pubkey memory pubkey, address signer) internal override {
         emit IssuerSchemaRemoved(id, pubkey, signer);
     }
 
-    function _emitPubkeyUpdated(uint256 id, Pubkey memory oldPubkey, Pubkey memory newPubkey, address signer)
+    function _emitPubkeyUpdated(uint64 id, Pubkey memory oldPubkey, Pubkey memory newPubkey, address signer)
         internal
         override
     {
         emit IssuerSchemaPubkeyUpdated(id, oldPubkey, newPubkey, signer);
     }
 
-    function _emitSignerUpdated(uint256 id, address oldSigner, address newSigner) internal override {
+    function _emitSignerUpdated(uint64 id, address oldSigner, address newSigner) internal override {
         emit IssuerSchemaSignerUpdated(id, oldSigner, newSigner);
     }
 
@@ -106,7 +106,7 @@ contract CredentialSchemaIssuerRegistry is AbstractSignerPubkeyRegistry {
      * @param issuerSchemaId The issuer+schema ID.
      * @return The schema URI for the issuerSchemaId.
      */
-    function getIssuerSchemaUri(uint256 issuerSchemaId) public view returns (string memory) {
+    function getIssuerSchemaUri(uint64 issuerSchemaId) public view returns (string memory) {
         return idToSchemaUri[issuerSchemaId];
     }
 
@@ -116,7 +116,7 @@ contract CredentialSchemaIssuerRegistry is AbstractSignerPubkeyRegistry {
      * @param schemaUri The new schema URI to set.
      * @param signature The signature of the issuer authorizing the update.
      */
-    function updateIssuerSchemaUri(uint256 issuerSchemaId, string memory schemaUri, bytes calldata signature) public {
+    function updateIssuerSchemaUri(uint64 issuerSchemaId, string memory schemaUri, bytes calldata signature) public {
         require(issuerSchemaId != 0, "Schema ID not registered");
         bytes32 hash =
             _hashTypedDataV4(keccak256(abi.encode(UPDATE_ISSUER_SCHEMA_URI_TYPEHASH, issuerSchemaId, schemaUri)));

--- a/contracts/src/RpRegistry.sol
+++ b/contracts/src/RpRegistry.sol
@@ -5,30 +5,30 @@ import {AbstractSignerPubkeyRegistry} from "./AbstractSignerPubkeyRegistry.sol";
 import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 
 contract RpRegistry is AbstractSignerPubkeyRegistry {
-    mapping(uint256 => uint256) public actionValidity;
-    mapping(uint256 => uint256) public nextActionId;
+    mapping(uint64 => uint256) public actionValidity;
+    mapping(uint64 => uint256) public nextActionId;
 
     // Keep constants and events for ABI stability and off-chain use
     string public constant EIP712_NAME = "RpRegistry";
     string public constant EIP712_VERSION = "1.0";
 
-    string public constant REMOVE_RP_TYPEDEF = "RemoveRp(uint256 rpId,uint256 nonce)";
+    string public constant REMOVE_RP_TYPEDEF = "RemoveRp(uint64 rpId,uint256 nonce)";
     string public constant UPDATE_PUBKEY_TYPEDEF =
-        "UpdatePubkey(uint256 rpId,Pubkey newPubkey,Pubkey oldPubkey,uint256 nonce)";
-    string public constant UPDATE_SIGNER_TYPEDEF = "UpdateSigner(uint256 rpId,address newSigner,uint256 nonce)";
+        "UpdatePubkey(uint64 rpId,Pubkey newPubkey,Pubkey oldPubkey,uint256 nonce)";
+    string public constant UPDATE_SIGNER_TYPEDEF = "UpdateSigner(uint64 rpId,address newSigner,uint256 nonce)";
     string public constant REGISTER_ACTION_TYPEDEF =
-        "RegisterAction(uint256 rpId,uint256 validityDuration,uint256 nonce)";
+        "RegisterAction(uint64 rpId,uint256 validityDuration,uint256 nonce)";
 
     bytes32 public constant REMOVE_RP_TYPEHASH = keccak256(abi.encodePacked(REMOVE_RP_TYPEDEF));
     bytes32 public constant UPDATE_PUBKEY_TYPEHASH = keccak256(abi.encodePacked(UPDATE_PUBKEY_TYPEDEF));
     bytes32 public constant UPDATE_SIGNER_TYPEHASH = keccak256(abi.encodePacked(UPDATE_SIGNER_TYPEDEF));
     bytes32 public constant REGISTER_ACTION_TYPEHASH = keccak256(abi.encodePacked(REGISTER_ACTION_TYPEDEF));
 
-    event RpRegistered(uint256 indexed rpId, Pubkey pubkey, address signer);
-    event RpRemoved(uint256 indexed rpId, Pubkey pubkey, address signer);
-    event PubkeyUpdated(uint256 indexed rpId, Pubkey oldPubkey, Pubkey newPubkey, address signer);
-    event SignerUpdated(uint256 indexed rpId, address oldSigner, address newSigner);
-    event ActionRegistered(uint256 indexed rpId, uint256 actionId, uint256 validityDuration);
+    event RpRegistered(uint64 indexed rpId, Pubkey pubkey, address signer);
+    event RpRemoved(uint64 indexed rpId, Pubkey pubkey, address signer);
+    event PubkeyUpdated(uint64 indexed rpId, Pubkey oldPubkey, Pubkey newPubkey, address signer);
+    event SignerUpdated(uint64 indexed rpId, address oldSigner, address newSigner);
+    event ActionRegistered(uint64 indexed rpId, uint256 actionId, uint256 validityDuration);
 
     constructor() AbstractSignerPubkeyRegistry(EIP712_NAME, EIP712_VERSION) {}
 
@@ -38,13 +38,13 @@ contract RpRegistry is AbstractSignerPubkeyRegistry {
      * @param validityDuration The validity duration of the action.
      * @param signature The signature of the action.
      */
-    function registerAction(uint256 rpId, uint256 validityDuration, bytes calldata signature) public onlyOwner {
+    function registerAction(uint64 rpId, uint256 validityDuration, bytes calldata signature) public onlyOwner {
         bytes32 hash =
             _hashTypedDataV4(keccak256(abi.encode(REGISTER_ACTION_TYPEHASH, rpId, validityDuration, _nonces[rpId])));
         address signer = ECDSA.recover(hash, signature);
         require(signer != address(0), "Invalid signature");
         require(_addressToId[signer] == rpId, "Signer not registered for this RP");
-        uint256 actionIdPacked = rpId << 128 | nextActionId[rpId];
+        uint64 actionIdPacked = (uint64(rpId) << 32) | uint64(uint32(nextActionId[rpId]));
         require(actionValidity[actionIdPacked] == 0, "Action already registered");
         actionValidity[actionIdPacked] = block.timestamp + validityDuration;
         emit ActionRegistered(rpId, nextActionId[rpId], validityDuration);
@@ -58,20 +58,20 @@ contract RpRegistry is AbstractSignerPubkeyRegistry {
      * @param actionId The ID of the action.
      * @return True if the action is valid, false otherwise.
      */
-    function isActionValid(uint256 rpId, uint256 actionId) public view returns (bool) {
-        uint256 actionIdPacked = rpId << 128 | actionId;
+    function isActionValid(uint64 rpId, uint256 actionId) public view returns (bool) {
+        uint64 actionIdPacked = (uint64(rpId) << 32) | uint64(uint32(actionId));
         return actionValidity[actionIdPacked] > block.timestamp;
     }
 
-    function rpIdToPubkey(uint256 rpId) public view returns (Pubkey memory) {
+    function rpIdToPubkey(uint64 rpId) public view returns (Pubkey memory) {
         return _idToPubkey[rpId];
     }
 
-    function addressToRpId(address signer) public view returns (uint256) {
-        return _addressToId[signer];
+    function addressToRpId(address signer) public view returns (uint64) {
+        return uint64(_addressToId[signer]);
     }
 
-    function nextRpId() public view returns (uint256) {
+    function nextRpId() public view returns (uint64) {
         return _nextId;
     }
 
@@ -87,22 +87,22 @@ contract RpRegistry is AbstractSignerPubkeyRegistry {
         return UPDATE_SIGNER_TYPEHASH;
     }
 
-    function _emitRegistered(uint256 id, Pubkey memory pubkey, address signer) internal override {
+    function _emitRegistered(uint64 id, Pubkey memory pubkey, address signer) internal override {
         emit RpRegistered(id, pubkey, signer);
     }
 
-    function _emitRemoved(uint256 id, Pubkey memory pubkey, address signer) internal override {
+    function _emitRemoved(uint64 id, Pubkey memory pubkey, address signer) internal override {
         emit RpRemoved(id, pubkey, signer);
     }
 
-    function _emitPubkeyUpdated(uint256 id, Pubkey memory oldPubkey, Pubkey memory newPubkey, address signer)
+    function _emitPubkeyUpdated(uint64 id, Pubkey memory oldPubkey, Pubkey memory newPubkey, address signer)
         internal
         override
     {
         emit PubkeyUpdated(id, oldPubkey, newPubkey, signer);
     }
 
-    function _emitSignerUpdated(uint256 id, address oldSigner, address newSigner) internal override {
+    function _emitSignerUpdated(uint64 id, address oldSigner, address newSigner) internal override {
         emit SignerUpdated(id, oldSigner, newSigner);
     }
 }

--- a/contracts/src/Verifier.sol
+++ b/contracts/src/Verifier.sol
@@ -22,9 +22,9 @@ contract Verifier is Ownable {
 
     function verify(
         bytes memory proof,
-        uint256 rpId,
+        uint64 rpId,
         uint256 actionId,
-        uint256 credentialIssuerId,
+        uint64 credentialIssuerId,
         uint256 authenticatorRoot
     ) external view returns (bool) {
         require(accountRegistry.isValidRoot(authenticatorRoot), "Invalid authenticator root");

--- a/contracts/test/CredentialSchemaIssuerRegistry.t.sol
+++ b/contracts/test/CredentialSchemaIssuerRegistry.t.sol
@@ -86,7 +86,7 @@ contract CredentialIssuerRegistryTest is RegistryTestBase {
         assertEq(registry.addressToIssuerSchemaId(signer), 0);
     }
 
-    function _signUpdateIssuerSchemaUri(uint256 sk, uint256 issuerSchemaId, string memory schemaUri)
+    function _signUpdateIssuerSchemaUri(uint256 sk, uint64 issuerSchemaId, string memory schemaUri)
         internal
         view
         returns (bytes memory)

--- a/contracts/test/RegistryTestBase.t.sol
+++ b/contracts/test/RegistryTestBase.t.sol
@@ -7,7 +7,7 @@ import {AbstractSignerPubkeyRegistry as A} from "../src/AbstractSignerPubkeyRegi
 interface RegistryLike {
     function EIP712_NAME() external view returns (string memory);
     function EIP712_VERSION() external view returns (string memory);
-    function nonceOf(uint256 id) external view returns (uint256);
+    function nonceOf(uint64 id) external view returns (uint256);
 }
 
 abstract contract RegistryTestBase is Test {
@@ -24,7 +24,7 @@ abstract contract RegistryTestBase is Test {
         return keccak256(abi.encode(EIP712_DOMAIN_TYPEHASH, nameHash, versionHash, block.chainid, registry));
     }
 
-    function _signRemove(bytes32 removeTypehash, RegistryLike registry, uint256 pk, uint256 id)
+    function _signRemove(bytes32 removeTypehash, RegistryLike registry, uint256 pk, uint64 id)
         internal
         view
         returns (bytes memory)
@@ -45,7 +45,7 @@ abstract contract RegistryTestBase is Test {
         bytes32 updatePubkeyTypehash,
         RegistryLike registry,
         uint256 pk,
-        uint256 id,
+        uint64 id,
         A.Pubkey memory newPubkey,
         A.Pubkey memory oldPubkey
     ) internal view returns (bytes memory) {
@@ -65,7 +65,7 @@ abstract contract RegistryTestBase is Test {
         bytes32 updateSignerTypehash,
         RegistryLike registry,
         uint256 pk,
-        uint256 id,
+        uint64 id,
         address newSigner
     ) internal view returns (bytes memory) {
         bytes32 structHash = keccak256(abi.encode(updateSignerTypehash, id, newSigner, registry.nonceOf(id)));


### PR DESCRIPTION
The `account_id` and `issuer_schema_id` are `u64` in the implementation, this updates the contract to also use `uint64` for consistency.