### PR TITLE
feat: flip signer <-> id lookup for cred registry

### DIFF
--- a/contracts/foundry.lock
+++ b/contracts/foundry.lock
@@ -1,0 +1,11 @@
+{
+  "lib/forge-std": {
+    "rev": "8bbcf6e3f8f62f419e5429a0bd89331c85c37824"
+  },
+  "lib/openzeppelin-contracts": {
+    "rev": "c64a1edb67b6e3f4a15cca8909c9482ad33a02b0"
+  },
+  "lib/poseidon-solidity": {
+    "rev": "8205c97ec4a35a9adb854b70b2c9ba92668d1304"
+  }
+}

--- a/contracts/src/CredentialSchemaIssuerRegistry.sol
+++ b/contracts/src/CredentialSchemaIssuerRegistry.sol
@@ -24,7 +24,10 @@ contract CredentialSchemaIssuerRegistry is EIP712 {
     ////////////////////////////////////////////////////////////
 
     mapping(uint256 => Pubkey) private _idToPubkey;
-    mapping(address => uint256) private _addressToId;
+
+    // Stores the on-chain signer address for each issuerSchemaId, i.e. who is authorized to perform updates on the issuerSchemaId.
+    mapping(uint256 => address) private _idToAddress;
+
     uint256 private _nextId = 1;
     mapping(uint256 => uint256) private _nonces;
 
@@ -75,11 +78,10 @@ contract CredentialSchemaIssuerRegistry is EIP712 {
     function register(Pubkey memory pubkey, address signer) public {
         require(pubkey.x != 0 && pubkey.y != 0, "Registry: pubkey cannot be zero");
         require(signer != address(0), "Registry: signer cannot be zero address");
-        require(_addressToId[signer] == 0, "Registry: signer already registered");
 
         uint256 issuerSchemaId = _nextId;
         _idToPubkey[issuerSchemaId] = pubkey;
-        _addressToId[signer] = issuerSchemaId;
+        _idToAddress[issuerSchemaId] = signer;
         emit IssuerSchemaRegistered(issuerSchemaId, pubkey, signer);
         _nextId = issuerSchemaId + 1;
     }
@@ -91,13 +93,13 @@ contract CredentialSchemaIssuerRegistry is EIP712 {
             keccak256(abi.encode(REMOVE_ISSUER_SCHEMA_TYPEHASH, issuerSchemaId, _nonces[issuerSchemaId]))
         );
         address signer = ECDSA.recover(hash, signature);
-        require(_addressToId[signer] == issuerSchemaId, "Registry: invalid signature");
+        require(_idToAddress[issuerSchemaId] == signer, "Registry: invalid signature");
 
         emit IssuerSchemaRemoved(issuerSchemaId, pubkey, signer);
 
         _nonces[issuerSchemaId]++;
         delete _idToPubkey[issuerSchemaId];
-        delete _addressToId[signer];
+        delete _idToAddress[issuerSchemaId];
         delete idToSchemaUri[issuerSchemaId];
     }
 
@@ -109,7 +111,7 @@ contract CredentialSchemaIssuerRegistry is EIP712 {
             keccak256(abi.encode(UPDATE_PUBKEY_TYPEHASH, issuerSchemaId, newPubkey, oldPubkey, _nonces[issuerSchemaId]))
         );
         address signer = ECDSA.recover(hash, signature);
-        require(_addressToId[signer] == issuerSchemaId, "Registry: invalid signature");
+        require(_idToAddress[issuerSchemaId] == signer, "Registry: invalid signature");
 
         _idToPubkey[issuerSchemaId] = newPubkey;
         emit IssuerSchemaPubkeyUpdated(issuerSchemaId, oldPubkey, newPubkey, signer);
@@ -120,16 +122,15 @@ contract CredentialSchemaIssuerRegistry is EIP712 {
     function updateSigner(uint256 issuerSchemaId, address newSigner, bytes calldata signature) public {
         require(!_isEmptyPubkey(_idToPubkey[issuerSchemaId]), "Registry: id not registered");
         require(newSigner != address(0), "Registry: newSigner cannot be zero address");
-        require(_addressToId[newSigner] == 0, "Registry: newSigner already registered");
+        require(_idToAddress[issuerSchemaId] != newSigner, "Registry: newSigner is already the assigned signer");
 
         bytes32 hash = _hashTypedDataV4(
             keccak256(abi.encode(UPDATE_SIGNER_TYPEHASH, issuerSchemaId, newSigner, _nonces[issuerSchemaId]))
         );
         address oldSigner = ECDSA.recover(hash, signature);
-        require(_addressToId[oldSigner] == issuerSchemaId, "Registry: invalid signature");
+        require(_idToAddress[issuerSchemaId] == oldSigner, "Registry: invalid signature");
 
-        _addressToId[newSigner] = issuerSchemaId;
-        delete _addressToId[oldSigner];
+        _idToAddress[issuerSchemaId] = newSigner;
         emit IssuerSchemaSignerUpdated(issuerSchemaId, oldSigner, newSigner);
 
         _nonces[issuerSchemaId]++;
@@ -155,7 +156,7 @@ contract CredentialSchemaIssuerRegistry is EIP712 {
         bytes32 hash =
             _hashTypedDataV4(keccak256(abi.encode(UPDATE_ISSUER_SCHEMA_URI_TYPEHASH, issuerSchemaId, schemaUri)));
         address signer = ECDSA.recover(hash, signature);
-        require(_addressToId[signer] == issuerSchemaId, "Registry: invalid signature");
+        require(_idToAddress[issuerSchemaId] == signer, "Registry: invalid signature");
 
         string memory oldSchemaUri = idToSchemaUri[issuerSchemaId];
         idToSchemaUri[issuerSchemaId] = schemaUri;
@@ -163,12 +164,22 @@ contract CredentialSchemaIssuerRegistry is EIP712 {
         emit IssuerSchemaUpdated(issuerSchemaId, oldSchemaUri, schemaUri);
     }
 
+    /**
+     * @dev Returns the off-chain pubkey for a specific issuerSchemaId which signs credentials and whose signature is verified on World ID ZKPs.
+     * @param issuerSchemaId The issuer-schema ID whose pubkey will be returned.
+     * @return The pubkey for the issuerSchemaId.
+     */
     function issuerSchemaIdToPubkey(uint256 issuerSchemaId) public view returns (Pubkey memory) {
         return _idToPubkey[issuerSchemaId];
     }
 
-    function addressToIssuerSchemaId(address signer) public view returns (uint256) {
-        return _addressToId[signer];
+    /**
+     * @dev Returns the on-chain signer address authorized to perform updates on a specific issuerSchemaId.
+     * @param issuerSchemaId The issuer-schema ID whose signer will be returned.
+     * @return The on-chain signer address for the issuerSchemaId.
+     */
+    function getSignerForIssuerSchemaId(uint256 issuerSchemaId) public view returns (address) {
+        return _idToAddress[issuerSchemaId];
     }
 
     function nextIssuerSchemaId() public view returns (uint256) {

--- a/contracts/test/CredentialSchemaIssuerRegistry.t.sol
+++ b/contracts/test/CredentialSchemaIssuerRegistry.t.sol
@@ -72,7 +72,7 @@ contract CredentialIssuerRegistryTest is Test {
 
         assertEq(registry.nextIssuerSchemaId(), 2);
         assertTrue(_isEq(registry.issuerSchemaIdToPubkey(1), pubkey));
-        assertEq(registry.addressToIssuerSchemaId(signer), 1);
+        assertEq(registry.getSignerForIssuerSchemaId(1), signer);
     }
 
     function testUpdatePubkeyFlow() public {
@@ -103,8 +103,18 @@ contract CredentialIssuerRegistryTest is Test {
         emit CredentialSchemaIssuerRegistry.IssuerSchemaSignerUpdated(1, oldSigner, newSigner);
         registry.updateSigner(1, newSigner, sig);
 
-        assertEq(registry.addressToIssuerSchemaId(oldSigner), 0);
-        assertEq(registry.addressToIssuerSchemaId(newSigner), 1);
+        assertEq(registry.getSignerForIssuerSchemaId(1), newSigner);
+    }
+
+    function testUpdateSignerToSameSigner() public {
+        uint256 signerPk = 0xAAA3;
+        address signer = vm.addr(signerPk);
+        registry.register(_generatePubkey("k"), signer);
+
+        bytes memory sig = _signUpdateSigner(signerPk, 1, signer);
+        vm.expectRevert(bytes("Registry: newSigner is already the assigned signer"));
+        registry.updateSigner(1, signer, sig);
+        assertEq(registry.getSignerForIssuerSchemaId(1), signer);
     }
 
     function testRemoveFlow() public {
@@ -120,7 +130,7 @@ contract CredentialIssuerRegistryTest is Test {
         registry.remove(1, sig);
 
         assertTrue(_isEq(registry.issuerSchemaIdToPubkey(1), CredentialSchemaIssuerRegistry.Pubkey(0, 0)));
-        assertEq(registry.addressToIssuerSchemaId(signer), 0);
+        assertEq(registry.getSignerForIssuerSchemaId(1), address(0));
     }
 
     function _signUpdateIssuerSchemaUri(uint256 sk, uint256 issuerSchemaId, string memory schemaUri)


### PR DESCRIPTION
Each schemaIssuerId must have one signer, but a single signer can register many schemas.