### PR TITLE
feat: receive genesis_issued_at_min constraint from the RP

### DIFF
--- a/crates/core/bin/issuer.rs
+++ b/crates/core/bin/issuer.rs
@@ -19,7 +19,7 @@ async fn main() -> Result<()> {
     let cred_sub_blinding_factor = FieldElement::random(&mut rng);
     let current_timestamp = Utc::now().timestamp() as u64;
     let credential = Credential::new()
-        .blinded_sub(leaf_index, cred_sub_blinding_factor)
+        .sub(leaf_index, cred_sub_blinding_factor)
         .issuer_schema_id(ISSUER_SCHEMA_ID)
         .genesis_issued_at(current_timestamp)
         .expires_at(current_timestamp + EXPIRATION_TIME)

--- a/crates/core/src/authenticator.rs
+++ b/crates/core/src/authenticator.rs
@@ -466,6 +466,7 @@ impl Authenticator {
             rp_signature: proof_request.signature,
             oprf_public_key: proof_request.oprf_public_key,
             signal_hash: request_item.signal_hash(),
+            genesis_issued_at_min: request_item.genesis_issued_at_min.unwrap_or(0), // When not provided, the minimum is set to 0 to "ignore" the constraint
         };
 
         let private_key = self.signer.offchain_signer_private_key().expose_secret();

--- a/crates/core/src/credential.rs
+++ b/crates/core/src/credential.rs
@@ -65,7 +65,7 @@ impl HashableCredential for Credential {
                 let mut input = [
                     *self.get_cred_ds(),
                     self.issuer_schema_id.into(),
-                    *self.blinded_sub,
+                    *self.sub,
                     self.genesis_issued_at.into(),
                     self.expires_at.into(),
                     *self.claims_hash()?,
@@ -114,7 +114,7 @@ mod tests {
         let credential = Credential::new()
             .version(CredentialVersion::V1)
             .issuer_schema_id(123)
-            .blinded_sub(456, FieldElement::random(&mut rand::thread_rng()))
+            .sub(456, FieldElement::random(&mut rand::thread_rng()))
             .genesis_issued_at(1234567890)
             .expires_at(1234567890 + 86_400)
             .claim_hash(0, U256::from(999))

--- a/crates/core/src/proof.rs
+++ b/crates/core/src/proof.rs
@@ -294,7 +294,7 @@ pub async fn nullifier<R: Rng + CryptoRng>(
             *args.credential.associated_data_hash,
         ],
         cred_genesis_issued_at: args.credential.genesis_issued_at.into(),
-        cred_genesis_issued_at_min: args.credential.genesis_issued_at_min.into(),
+        cred_genesis_issued_at_min: args.genesis_issued_at_min.into(),
         cred_expires_at: args.credential.expires_at.into(),
         cred_id: args.credential.id.into(),
         cred_sub_blinding_factor: *args.credential_sub_blinding_factor,

--- a/crates/core/tests/nullifier_proof_generation.rs
+++ b/crates/core/tests/nullifier_proof_generation.rs
@@ -199,6 +199,7 @@ async fn test_nullifier_proof_generation() -> eyre::Result<()> {
         oprf_public_key,
         signal_hash,
         session_id_r_seed: rp_fixture.rp_session_id_r_seed,
+        genesis_issued_at_min: 0,
     };
 
     // Produce πR (signed OPRF query) — blinded request + query inputs
@@ -245,7 +246,7 @@ async fn test_nullifier_proof_generation() -> eyre::Result<()> {
             *args.credential.associated_data_hash,
         ],
         cred_genesis_issued_at: args.credential.genesis_issued_at.into(),
-        cred_genesis_issued_at_min: args.credential.genesis_issued_at_min.into(),
+        cred_genesis_issued_at_min: args.genesis_issued_at_min.into(),
         cred_expires_at: args.credential.expires_at.into(),
         cred_id: args.credential.id.into(),
         cred_sub_blinding_factor: *args.credential_sub_blinding_factor,

--- a/crates/primitives/src/proof.rs
+++ b/crates/primitives/src/proof.rs
@@ -171,6 +171,12 @@ pub struct SingleProofInput<const TREE_DEPTH: usize> {
     /// to ensure the integrity of the proof. For example, in a voting application, the signal could
     /// be used to encode the user's vote.
     pub signal_hash: FieldElement,
+
+    /// The minimum genesis issued at (unix seconds) of the credential.
+    ///
+    /// This minimum allows RPs to require that the credential was first issued
+    /// after a certain time (`genesis_issued_at` in the `Credential` must be >= `genesis_issued_at_min`)
+    pub genesis_issued_at_min: u64,
 }
 
 #[cfg(test)]

--- a/crates/test-utils/src/fixtures.rs
+++ b/crates/test-utils/src/fixtures.rs
@@ -118,7 +118,7 @@ pub fn build_base_credential(
     let credential_sub_blinding_factor = FieldElement::random(&mut rng);
     let credential = Credential::new()
         .issuer_schema_id(issuer_schema_id)
-        .blinded_sub(leaf_index, credential_sub_blinding_factor)
+        .sub(leaf_index, credential_sub_blinding_factor)
         .genesis_issued_at(genesis_issued_at)
         .expires_at(expires_at);
 

--- a/services/oprf-dev-client/src/bin/world-id-oprf-dev-client.rs
+++ b/services/oprf-dev-client/src/bin/world-id-oprf-dev-client.rs
@@ -291,6 +291,7 @@ fn prepare_nullifier_stress_test_oprf_request(
         oprf_public_key,
         signal_hash: signal_hash.into(),
         credential_sub_blinding_factor,
+        genesis_issued_at_min: 0,
     };
 
     let query_hash =
@@ -492,7 +493,7 @@ async fn stress_test(
                         cred_s: cred_signature.s,
                         cred_r: cred_signature.r,
                         current_timestamp: args.current_timestamp.into(),
-                        cred_genesis_issued_at_min: args.credential.genesis_issued_at_min.into(),
+                        cred_genesis_issued_at_min: args.genesis_issued_at_min.into(),
                         cred_sub_blinding_factor: *args.credential_sub_blinding_factor,
                         cred_id: args.credential.id.into(),
                     };


### PR DESCRIPTION
- In my final pass of #162 I realized we have a bug. The `genesis_issued_at_min` should be an input provided by the RP, it's not part of the credential. 
- A minor point, `sub` is updated instead of `blinded_sub` to avoid introducing another term.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Shifts minimum issuance time to be RP-provided during proof generation and simplifies subject naming.
> 
> - Removes `genesis_issued_at_min` from `Credential`; adds `genesis_issued_at_min` to `SingleProofInput` and plumbs it through `authenticator`, `proof` generation, tests, and dev client (defaulting to `0` when unspecified)
> - Renames `blinded_sub` → `sub` and corresponding builder `blinded_sub(...)` → `sub(...)`; updates credential hashing to use `sub`
> - Updates call sites: `issuer.rs`, test fixtures, proofs, and E2E/stress tooling to reflect the new API
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b1b6db52983be23ab27553f8a67bd7a4f78f288e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->