### PR TITLE
skip 'forge install' in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,12 +48,12 @@ run-gateway:
 
 # forge install requires git; skip in Docker where .git is excluded but lib/ contents are copied
 sol-build:
-	cd contracts && (git rev-parse --git-dir > /dev/null 2>&1 && forge install || true) && forge build && \
+	cd contracts && if git rev-parse --git-dir > /dev/null 2>&1; then forge install; fi && forge build && \
 	forge inspect AccountRegistry abi --json > ../crates/core/contracts/out/AccountRegistry.sol/AccountRegistryAbi.json && \
 	forge inspect CredentialSchemaIssuerRegistry abi --json > ../crates/core/contracts/out/CredentialSchemaIssuerRegistry.sol/CredentialSchemaIssuerRegistryAbi.json
 
 sol-test:
-	cd contracts && (git rev-parse --git-dir > /dev/null 2>&1 && forge install || true) && forge test -vvv
+	cd contracts && if git rev-parse --git-dir > /dev/null 2>&1; then forge install; fi && forge test -vvv
 
 sol-fmt:
 	cd contracts && forge fmt


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Skip `forge install` in `sol-build` and `sol-test` when the repository metadata is absent (e.g., CI/Docker), while keeping build/tests intact.
> 
> - **Build/Makefile**:
>   - `sol-build`: Wrap `forge install` with a git check (`git rev-parse`) to skip when `.git` is missing; still runs `forge build` and ABI exports.
>   - `sol-test`: Apply the same conditional around `forge install` before running tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 15b80f0da570a87bfb3c7b19e5e0ff623547c955. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->