### PR TITLE
refactor(indexer): improve modules separation

### DIFF
--- a/services/indexer/src/db.rs
+++ b/services/indexer/src/db.rs
@@ -1,0 +1,206 @@
+use crate::events::AccountCreatedEvent;
+use alloy::primitives::{Address, U256};
+use sqlx::{postgres::PgPoolOptions, types::Json, PgPool, Row};
+
+pub async fn make_db_pool(db_url: &str) -> anyhow::Result<PgPool> {
+    let pool = PgPoolOptions::new()
+        .max_connections(10)
+        .connect(db_url)
+        .await?;
+    Ok(pool)
+}
+
+pub async fn init_db(pool: &PgPool) -> anyhow::Result<()> {
+    // Run sqlx migrations from ./migrations
+    tracing::info!("Running migrations...");
+    sqlx::migrate!("./migrations").run(pool).await?;
+    tracing::info!("🟢 Migrations synced successfully.");
+    Ok(())
+}
+
+pub async fn load_checkpoint(pool: &PgPool) -> anyhow::Result<Option<u64>> {
+    let rec: Option<(i64,)> = sqlx::query_as("select last_block from checkpoints where name = $1")
+        .bind("account_created")
+        .fetch_optional(pool)
+        .await?;
+    Ok(rec.map(|t| t.0 as u64))
+}
+
+pub async fn save_checkpoint(pool: &PgPool, block: u64) -> anyhow::Result<()> {
+    sqlx::query(
+        "insert into checkpoints (name, last_block) values ($1, $2) on conflict (name) do update set last_block = excluded.last_block",
+    )
+        .bind("account_created")
+        .bind(block as i64)
+        .execute(pool)
+        .await?;
+    Ok(())
+}
+
+pub async fn insert_account(pool: &PgPool, ev: &AccountCreatedEvent) -> anyhow::Result<()> {
+    sqlx::query(
+        r#"insert into accounts
+        (leaf_index, recovery_address, authenticator_addresses, authenticator_pubkeys, offchain_signer_commitment)
+        values ($1, $2, $3, $4, $5)
+        on conflict (leaf_index) do nothing"#,
+    )
+        .bind(ev.leaf_index.to_string())
+        .bind(ev.recovery_address.to_string())
+        .bind(Json(
+            ev.authenticator_addresses
+                .iter()
+                .map(|a| a.to_string())
+                .collect::<Vec<_>>(),
+        ))
+        .bind(Json(
+            ev.authenticator_pubkeys
+                .iter()
+                .map(|p| p.to_string())
+                .collect::<Vec<_>>(),
+        ))
+        .bind(ev.offchain_signer_commitment.to_string())
+        .execute(pool)
+        .await?;
+    Ok(())
+}
+
+pub async fn update_authenticator_at_index(
+    pool: &PgPool,
+    leaf_index: U256,
+    pubkey_id: u32,
+    new_address: Address,
+    new_pubkey: U256,
+    new_commitment: U256,
+) -> anyhow::Result<()> {
+    // Update authenticator at specific index (pubkey_id)
+    sqlx::query(
+        r#"update accounts
+        set authenticator_addresses = jsonb_set(authenticator_addresses, $2, to_jsonb($3::text), false),
+            authenticator_pubkeys = jsonb_set(authenticator_pubkeys, $2, to_jsonb($4::text), false),
+            offchain_signer_commitment = $5
+        where leaf_index = $1"#,
+    )
+        .bind(leaf_index.to_string())
+        .bind(format!("{{{pubkey_id}}}")) // JSONB path format: {0}, {1}, etc
+        .bind(new_address.to_string())
+        .bind(new_pubkey.to_string())
+        .bind(new_commitment.to_string())
+        .execute(pool)
+        .await?;
+    Ok(())
+}
+
+pub async fn insert_authenticator_at_index(
+    pool: &PgPool,
+    leaf_index: U256,
+    pubkey_id: u32,
+    new_address: Address,
+    new_pubkey: U256,
+    new_commitment: U256,
+) -> anyhow::Result<()> {
+    // Ensure arrays are large enough and insert at specific index
+    sqlx::query(
+        r#"update accounts
+        set authenticator_addresses = jsonb_set(authenticator_addresses, $2, to_jsonb($3::text), true),
+            authenticator_pubkeys = jsonb_set(authenticator_pubkeys, $2, to_jsonb($4::text), true),
+            offchain_signer_commitment = $5
+        where leaf_index = $1"#,
+    )
+        .bind(leaf_index.to_string())
+        .bind(format!("{{{pubkey_id}}}"))
+        .bind(new_address.to_string())
+        .bind(new_pubkey.to_string())
+        .bind(new_commitment.to_string())
+        .execute(pool)
+        .await?;
+    Ok(())
+}
+
+pub async fn remove_authenticator_at_index(
+    pool: &PgPool,
+    leaf_index: U256,
+    pubkey_id: u32,
+    new_commitment: U256,
+) -> anyhow::Result<()> {
+    // Remove authenticator at specific index by setting to null
+    sqlx::query(
+        r#"update accounts
+        set authenticator_addresses = jsonb_set(authenticator_addresses, $2, 'null'::jsonb, false),
+            authenticator_pubkeys = jsonb_set(authenticator_pubkeys, $2, 'null'::jsonb, false),
+            offchain_signer_commitment = $3
+        where leaf_index = $1"#,
+    )
+    .bind(leaf_index.to_string())
+    .bind(format!("{{{pubkey_id}}}"))
+    .bind(new_commitment.to_string())
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+pub async fn record_commitment_update(
+    pool: &PgPool,
+    leaf_index: U256,
+    event_type: &str,
+    new_commitment: U256,
+    block_number: u64,
+    tx_hash: &str,
+    log_index: u64,
+) -> anyhow::Result<()> {
+    sqlx::query(
+        r#"insert into commitment_update_events
+        (leaf_index, event_type, new_commitment, block_number, tx_hash, log_index)
+        values ($1, $2, $3, $4, $5, $6)
+        on conflict (tx_hash, log_index) do nothing"#,
+    )
+    .bind(leaf_index.to_string())
+    .bind(event_type)
+    .bind(new_commitment.to_string())
+    .bind(block_number as i64)
+    .bind(tx_hash)
+    .bind(log_index as i64)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+pub async fn fetch_recent_account_updates(
+    pool: &PgPool,
+    since: std::time::SystemTime,
+) -> anyhow::Result<Vec<(U256, U256)>> {
+    // Convert SystemTime to timestamp
+    let since_duration = since
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default();
+    let since_timestamp = since_duration.as_secs() as i64;
+
+    // Query commitment_update_events for recent changes
+    let rows = sqlx::query(
+        r#"
+        SELECT DISTINCT ON (leaf_index)
+            leaf_index,
+            new_commitment
+        FROM commitment_update_events
+        WHERE created_at > to_timestamp($1)
+        ORDER BY leaf_index, created_at DESC
+        "#,
+    )
+    .bind(since_timestamp)
+    .fetch_all(pool)
+    .await?;
+
+    let mut updates = Vec::new();
+    for row in rows {
+        let leaf_index_str: String = row.try_get("leaf_index")?;
+        let commitment_str: String = row.try_get("new_commitment")?;
+
+        if let (Ok(idx), Ok(comm)) = (
+            leaf_index_str.parse::<U256>(),
+            commitment_str.parse::<U256>(),
+        ) {
+            updates.push((idx, comm));
+        }
+    }
+
+    Ok(updates)
+}

--- a/services/indexer/src/events/decoders.rs
+++ b/services/indexer/src/events/decoders.rs
@@ -1,0 +1,116 @@
+use crate::events::{
+    AccountCreatedEvent, AccountRecoveredEvent, AccountUpdatedEvent, AuthenticatorInsertedEvent,
+    AuthenticatorRemovedEvent, RegistryEvent,
+};
+use alloy::primitives::Log;
+use alloy::sol_types::SolEvent;
+use world_id_core::world_id_registry::WorldIdRegistry;
+
+pub fn decode_account_created(lg: &alloy::rpc::types::Log) -> anyhow::Result<AccountCreatedEvent> {
+    let prim = Log::new(lg.address(), lg.topics().to_vec(), lg.data().data.clone())
+        .ok_or_else(|| anyhow::anyhow!("invalid log for decoding"))?;
+    let typed = WorldIdRegistry::AccountCreated::decode_log(&prim)?;
+
+    // TODO: Validate pubkey is valid affine compressed
+    Ok(AccountCreatedEvent {
+        leaf_index: typed.data.leafIndex,
+        recovery_address: typed.data.recoveryAddress,
+        authenticator_addresses: typed.data.authenticatorAddresses,
+        authenticator_pubkeys: typed.data.authenticatorPubkeys,
+        offchain_signer_commitment: typed.data.offchainSignerCommitment,
+    })
+}
+
+pub fn decode_account_updated(lg: &alloy::rpc::types::Log) -> anyhow::Result<AccountUpdatedEvent> {
+    let prim = Log::new(lg.address(), lg.topics().to_vec(), lg.data().data.clone())
+        .ok_or_else(|| anyhow::anyhow!("invalid log for decoding"))?;
+    let typed = WorldIdRegistry::AccountUpdated::decode_log(&prim)?;
+
+    Ok(AccountUpdatedEvent {
+        leaf_index: typed.data.leafIndex,
+        pubkey_id: typed.data.pubkeyId,
+        new_authenticator_pubkey: typed.data.newAuthenticatorPubkey,
+        old_authenticator_address: typed.data.oldAuthenticatorAddress,
+        new_authenticator_address: typed.data.newAuthenticatorAddress,
+        old_offchain_signer_commitment: typed.data.oldOffchainSignerCommitment,
+        new_offchain_signer_commitment: typed.data.newOffchainSignerCommitment,
+    })
+}
+
+pub fn decode_authenticator_inserted(
+    lg: &alloy::rpc::types::Log,
+) -> anyhow::Result<AuthenticatorInsertedEvent> {
+    let prim = Log::new(lg.address(), lg.topics().to_vec(), lg.data().data.clone())
+        .ok_or_else(|| anyhow::anyhow!("invalid log for decoding"))?;
+    let typed = WorldIdRegistry::AuthenticatorInserted::decode_log(&prim)?;
+
+    Ok(AuthenticatorInsertedEvent {
+        leaf_index: typed.data.leafIndex,
+        pubkey_id: typed.data.pubkeyId,
+        authenticator_address: typed.data.authenticatorAddress,
+        new_authenticator_pubkey: typed.data.newAuthenticatorPubkey,
+        old_offchain_signer_commitment: typed.data.oldOffchainSignerCommitment,
+        new_offchain_signer_commitment: typed.data.newOffchainSignerCommitment,
+    })
+}
+
+pub fn decode_authenticator_removed(
+    lg: &alloy::rpc::types::Log,
+) -> anyhow::Result<AuthenticatorRemovedEvent> {
+    let prim = Log::new(lg.address(), lg.topics().to_vec(), lg.data().data.clone())
+        .ok_or_else(|| anyhow::anyhow!("invalid log for decoding"))?;
+    let typed = WorldIdRegistry::AuthenticatorRemoved::decode_log(&prim)?;
+
+    Ok(AuthenticatorRemovedEvent {
+        leaf_index: typed.data.leafIndex,
+        pubkey_id: typed.data.pubkeyId,
+        authenticator_address: typed.data.authenticatorAddress,
+        authenticator_pubkey: typed.data.authenticatorPubkey,
+        old_offchain_signer_commitment: typed.data.oldOffchainSignerCommitment,
+        new_offchain_signer_commitment: typed.data.newOffchainSignerCommitment,
+    })
+}
+
+pub fn decode_account_recovered(
+    lg: &alloy::rpc::types::Log,
+) -> anyhow::Result<AccountRecoveredEvent> {
+    let prim = Log::new(lg.address(), lg.topics().to_vec(), lg.data().data.clone())
+        .ok_or_else(|| anyhow::anyhow!("invalid log for decoding"))?;
+    let typed = WorldIdRegistry::AccountRecovered::decode_log(&prim)?;
+
+    Ok(AccountRecoveredEvent {
+        leaf_index: typed.data.leafIndex,
+        new_authenticator_address: typed.data.newAuthenticatorAddress,
+        new_authenticator_pubkey: typed.data.newAuthenticatorPubkey,
+        old_offchain_signer_commitment: typed.data.oldOffchainSignerCommitment,
+        new_offchain_signer_commitment: typed.data.newOffchainSignerCommitment,
+    })
+}
+
+pub fn decode_registry_event(lg: &alloy::rpc::types::Log) -> anyhow::Result<RegistryEvent> {
+    if lg.topics().is_empty() {
+        anyhow::bail!("log has no topics");
+    }
+
+    let event_sig = lg.topics()[0];
+
+    if event_sig == WorldIdRegistry::AccountCreated::SIGNATURE_HASH {
+        Ok(RegistryEvent::AccountCreated(decode_account_created(lg)?))
+    } else if event_sig == WorldIdRegistry::AccountUpdated::SIGNATURE_HASH {
+        Ok(RegistryEvent::AccountUpdated(decode_account_updated(lg)?))
+    } else if event_sig == WorldIdRegistry::AuthenticatorInserted::SIGNATURE_HASH {
+        Ok(RegistryEvent::AuthenticatorInserted(
+            decode_authenticator_inserted(lg)?,
+        ))
+    } else if event_sig == WorldIdRegistry::AuthenticatorRemoved::SIGNATURE_HASH {
+        Ok(RegistryEvent::AuthenticatorRemoved(
+            decode_authenticator_removed(lg)?,
+        ))
+    } else if event_sig == WorldIdRegistry::AccountRecovered::SIGNATURE_HASH {
+        Ok(RegistryEvent::AccountRecovered(decode_account_recovered(
+            lg,
+        )?))
+    } else {
+        anyhow::bail!("unknown event signature: {event_sig:?}")
+    }
+}

--- a/services/indexer/src/events/mod.rs
+++ b/services/indexer/src/events/mod.rs
@@ -1,0 +1,61 @@
+use alloy::primitives::{Address, U256};
+
+pub mod decoders;
+
+#[derive(Debug, Clone)]
+pub struct AccountCreatedEvent {
+    pub leaf_index: U256,
+    pub recovery_address: Address,
+    pub authenticator_addresses: Vec<Address>,
+    pub authenticator_pubkeys: Vec<U256>,
+    pub offchain_signer_commitment: U256,
+}
+
+#[derive(Debug, Clone)]
+pub struct AccountUpdatedEvent {
+    pub leaf_index: U256,
+    pub pubkey_id: u32,
+    pub new_authenticator_pubkey: U256,
+    pub old_authenticator_address: Address,
+    pub new_authenticator_address: Address,
+    pub old_offchain_signer_commitment: U256,
+    pub new_offchain_signer_commitment: U256,
+}
+
+#[derive(Debug, Clone)]
+pub struct AuthenticatorInsertedEvent {
+    pub leaf_index: U256,
+    pub pubkey_id: u32,
+    pub authenticator_address: Address,
+    pub new_authenticator_pubkey: U256,
+    pub old_offchain_signer_commitment: U256,
+    pub new_offchain_signer_commitment: U256,
+}
+
+#[derive(Debug, Clone)]
+pub struct AuthenticatorRemovedEvent {
+    pub leaf_index: U256,
+    pub pubkey_id: u32,
+    pub authenticator_address: Address,
+    pub authenticator_pubkey: U256,
+    pub old_offchain_signer_commitment: U256,
+    pub new_offchain_signer_commitment: U256,
+}
+
+#[derive(Debug, Clone)]
+pub struct AccountRecoveredEvent {
+    pub leaf_index: U256,
+    pub new_authenticator_address: Address,
+    pub new_authenticator_pubkey: U256,
+    pub old_offchain_signer_commitment: U256,
+    pub new_offchain_signer_commitment: U256,
+}
+
+#[derive(Debug, Clone)]
+pub enum RegistryEvent {
+    AccountCreated(AccountCreatedEvent),
+    AccountUpdated(AccountUpdatedEvent),
+    AuthenticatorInserted(AuthenticatorInsertedEvent),
+    AuthenticatorRemoved(AuthenticatorRemovedEvent),
+    AccountRecovered(AccountRecoveredEvent),
+}

--- a/services/indexer/src/lib.rs
+++ b/services/indexer/src/lib.rs
@@ -1,212 +1,31 @@
 use std::net::SocketAddr;
-use std::sync::{Arc, LazyLock};
+use std::sync::Arc;
 use std::time::Duration;
 
-use alloy::primitives::{Address, Log, U256};
+use alloy::primitives::Address;
 use alloy::providers::{Provider, ProviderBuilder, WsConnect};
 use alloy::rpc::types::Filter;
 use alloy::sol_types::SolEvent;
-use ark_bn254::Fr;
-use poseidon2::{Poseidon2, POSEIDON2_BN254_T2_PARAMS};
-use semaphore_rs_hasher::Hasher;
-use semaphore_rs_trees::lazy::{Canonical, LazyMerkleTree as MerkleTree};
-use semaphore_rs_trees::proof::InclusionProof;
-use semaphore_rs_trees::Branch;
-use sqlx::migrate::Migrator;
-use sqlx::{postgres::PgPoolOptions, types::Json, PgPool, Row};
-use tokio::sync::RwLock;
+use sqlx::PgPool;
 use world_id_core::world_id_registry::WorldIdRegistry;
-use world_id_primitives::TREE_DEPTH;
 
 pub mod config;
+mod db;
+mod events;
 mod routes;
 mod sanity_check;
+mod tree;
+
 use crate::config::{AppState, HttpConfig, IndexerConfig, RunMode};
+pub use crate::db::{
+    fetch_recent_account_updates, init_db, insert_account, insert_authenticator_at_index,
+    load_checkpoint, make_db_pool, record_commitment_update, remove_authenticator_at_index,
+    save_checkpoint, update_authenticator_at_index,
+};
+use crate::events::decoders::decode_registry_event;
+use crate::events::RegistryEvent;
+use crate::tree::{build_tree_from_db, update_tree_with_commitment};
 pub use config::GlobalConfig;
-
-static MIGRATOR: Migrator = sqlx::migrate!("./migrations");
-
-#[derive(Debug, Clone)]
-pub struct AccountCreatedEvent {
-    pub leaf_index: U256,
-    pub recovery_address: Address,
-    pub authenticator_addresses: Vec<Address>,
-    pub authenticator_pubkeys: Vec<U256>,
-    pub offchain_signer_commitment: U256,
-}
-
-#[derive(Debug, Clone)]
-pub struct AccountUpdatedEvent {
-    pub leaf_index: U256,
-    pub pubkey_id: u32,
-    pub new_authenticator_pubkey: U256,
-    pub old_authenticator_address: Address,
-    pub new_authenticator_address: Address,
-    pub old_offchain_signer_commitment: U256,
-    pub new_offchain_signer_commitment: U256,
-}
-
-#[derive(Debug, Clone)]
-pub struct AuthenticatorInsertedEvent {
-    pub leaf_index: U256,
-    pub pubkey_id: u32,
-    pub authenticator_address: Address,
-    pub new_authenticator_pubkey: U256,
-    pub old_offchain_signer_commitment: U256,
-    pub new_offchain_signer_commitment: U256,
-}
-
-#[derive(Debug, Clone)]
-pub struct AuthenticatorRemovedEvent {
-    pub leaf_index: U256,
-    pub pubkey_id: u32,
-    pub authenticator_address: Address,
-    pub authenticator_pubkey: U256,
-    pub old_offchain_signer_commitment: U256,
-    pub new_offchain_signer_commitment: U256,
-}
-
-#[derive(Debug, Clone)]
-pub struct AccountRecoveredEvent {
-    pub leaf_index: U256,
-    pub new_authenticator_address: Address,
-    pub new_authenticator_pubkey: U256,
-    pub old_offchain_signer_commitment: U256,
-    pub new_offchain_signer_commitment: U256,
-}
-
-#[derive(Debug, Clone)]
-pub enum RegistryEvent {
-    AccountCreated(AccountCreatedEvent),
-    AccountUpdated(AccountUpdatedEvent),
-    AuthenticatorInserted(AuthenticatorInsertedEvent),
-    AuthenticatorRemoved(AuthenticatorRemovedEvent),
-    AccountRecovered(AccountRecoveredEvent),
-}
-
-static POSEIDON_HASHER: LazyLock<Poseidon2<Fr, 2, 5>> =
-    LazyLock::new(|| Poseidon2::new(&POSEIDON2_BN254_T2_PARAMS));
-
-struct PoseidonHasher {}
-
-impl Hasher for PoseidonHasher {
-    type Hash = U256;
-
-    fn hash_node(left: &Self::Hash, right: &Self::Hash) -> Self::Hash {
-        let left: Fr = left.try_into().unwrap();
-        let right: Fr = right.try_into().unwrap();
-        let mut input = [left, right];
-        let feed_forward = input[0];
-        POSEIDON_HASHER.permutation_in_place(&mut input);
-        input[0] += feed_forward;
-        input[0].into()
-    }
-}
-
-fn tree_capacity() -> usize {
-    1usize << TREE_DEPTH
-}
-
-// Global Merkle tree (singleton). Protected by an async RwLock for concurrent reads.
-pub(crate) static GLOBAL_TREE: LazyLock<RwLock<MerkleTree<PoseidonHasher, Canonical>>> =
-    LazyLock::new(|| RwLock::new(MerkleTree::<PoseidonHasher>::new(TREE_DEPTH, U256::ZERO)));
-
-async fn set_leaf_at_index(leaf_index: usize, value: U256) -> anyhow::Result<()> {
-    if leaf_index >= tree_capacity() {
-        anyhow::bail!("leaf index {leaf_index} out of range for tree depth {TREE_DEPTH}");
-    }
-
-    let mut tree = GLOBAL_TREE.write().await;
-    take_mut::take(&mut *tree, |tree| {
-        tree.update_with_mutation(leaf_index, &value)
-    });
-    Ok(())
-}
-
-async fn build_tree_from_db(pool: &PgPool) -> anyhow::Result<()> {
-    let rows = sqlx::query(
-        "select leaf_index, offchain_signer_commitment from accounts order by leaf_index asc",
-    )
-    .fetch_all(pool)
-    .await?;
-
-    tracing::info!("There are {:?} rows in the table.", rows.len());
-
-    let mut leaves: Vec<(usize, U256)> = Vec::with_capacity(rows.len());
-    for r in rows {
-        let leaf_index: String = r.get("leaf_index");
-        let offchain: String = r.get("offchain_signer_commitment");
-        let leaf_index: U256 = leaf_index.parse::<U256>()?;
-        if leaf_index == U256::ZERO {
-            continue;
-        }
-        let leaf_index = leaf_index.as_limbs()[0] as usize;
-        let leaf_val = offchain.parse::<U256>()?;
-        leaves.push((leaf_index, leaf_val));
-    }
-
-    let mut new_tree = MerkleTree::<PoseidonHasher>::new(TREE_DEPTH, U256::ZERO);
-    for (idx, value) in leaves {
-        if idx >= tree_capacity() {
-            anyhow::bail!(
-                "leaf index {idx} out of range while rebuilding tree (depth {TREE_DEPTH})",
-            );
-        }
-        new_tree = new_tree.update_with_mutation(idx, &value);
-    }
-
-    let root = new_tree.root();
-    {
-        let mut tree = GLOBAL_TREE.write().await;
-        *tree = new_tree;
-    }
-    tracing::info!(
-        root = %format!("0x{:x}", root),
-        depth = TREE_DEPTH,
-        "tree built from DB"
-    );
-    Ok(())
-}
-
-async fn update_tree_with_commitment(leaf_index: U256, new_commitment: U256) -> anyhow::Result<()> {
-    if leaf_index == 0 {
-        anyhow::bail!("account index cannot be zero");
-    }
-    let leaf_index = leaf_index.as_limbs()[0] as usize;
-    set_leaf_at_index(leaf_index, new_commitment).await?;
-    Ok(())
-}
-
-async fn update_tree_with_event(ev: &RegistryEvent) -> anyhow::Result<()> {
-    match ev {
-        RegistryEvent::AccountCreated(e) => {
-            update_tree_with_commitment(e.leaf_index, e.offchain_signer_commitment).await
-        }
-        RegistryEvent::AccountUpdated(e) => {
-            update_tree_with_commitment(e.leaf_index, e.new_offchain_signer_commitment).await
-        }
-        RegistryEvent::AuthenticatorInserted(e) => {
-            update_tree_with_commitment(e.leaf_index, e.new_offchain_signer_commitment).await
-        }
-        RegistryEvent::AuthenticatorRemoved(e) => {
-            update_tree_with_commitment(e.leaf_index, e.new_offchain_signer_commitment).await
-        }
-        RegistryEvent::AccountRecovered(e) => {
-            update_tree_with_commitment(e.leaf_index, e.new_offchain_signer_commitment).await
-        }
-    }
-}
-
-fn proof_to_vec(proof: &InclusionProof<PoseidonHasher>) -> Vec<U256> {
-    proof
-        .0
-        .iter()
-        .map(|b| match b {
-            Branch::Left(sib) => *sib,
-            Branch::Right(sib) => *sib,
-        })
-        .collect()
-}
 
 async fn start_http_server(
     rpc_url: &str,
@@ -224,11 +43,9 @@ async fn start_http_server(
 
 pub async fn run_indexer(cfg: GlobalConfig) -> anyhow::Result<()> {
     let pool = make_db_pool(&cfg.db_url).await?;
+    tracing::info!("Connection to DB successful. Initializing database...");
     init_db(&pool).await?;
-
-    tracing::info!("Connection to DB successful, running migrations.");
-    MIGRATOR.run(&pool).await.expect("failed to run migrations");
-    tracing::info!("🟢 Migrations synced successfully.");
+    tracing::info!("🟢 Database successfully initialized.");
 
     let rpc_url = &cfg.rpc_url;
     let registry_address = cfg.registry_address;
@@ -386,39 +203,6 @@ async fn run_both(
     Ok(())
 }
 
-pub async fn make_db_pool(db_url: &str) -> anyhow::Result<PgPool> {
-    let pool = PgPoolOptions::new()
-        .max_connections(10)
-        .connect(db_url)
-        .await?;
-    Ok(pool)
-}
-
-pub async fn init_db(pool: &PgPool) -> anyhow::Result<()> {
-    // Run sqlx migrations from ./migrations
-    sqlx::migrate!("./migrations").run(pool).await?;
-    Ok(())
-}
-
-pub async fn load_checkpoint(pool: &PgPool) -> anyhow::Result<Option<u64>> {
-    let rec: Option<(i64,)> = sqlx::query_as("select last_block from checkpoints where name = $1")
-        .bind("account_created")
-        .fetch_optional(pool)
-        .await?;
-    Ok(rec.map(|t| t.0 as u64))
-}
-
-pub async fn save_checkpoint(pool: &PgPool, block: u64) -> anyhow::Result<()> {
-    sqlx::query(
-        "insert into checkpoints (name, last_block) values ($1, $2) on conflict (name) do update set last_block = excluded.last_block",
-    )
-    .bind("account_created")
-    .bind(block as i64)
-    .execute(pool)
-    .await?;
-    Ok(())
-}
-
 async fn backfill_batch<P: Provider>(
     provider: &P,
     pool: &PgPool,
@@ -541,259 +325,6 @@ pub async fn backfill<P: Provider>(
             }
         }
     }
-    Ok(())
-}
-
-pub fn decode_account_created(lg: &alloy::rpc::types::Log) -> anyhow::Result<AccountCreatedEvent> {
-    let prim = Log::new(lg.address(), lg.topics().to_vec(), lg.data().data.clone())
-        .ok_or_else(|| anyhow::anyhow!("invalid log for decoding"))?;
-    let typed = WorldIdRegistry::AccountCreated::decode_log(&prim)?;
-
-    // TODO: Validate pubkey is valid affine compressed
-    Ok(AccountCreatedEvent {
-        leaf_index: typed.data.leafIndex,
-        recovery_address: typed.data.recoveryAddress,
-        authenticator_addresses: typed.data.authenticatorAddresses,
-        authenticator_pubkeys: typed.data.authenticatorPubkeys,
-        offchain_signer_commitment: typed.data.offchainSignerCommitment,
-    })
-}
-
-pub fn decode_account_updated(lg: &alloy::rpc::types::Log) -> anyhow::Result<AccountUpdatedEvent> {
-    let prim = Log::new(lg.address(), lg.topics().to_vec(), lg.data().data.clone())
-        .ok_or_else(|| anyhow::anyhow!("invalid log for decoding"))?;
-    let typed = WorldIdRegistry::AccountUpdated::decode_log(&prim)?;
-
-    Ok(AccountUpdatedEvent {
-        leaf_index: typed.data.leafIndex,
-        pubkey_id: typed.data.pubkeyId,
-        new_authenticator_pubkey: typed.data.newAuthenticatorPubkey,
-        old_authenticator_address: typed.data.oldAuthenticatorAddress,
-        new_authenticator_address: typed.data.newAuthenticatorAddress,
-        old_offchain_signer_commitment: typed.data.oldOffchainSignerCommitment,
-        new_offchain_signer_commitment: typed.data.newOffchainSignerCommitment,
-    })
-}
-
-pub fn decode_authenticator_inserted(
-    lg: &alloy::rpc::types::Log,
-) -> anyhow::Result<AuthenticatorInsertedEvent> {
-    let prim = Log::new(lg.address(), lg.topics().to_vec(), lg.data().data.clone())
-        .ok_or_else(|| anyhow::anyhow!("invalid log for decoding"))?;
-    let typed = WorldIdRegistry::AuthenticatorInserted::decode_log(&prim)?;
-
-    Ok(AuthenticatorInsertedEvent {
-        leaf_index: typed.data.leafIndex,
-        pubkey_id: typed.data.pubkeyId,
-        authenticator_address: typed.data.authenticatorAddress,
-        new_authenticator_pubkey: typed.data.newAuthenticatorPubkey,
-        old_offchain_signer_commitment: typed.data.oldOffchainSignerCommitment,
-        new_offchain_signer_commitment: typed.data.newOffchainSignerCommitment,
-    })
-}
-
-pub fn decode_authenticator_removed(
-    lg: &alloy::rpc::types::Log,
-) -> anyhow::Result<AuthenticatorRemovedEvent> {
-    let prim = Log::new(lg.address(), lg.topics().to_vec(), lg.data().data.clone())
-        .ok_or_else(|| anyhow::anyhow!("invalid log for decoding"))?;
-    let typed = WorldIdRegistry::AuthenticatorRemoved::decode_log(&prim)?;
-
-    Ok(AuthenticatorRemovedEvent {
-        leaf_index: typed.data.leafIndex,
-        pubkey_id: typed.data.pubkeyId,
-        authenticator_address: typed.data.authenticatorAddress,
-        authenticator_pubkey: typed.data.authenticatorPubkey,
-        old_offchain_signer_commitment: typed.data.oldOffchainSignerCommitment,
-        new_offchain_signer_commitment: typed.data.newOffchainSignerCommitment,
-    })
-}
-
-pub fn decode_account_recovered(
-    lg: &alloy::rpc::types::Log,
-) -> anyhow::Result<AccountRecoveredEvent> {
-    let prim = Log::new(lg.address(), lg.topics().to_vec(), lg.data().data.clone())
-        .ok_or_else(|| anyhow::anyhow!("invalid log for decoding"))?;
-    let typed = WorldIdRegistry::AccountRecovered::decode_log(&prim)?;
-
-    Ok(AccountRecoveredEvent {
-        leaf_index: typed.data.leafIndex,
-        new_authenticator_address: typed.data.newAuthenticatorAddress,
-        new_authenticator_pubkey: typed.data.newAuthenticatorPubkey,
-        old_offchain_signer_commitment: typed.data.oldOffchainSignerCommitment,
-        new_offchain_signer_commitment: typed.data.newOffchainSignerCommitment,
-    })
-}
-
-pub fn decode_registry_event(lg: &alloy::rpc::types::Log) -> anyhow::Result<RegistryEvent> {
-    if lg.topics().is_empty() {
-        anyhow::bail!("log has no topics");
-    }
-
-    let event_sig = lg.topics()[0];
-
-    if event_sig == WorldIdRegistry::AccountCreated::SIGNATURE_HASH {
-        Ok(RegistryEvent::AccountCreated(decode_account_created(lg)?))
-    } else if event_sig == WorldIdRegistry::AccountUpdated::SIGNATURE_HASH {
-        Ok(RegistryEvent::AccountUpdated(decode_account_updated(lg)?))
-    } else if event_sig == WorldIdRegistry::AuthenticatorInserted::SIGNATURE_HASH {
-        Ok(RegistryEvent::AuthenticatorInserted(
-            decode_authenticator_inserted(lg)?,
-        ))
-    } else if event_sig == WorldIdRegistry::AuthenticatorRemoved::SIGNATURE_HASH {
-        Ok(RegistryEvent::AuthenticatorRemoved(
-            decode_authenticator_removed(lg)?,
-        ))
-    } else if event_sig == WorldIdRegistry::AccountRecovered::SIGNATURE_HASH {
-        Ok(RegistryEvent::AccountRecovered(decode_account_recovered(
-            lg,
-        )?))
-    } else {
-        anyhow::bail!("unknown event signature: {event_sig:?}")
-    }
-}
-
-pub async fn insert_account(pool: &PgPool, ev: &AccountCreatedEvent) -> anyhow::Result<()> {
-    sqlx::query(
-        r#"insert into accounts
-        (leaf_index, recovery_address, authenticator_addresses, authenticator_pubkeys, offchain_signer_commitment)
-        values ($1, $2, $3, $4, $5)
-        on conflict (leaf_index) do nothing"#,
-    )
-    .bind(ev.leaf_index.to_string())
-    .bind(ev.recovery_address.to_string())
-    .bind(Json(
-        ev.authenticator_addresses
-            .iter()
-            .map(|a| a.to_string())
-            .collect::<Vec<_>>(),
-    ))
-    .bind(Json(
-        ev.authenticator_pubkeys
-            .iter()
-            .map(|p| p.to_string())
-            .collect::<Vec<_>>(),
-    ))
-    .bind(ev.offchain_signer_commitment.to_string())
-    .execute(pool)
-    .await?;
-    Ok(())
-}
-
-pub async fn update_commitment(
-    pool: &PgPool,
-    leaf_index: U256,
-    new_commitment: U256,
-) -> anyhow::Result<()> {
-    sqlx::query(
-        r#"update accounts
-        set offchain_signer_commitment = $2
-        where leaf_index = $1"#,
-    )
-    .bind(leaf_index.to_string())
-    .bind(new_commitment.to_string())
-    .execute(pool)
-    .await?;
-    Ok(())
-}
-
-pub async fn update_authenticator_at_index(
-    pool: &PgPool,
-    leaf_index: U256,
-    pubkey_id: u32,
-    new_address: Address,
-    new_pubkey: U256,
-    new_commitment: U256,
-) -> anyhow::Result<()> {
-    // Update authenticator at specific index (pubkey_id)
-    sqlx::query(
-        r#"update accounts
-        set authenticator_addresses = jsonb_set(authenticator_addresses, $2, to_jsonb($3::text), false),
-            authenticator_pubkeys = jsonb_set(authenticator_pubkeys, $2, to_jsonb($4::text), false),
-            offchain_signer_commitment = $5
-        where leaf_index = $1"#,
-    )
-    .bind(leaf_index.to_string())
-    .bind(format!("{{{pubkey_id}}}")) // JSONB path format: {0}, {1}, etc
-    .bind(new_address.to_string())
-    .bind(new_pubkey.to_string())
-    .bind(new_commitment.to_string())
-    .execute(pool)
-    .await?;
-    Ok(())
-}
-
-pub async fn insert_authenticator_at_index(
-    pool: &PgPool,
-    leaf_index: U256,
-    pubkey_id: u32,
-    new_address: Address,
-    new_pubkey: U256,
-    new_commitment: U256,
-) -> anyhow::Result<()> {
-    // Ensure arrays are large enough and insert at specific index
-    sqlx::query(
-        r#"update accounts
-        set authenticator_addresses = jsonb_set(authenticator_addresses, $2, to_jsonb($3::text), true),
-            authenticator_pubkeys = jsonb_set(authenticator_pubkeys, $2, to_jsonb($4::text), true),
-            offchain_signer_commitment = $5
-        where leaf_index = $1"#,
-    )
-    .bind(leaf_index.to_string())
-    .bind(format!("{{{pubkey_id}}}"))
-    .bind(new_address.to_string())
-    .bind(new_pubkey.to_string())
-    .bind(new_commitment.to_string())
-    .execute(pool)
-    .await?;
-    Ok(())
-}
-
-pub async fn remove_authenticator_at_index(
-    pool: &PgPool,
-    leaf_index: U256,
-    pubkey_id: u32,
-    new_commitment: U256,
-) -> anyhow::Result<()> {
-    // Remove authenticator at specific index by setting to null
-    sqlx::query(
-        r#"update accounts
-        set authenticator_addresses = jsonb_set(authenticator_addresses, $2, 'null'::jsonb, false),
-            authenticator_pubkeys = jsonb_set(authenticator_pubkeys, $2, 'null'::jsonb, false),
-            offchain_signer_commitment = $3
-        where leaf_index = $1"#,
-    )
-    .bind(leaf_index.to_string())
-    .bind(format!("{{{pubkey_id}}}"))
-    .bind(new_commitment.to_string())
-    .execute(pool)
-    .await?;
-    Ok(())
-}
-
-pub async fn record_commitment_update(
-    pool: &PgPool,
-    leaf_index: U256,
-    event_type: &str,
-    new_commitment: U256,
-    block_number: u64,
-    tx_hash: &str,
-    log_index: u64,
-) -> anyhow::Result<()> {
-    sqlx::query(
-        r#"insert into commitment_update_events
-        (leaf_index, event_type, new_commitment, block_number, tx_hash, log_index)
-        values ($1, $2, $3, $4, $5, $6)
-        on conflict (tx_hash, log_index) do nothing"#,
-    )
-    .bind(leaf_index.to_string())
-    .bind(event_type)
-    .bind(new_commitment.to_string())
-    .bind(block_number as i64)
-    .bind(tx_hash)
-    .bind(log_index as i64)
-    .execute(pool)
-    .await?;
     Ok(())
 }
 
@@ -961,45 +492,24 @@ pub async fn poll_db_changes(pool: PgPool, poll_interval_secs: u64) -> anyhow::R
     }
 }
 
-async fn fetch_recent_account_updates(
-    pool: &PgPool,
-    since: std::time::SystemTime,
-) -> anyhow::Result<Vec<(U256, U256)>> {
-    // Convert SystemTime to timestamp
-    let since_duration = since
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default();
-    let since_timestamp = since_duration.as_secs() as i64;
-
-    // Query commitment_update_events for recent changes
-    let rows = sqlx::query(
-        r#"
-        SELECT DISTINCT ON (leaf_index)
-            leaf_index,
-            new_commitment
-        FROM commitment_update_events
-        WHERE created_at > to_timestamp($1)
-        ORDER BY leaf_index, created_at DESC
-        "#,
-    )
-    .bind(since_timestamp)
-    .fetch_all(pool)
-    .await?;
-
-    let mut updates = Vec::new();
-    for row in rows {
-        let leaf_index_str: String = row.try_get("leaf_index")?;
-        let commitment_str: String = row.try_get("new_commitment")?;
-
-        if let (Ok(idx), Ok(comm)) = (
-            leaf_index_str.parse::<U256>(),
-            commitment_str.parse::<U256>(),
-        ) {
-            updates.push((idx, comm));
+pub async fn update_tree_with_event(ev: &RegistryEvent) -> anyhow::Result<()> {
+    match ev {
+        RegistryEvent::AccountCreated(e) => {
+            update_tree_with_commitment(e.leaf_index, e.offchain_signer_commitment).await
+        }
+        RegistryEvent::AccountUpdated(e) => {
+            update_tree_with_commitment(e.leaf_index, e.new_offchain_signer_commitment).await
+        }
+        RegistryEvent::AuthenticatorInserted(e) => {
+            update_tree_with_commitment(e.leaf_index, e.new_offchain_signer_commitment).await
+        }
+        RegistryEvent::AuthenticatorRemoved(e) => {
+            update_tree_with_commitment(e.leaf_index, e.new_offchain_signer_commitment).await
+        }
+        RegistryEvent::AccountRecovered(e) => {
+            update_tree_with_commitment(e.leaf_index, e.new_offchain_signer_commitment).await
         }
     }
-
-    Ok(updates)
 }
 
 pub async fn stream_logs(
@@ -1058,25 +568,4 @@ pub async fn stream_logs(
         }
     }
     Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use alloy::uint;
-    use semaphore_rs_trees::Branch;
-
-    use super::*;
-
-    #[test]
-    fn test_poseidon2_merkle_tree() {
-        let tree = MerkleTree::<PoseidonHasher>::new(10, U256::ZERO);
-        let proof = tree.proof(0);
-        let proof = proof.0.iter().collect::<Vec<_>>();
-        assert!(
-            *proof[1]
-                == Branch::Left(uint!(
-                15621590199821056450610068202457788725601603091791048810523422053872049975191_U256
-            ))
-        );
-    }
 }

--- a/services/indexer/src/sanity_check.rs
+++ b/services/indexer/src/sanity_check.rs
@@ -4,7 +4,7 @@ use alloy::primitives::{Address, U256};
 use alloy::providers::ProviderBuilder;
 use world_id_core::world_id_registry::WorldIdRegistry;
 
-use crate::GLOBAL_TREE;
+use crate::tree::GLOBAL_TREE;
 
 /// Periodically checks that the local in-memory Merkle root remains valid on-chain.
 pub async fn root_sanity_check_loop(

--- a/services/indexer/src/tree.rs
+++ b/services/indexer/src/tree.rs
@@ -1,0 +1,132 @@
+use alloy::primitives::U256;
+use ark_bn254::Fr;
+use poseidon2::{Poseidon2, POSEIDON2_BN254_T2_PARAMS};
+use semaphore_rs_hasher::Hasher;
+use semaphore_rs_trees::lazy::{Canonical, LazyMerkleTree};
+use sqlx::PgPool;
+use sqlx::Row;
+use std::sync::LazyLock;
+use tokio::sync::RwLock;
+use world_id_primitives::TREE_DEPTH;
+
+static POSEIDON_HASHER: LazyLock<Poseidon2<Fr, 2, 5>> =
+    LazyLock::new(|| Poseidon2::new(&POSEIDON2_BN254_T2_PARAMS));
+
+pub struct PoseidonHasher {}
+
+impl Hasher for PoseidonHasher {
+    type Hash = U256;
+
+    fn hash_node(left: &Self::Hash, right: &Self::Hash) -> Self::Hash {
+        let left: Fr = left.try_into().unwrap();
+        let right: Fr = right.try_into().unwrap();
+        let mut input = [left, right];
+        let feed_forward = input[0];
+        POSEIDON_HASHER.permutation_in_place(&mut input);
+        input[0] += feed_forward;
+        input[0].into()
+    }
+}
+
+pub fn tree_capacity() -> usize {
+    1usize << TREE_DEPTH
+}
+
+// Global Merkle tree (singleton). Protected by an async RwLock for concurrent reads.
+pub static GLOBAL_TREE: LazyLock<RwLock<LazyMerkleTree<PoseidonHasher, Canonical>>> =
+    LazyLock::new(|| {
+        RwLock::new(LazyMerkleTree::<PoseidonHasher>::new(
+            TREE_DEPTH,
+            U256::ZERO,
+        ))
+    });
+
+pub async fn set_leaf_at_index(leaf_index: usize, value: U256) -> anyhow::Result<()> {
+    if leaf_index >= tree_capacity() {
+        anyhow::bail!("leaf index {leaf_index} out of range for tree depth {TREE_DEPTH}");
+    }
+
+    let mut tree = GLOBAL_TREE.write().await;
+    take_mut::take(&mut *tree, |tree| {
+        tree.update_with_mutation(leaf_index, &value)
+    });
+    Ok(())
+}
+
+pub async fn build_tree_from_db(pool: &PgPool) -> anyhow::Result<()> {
+    let rows = sqlx::query(
+        "select leaf_index, offchain_signer_commitment from accounts order by leaf_index asc",
+    )
+    .fetch_all(pool)
+    .await?;
+
+    tracing::info!("There are {:?} rows in the table.", rows.len());
+
+    let mut leaves: Vec<(usize, U256)> = Vec::with_capacity(rows.len());
+    for r in rows {
+        let leaf_index: String = r.get("leaf_index");
+        let offchain: String = r.get("offchain_signer_commitment");
+        let leaf_index: U256 = leaf_index.parse::<U256>()?;
+        if leaf_index == U256::ZERO {
+            continue;
+        }
+        let leaf_index = leaf_index.as_limbs()[0] as usize;
+        let leaf_val = offchain.parse::<U256>()?;
+        leaves.push((leaf_index, leaf_val));
+    }
+
+    let mut new_tree = LazyMerkleTree::<PoseidonHasher>::new(TREE_DEPTH, U256::ZERO);
+    for (idx, value) in leaves {
+        if idx >= tree_capacity() {
+            anyhow::bail!(
+                "leaf index {idx} out of range while rebuilding tree (depth {TREE_DEPTH})",
+            );
+        }
+        new_tree = new_tree.update_with_mutation(idx, &value);
+    }
+
+    let root = new_tree.root();
+    {
+        let mut tree = GLOBAL_TREE.write().await;
+        *tree = new_tree;
+    }
+    tracing::info!(
+        root = %format!("0x{:x}", root),
+        depth = TREE_DEPTH,
+        "tree built from DB"
+    );
+    Ok(())
+}
+
+pub async fn update_tree_with_commitment(
+    leaf_index: U256,
+    new_commitment: U256,
+) -> anyhow::Result<()> {
+    if leaf_index == 0 {
+        anyhow::bail!("account index cannot be zero");
+    }
+    let leaf_index = leaf_index.as_limbs()[0] as usize;
+    set_leaf_at_index(leaf_index, new_commitment).await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy::uint;
+    use semaphore_rs_trees::Branch;
+
+    use super::*;
+
+    #[test]
+    fn test_poseidon2_merkle_tree() {
+        let tree = LazyMerkleTree::<PoseidonHasher>::new(10, U256::ZERO);
+        let proof = tree.proof(0);
+        let proof = proof.0.iter().collect::<Vec<_>>();
+        assert!(
+            *proof[1]
+                == Branch::Left(uint!(
+                15621590199821056450610068202457788725601603091791048810523422053872049975191_U256
+            ))
+        );
+    }
+}


### PR DESCRIPTION
Also ensure DB migrations are being run once.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Separates concerns and streamlines initialization.
> 
> - **Modularization**: Moves DB access (`db.rs`), event types/decoders (`events/*`), and Merkle tree logic (`tree.rs`) out of `lib.rs`; updates imports and re-exports accordingly
> - **DB initialization**: Adds `init_db` with logging to run migrations once at startup; removes inline migrator usage
> - **Tree handling**: Centralizes global tree, building from DB, and updates via `update_tree_with_commitment`; adds `update_tree_with_event` and moves tests to `tree.rs`
> - **Event processing**: Uses `decode_registry_event` from `events::decoders` for backfill/live streams; `handle_registry_event` records commitment updates consistently
> - **HTTP & routes**: `inclusion_proof` now sources tree utilities from `tree.rs`, defines local OpenAPI response schema, and inlines `proof_to_vec`
> - **Sanity check**: Reads global tree from new module; logging unchanged
> - **Runtime modes**: Both/HTTP-only modes build tree from DB on startup; indexer-only avoids in-memory updates
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4e7f20854a77b0c03dc129aa97ed03d08db6bd5f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->