### PR TITLE
fix eip712 type encoding

### DIFF
--- a/contracts/src/CredentialSchemaIssuerRegistry.sol
+++ b/contracts/src/CredentialSchemaIssuerRegistry.sol
@@ -43,7 +43,7 @@ contract CredentialSchemaIssuerRegistry is EIP712 {
 
     string public constant REMOVE_ISSUER_SCHEMA_TYPEDEF = "RemoveIssuerSchema(uint256 issuerSchemaId,uint256 nonce)";
     string public constant UPDATE_PUBKEY_TYPEDEF =
-        "UpdateIssuerSchemaPubkey(uint256 issuerSchemaId,Pubkey newPubkey,Pubkey oldPubkey,uint256 nonce)";
+        "UpdateIssuerSchemaPubkey(uint256 issuerSchemaId,Pubkey newPubkey,Pubkey oldPubkey,uint256 nonce)Pubkey(uint256 x,uint256 y)";
     string public constant UPDATE_SIGNER_TYPEDEF =
         "UpdateIssuerSchemaSigner(uint256 issuerSchemaId,address newSigner,uint256 nonce)";
     string public constant UPDATE_ISSUER_SCHEMA_URI_TYPEDEF =
@@ -154,8 +154,9 @@ contract CredentialSchemaIssuerRegistry is EIP712 {
      */
     function updateIssuerSchemaUri(uint256 issuerSchemaId, string memory schemaUri, bytes calldata signature) public {
         require(issuerSchemaId != 0, "Schema ID not registered");
+        bytes32 schemaUriHash = keccak256(bytes(schemaUri));
         bytes32 hash =
-            _hashTypedDataV4(keccak256(abi.encode(UPDATE_ISSUER_SCHEMA_URI_TYPEHASH, issuerSchemaId, schemaUri)));
+            _hashTypedDataV4(keccak256(abi.encode(UPDATE_ISSUER_SCHEMA_URI_TYPEHASH, issuerSchemaId, schemaUriHash)));
         address signer = ECDSA.recover(hash, signature);
         require(_idToAddress[issuerSchemaId] == signer, "Registry: invalid signature");
 

--- a/contracts/test/CredentialSchemaIssuerRegistry.t.sol
+++ b/contracts/test/CredentialSchemaIssuerRegistry.t.sol
@@ -139,8 +139,9 @@ contract CredentialIssuerRegistryTest is Test {
         view
         returns (bytes memory)
     {
+        bytes32 schemaUriHash = keccak256(bytes(schemaUri));
         bytes32 structHash =
-            keccak256(abi.encode(registry.UPDATE_ISSUER_SCHEMA_URI_TYPEHASH(), issuerSchemaId, schemaUri));
+            keccak256(abi.encode(registry.UPDATE_ISSUER_SCHEMA_URI_TYPEHASH(), issuerSchemaId, schemaUriHash));
         bytes32 digest = keccak256(abi.encodePacked("\x19\x01", _domainSeparator(), structHash));
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(sk, digest);
         return abi.encodePacked(r, s, v);


### PR DESCRIPTION
`Pubkey` definition needs to be part of type definition to be compatible: https://eips.ethereum.org/EIPS/eip-712#definition-of-encodetype