### PR TITLE
fix: hash updatePubkey following EIP-712

### DIFF
--- a/contracts/out/CredentialSchemaIssuerRegistry.sol/CredentialSchemaIssuerRegistryAbi.json
+++ b/contracts/out/CredentialSchemaIssuerRegistry.sol/CredentialSchemaIssuerRegistryAbi.json
@@ -32,6 +32,32 @@
   },
   {
     "type": "function",
+    "name": "PUBKEY_TYPEDEF",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "PUBKEY_TYPEHASH",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
     "name": "REMOVE_ISSUER_SCHEMA_TYPEDEF",
     "inputs": [],
     "outputs": [

--- a/contracts/src/CredentialSchemaIssuerRegistry.sol
+++ b/contracts/src/CredentialSchemaIssuerRegistry.sol
@@ -70,12 +70,14 @@ contract CredentialSchemaIssuerRegistry is Initializable, EIP712Upgradeable, Own
         "UpdateIssuerSchemaSigner(uint256 issuerSchemaId,address newSigner,uint256 nonce)";
     string public constant UPDATE_ISSUER_SCHEMA_URI_TYPEDEF =
         "UpdateIssuerSchemaUri(uint256 issuerSchemaId,string schemaUri,uint256 nonce)";
+    string public constant PUBKEY_TYPEDEF = "Pubkey(uint256 x,uint256 y)";
 
     bytes32 public constant REMOVE_ISSUER_SCHEMA_TYPEHASH = keccak256(abi.encodePacked(REMOVE_ISSUER_SCHEMA_TYPEDEF));
     bytes32 public constant UPDATE_PUBKEY_TYPEHASH = keccak256(abi.encodePacked(UPDATE_PUBKEY_TYPEDEF));
     bytes32 public constant UPDATE_SIGNER_TYPEHASH = keccak256(abi.encodePacked(UPDATE_SIGNER_TYPEDEF));
     bytes32 public constant UPDATE_ISSUER_SCHEMA_URI_TYPEHASH =
         keccak256(abi.encodePacked(UPDATE_ISSUER_SCHEMA_URI_TYPEDEF));
+    bytes32 public constant PUBKEY_TYPEHASH = keccak256(abi.encodePacked(PUBKEY_TYPEDEF));
 
     ////////////////////////////////////////////////////////////
     //                        Events                          //
@@ -148,8 +150,16 @@ contract CredentialSchemaIssuerRegistry is Initializable, EIP712Upgradeable, Own
         Pubkey memory oldPubkey = _idToPubkey[issuerSchemaId];
         require(!_isEmptyPubkey(oldPubkey), "Registry: id not registered");
         require(!_isEmptyPubkey(newPubkey), "Registry: newPubkey cannot be zero");
+
+        bytes32 newPubkeyHash = keccak256(abi.encode(PUBKEY_TYPEHASH, newPubkey.x, newPubkey.y));
+        bytes32 oldPubkeyHash = keccak256(abi.encode(PUBKEY_TYPEHASH, oldPubkey.x, oldPubkey.y));
+
         bytes32 hash = _hashTypedDataV4(
-            keccak256(abi.encode(UPDATE_PUBKEY_TYPEHASH, issuerSchemaId, newPubkey, oldPubkey, _nonces[issuerSchemaId]))
+            keccak256(
+                abi.encode(
+                    UPDATE_PUBKEY_TYPEHASH, issuerSchemaId, newPubkeyHash, oldPubkeyHash, _nonces[issuerSchemaId]
+                )
+            )
         );
         address signer = ECDSA.recover(hash, signature);
         require(_idToAddress[issuerSchemaId] == signer, InvalidSignature());

--- a/contracts/test/CredentialSchemaIssuerRegistry.t.sol
+++ b/contracts/test/CredentialSchemaIssuerRegistry.t.sol
@@ -45,8 +45,11 @@ contract CredentialIssuerRegistryTest is Test {
         CredentialSchemaIssuerRegistry.Pubkey memory newPubkey,
         CredentialSchemaIssuerRegistry.Pubkey memory oldPubkey
     ) internal view returns (bytes memory) {
+        bytes32 oldPubkeyHash = keccak256(abi.encode(registry.PUBKEY_TYPEHASH(), oldPubkey.x, oldPubkey.y));
+        bytes32 newPubkeyHash = keccak256(abi.encode(registry.PUBKEY_TYPEHASH(), newPubkey.x, newPubkey.y));
+
         bytes32 structHash = keccak256(
-            abi.encode(registry.UPDATE_PUBKEY_TYPEHASH(), id, newPubkey, oldPubkey, registry.nonceOf(id))
+            abi.encode(registry.UPDATE_PUBKEY_TYPEHASH(), id, newPubkeyHash, oldPubkeyHash, registry.nonceOf(id))
         );
         bytes32 digest = keccak256(abi.encodePacked("\x19\x01", _domainSeparator(), structHash));
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(pk, digest);


### PR DESCRIPTION
[EIP-712](https://eips.ethereum.org/EIPS/eip-712#definition-of-hashstruct) specifies that structs should be hashed recursively. Updating the `	updatePubkey` method to follow EIP-712 specs. Addresses report 6.4 from initial audit.