### PR TITLE
perf(request-tracker): improve caching layer

### DIFF
--- a/services/gateway/src/request_tracker.rs
+++ b/services/gateway/src/request_tracker.rs
@@ -13,6 +13,7 @@ pub struct RequestRecord {
 }
 
 const REQUESTS_TTL: Duration = Duration::from_secs(86_400); // 24 hours
+const CACHE_MAX_CAPACITY: u64 = 100_000;
 
 /// Custom expiry policy that preserves TTL on updates (like Redis KEEPTTL).
 struct RequestExpiry;
@@ -85,7 +86,10 @@ impl RequestTracker {
         };
 
         // Build moka cache with custom expiry that preserves TTL on updates
-        let cache = Cache::builder().expire_after(RequestExpiry).build();
+        let cache = Cache::builder()
+            .max_capacity(CACHE_MAX_CAPACITY)
+            .expire_after(RequestExpiry)
+            .build();
 
         Self {
             cache,


### PR DESCRIPTION
Closes https://github.com/worldcoin/world-id-protocol/issues/185
Read [this comment](https://github.com/worldcoin/world-id-protocol/issues/185#issuecomment-3760301399) too


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces ad-hoc in-memory tracking with a bounded moka async cache using TTL and a custom `Expiry` that preserves TTL on reads/updates.
> 
> - Introduces `Cache<String, RequestRecord>` with `REQUESTS_TTL` and `CACHE_MAX_CAPACITY`; removes manual HashMap + RwLock + cleanup task
> - Implements `RequestExpiry` to maintain TTL on create/read/update; local cache used when Redis is absent
> - Updates Redis writes to `EX(REQUESTS_TTL.as_secs())` and adds Lua script in `set_status_on_redis` to atomically update `status` with `KEEPTTL`
> - Adjusts batch updates to mutate cache entries in-place without resetting TTL; `snapshot` now reads from cache when Redis is not configured
> - Minor logging/message tweaks (clarify in-memory-only mode)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c2a36a37d3e592bbb7a46d457b61325e153a3ec2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->