### PR TITLE
feat: migrate to single MerkleInclusionProof

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-    "rust-analyzer.cargo.features": ["issuer", "authenticator", "integration-tests"]
+    "rust-analyzer.cargo.features": "all"
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4744,6 +4744,7 @@ dependencies = [
  "tracing",
  "uuid",
  "world-id-core",
+ "world-id-primitives",
 ]
 
 [[package]]
@@ -6909,6 +6910,7 @@ dependencies = [
  "serde_json",
  "taceo-ark-babyjubjub",
  "taceo-poseidon2",
+ "world-id-primitives",
 ]
 
 [[package]]

--- a/crates/oprf-client/Cargo.toml
+++ b/crates/oprf-client/Cargo.toml
@@ -32,6 +32,7 @@ tokio = { workspace = true, optional = true, features = [
 ] }
 tracing.workspace = true
 uuid = { workspace = true, features = ["serde", "v4"] }
+world-id-primitives = { workspace = true }
 
 [features]
 default = ["tokio"]

--- a/crates/oprf-world-types/src/lib.rs
+++ b/crates/oprf-world-types/src/lib.rs
@@ -8,9 +8,6 @@ use serde::{Deserialize, Serialize};
 pub mod api;
 pub mod proof_inputs;
 
-/// The depth of the merkle-tree
-pub const TREE_DEPTH: usize = 30;
-
 /// Represents a merkle root hash. The inner type is a base field element from BabyJubJub for convenience instead of a scalar field element on BN254.
 #[derive(
     Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Default, Serialize, Deserialize,
@@ -137,20 +134,4 @@ pub struct CredentialsSignature {
     pub issuer: EdDSAPublicKey,
     /// The credential’s signature object.
     pub signature: EdDSASignature,
-}
-
-/// Artifacts required to compute the Merkle inclusion proof
-/// for a user’s public key.
-///
-/// Each public key is tied to a leaf in a Merkle tree.
-/// To prove validity, the user shows membership in the tree
-/// with a sibling path up to the root.
-#[derive(Clone)]
-pub struct MerkleMembership {
-    /// The actual Merkle root (not sent to the OPRF service, only used for computing the proof).
-    pub root: MerkleRoot,
-    /// The index of the user’s leaf in the Merkle tree.
-    pub mt_index: u64,
-    /// The sibling path up to the Merkle root.  
-    pub siblings: [ark_babyjubjub::Fq; TREE_DEPTH],
 }

--- a/crates/test-utils/Cargo.toml
+++ b/crates/test-utils/Cargo.toml
@@ -22,3 +22,4 @@ poseidon2 = { workspace = true }
 ark-babyjubjub = { workspace = true }
 ark-ff = { workspace = true }
 oprf-world-types = { workspace = true }
+world-id-primitives = { workspace = true }

--- a/crates/test-utils/src/merkle.rs
+++ b/crates/test-utils/src/merkle.rs
@@ -1,25 +1,25 @@
 use ark_babyjubjub::Fq;
 use ark_ff::AdditiveGroup;
-use oprf_world_types::TREE_DEPTH;
 use poseidon2::Poseidon2;
+use world_id_primitives::{FieldElement, TREE_DEPTH};
 
 /// Builds the default-zero sibling path for index 0 and computes the Merkle root
 /// after inserting the provided `leaf` at that index, using Poseidon2 T2 compress.
-pub fn first_leaf_merkle_path(leaf: Fq) -> ([Fq; TREE_DEPTH], Fq) {
+pub fn first_leaf_merkle_path(leaf: Fq) -> ([FieldElement; TREE_DEPTH], FieldElement) {
     let poseidon2_2: Poseidon2<Fq, 2, 5> = Poseidon2::default();
-    let mut siblings = [Fq::ZERO; TREE_DEPTH];
+    let mut siblings = [FieldElement::ZERO; TREE_DEPTH];
     let mut zero = Fq::ZERO;
     for sibling in siblings.iter_mut() {
-        *sibling = zero;
+        *sibling = zero.into();
         zero = poseidon2_compress(&poseidon2_2, zero, zero);
     }
 
     let mut current = leaf;
     for sibling in siblings.iter() {
-        current = poseidon2_compress(&poseidon2_2, current, *sibling);
+        current = poseidon2_compress(&poseidon2_2, current, **sibling);
     }
 
-    (siblings, current)
+    (siblings, current.into())
 }
 
 /// Poseidon2 "compress" for a pair of field elements (left, right).


### PR DESCRIPTION
Removes duplicate `MerkleMembership` type.