### PR TITLE
fix: contract lint failures

### DIFF
--- a/contracts/src/AccountRegistry.sol
+++ b/contracts/src/AccountRegistry.sol
@@ -468,15 +468,14 @@ contract AccountRegistry is Initializable, EIP712Upgradeable, Ownable2StepUpgrad
         uint256 leafIndex = nextLeafIndex;
 
         uint256 bitmap = 0;
-        for (uint256 i = 0; i < authenticatorAddresses.length; i++) {
+        for (uint32 i = 0; i < authenticatorAddresses.length; i++) {
             address authenticatorAddress = authenticatorAddresses[i];
             if (authenticatorAddress == address(0)) {
                 revert ZeroAddress();
             }
 
             _validateNewAuthenticatorAddress(authenticatorAddress);
-            authenticatorAddressToPackedAccountData[authenticatorAddress] =
-                PackedAccountData.pack(leafIndex, 0, uint32(i));
+            authenticatorAddressToPackedAccountData[authenticatorAddress] = PackedAccountData.pack(leafIndex, 0, i);
             bitmap = bitmap | (1 << i);
         }
         _setRecoveryAddressAndBitmap(leafIndex, recoveryAddress, bitmap);

--- a/contracts/src/CredentialSchemaIssuerRegistry.sol
+++ b/contracts/src/CredentialSchemaIssuerRegistry.sol
@@ -32,10 +32,14 @@ contract CredentialSchemaIssuerRegistry is Initializable, EIP712Upgradeable, Own
     error InvalidPubkey();
 
     modifier onlyInitialized() {
+        _onlyInitialized();
+        _;
+    }
+
+    function _onlyInitialized() internal view {
         if (_getInitializedVersion() == 0) {
             revert ImplementationNotInitialized();
         }
-        _;
     }
 
     ////////////////////////////////////////////////////////////

--- a/contracts/src/Verifier.sol
+++ b/contracts/src/Verifier.sol
@@ -18,11 +18,16 @@ contract Verifier is Initializable, Ownable2StepUpgradeable, UUPSUpgradeable {
     error ImplementationNotInitialized();
 
     modifier onlyInitialized() {
+        _onlyInitialized();
+        _;
+    }
+
+    function _onlyInitialized() internal view {
         if (_getInitializedVersion() == 0) {
             revert ImplementationNotInitialized();
         }
-        _;
     }
+
     /// @notice Registry for credential schema and issuer management
     CredentialSchemaIssuerRegistry public credentialSchemaIssuerRegistry;
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Extracts internal _onlyInitialized in registries and switches AccountRegistry registration loop index to uint32, simplifying packing.
> 
> - **Contracts**:
>   - **Initialization guards** (`CredentialSchemaIssuerRegistry.sol`, `Verifier.sol`):
>     - Refactor `onlyInitialized` to delegate to internal `_onlyInitialized()` helper.
>   - **Account registration** (`AccountRegistry.sol`):
>     - Change authenticator loop index from `uint256` to `uint32`; pass `i` directly to `PackedAccountData.pack` during registration.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 49854e078c77fbf7f3b3e2768f4bf148b5f29d28. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->