### PR TITLE
fix: add root validity window (time-to-live) to MerkleWatcher cache

### DIFF
--- a/crates/test-utils/src/stubs.rs
+++ b/crates/test-utils/src/stubs.rs
@@ -151,6 +151,7 @@ async fn spawn_orpf_node(
         max_wait_time_shutdown: Duration::from_secs(10),
         max_merkle_cache_size: 10,
         max_rp_registry_store_size: 1000,
+        root_validity_window: Duration::from_secs(3600),
         current_time_stamp_max_difference: Duration::from_secs(3 * 60),
         world_id_registry_contract,
         rp_registry_contract,

--- a/services/oprf-node/src/auth/merkle_watcher.rs
+++ b/services/oprf-node/src/auth/merkle_watcher.rs
@@ -6,9 +6,12 @@
 //! - alloy (uses the alloy crate to interact with smart contracts)
 //! - test (contains initially provided merkle roots)
 
-use std::sync::{
-    atomic::{AtomicBool, Ordering},
-    Arc,
+use std::{
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+    time::Duration,
 };
 
 use alloy::{
@@ -51,12 +54,15 @@ impl MerkleWatcher {
     /// * `contract_address` - Address of the `WorldIDRegistry` contract
     /// * `ws_rpc_url` - WebSocket RPC URL for blockchain connection
     /// * `max_merkle_cache_size` - Maximum number of merkle roots to cache
+    /// * `root_validity_window` - Duration for which a merkle root is considered valid
+    /// * `started` - AtomicBool to indicate when the service has started
     /// * `cancellation_token` - CancellationToken to cancel the service in case of an error
     #[instrument(level = "info", skip_all)]
     pub(crate) async fn init(
         contract_address: Address,
         ws_rpc_url: &str,
         max_merkle_cache_size: u64,
+        root_validity_window: Duration,
         started: Arc<AtomicBool>,
         cancellation_token: CancellationToken,
     ) -> eyre::Result<Self> {
@@ -74,8 +80,10 @@ impl MerkleWatcher {
         let current_root = contract.currentRoot().call().await?;
         tracing::info!("root = {current_root}");
 
-        let merkle_root_cache: Cache<FieldElement, ()> =
-            Cache::builder().max_capacity(max_merkle_cache_size).build();
+        let merkle_root_cache: Cache<FieldElement, ()> = Cache::builder()
+            .max_capacity(max_merkle_cache_size)
+            .time_to_live(root_validity_window)
+            .build();
 
         // Insert current root
         merkle_root_cache.insert(current_root.try_into()?, ()).await;
@@ -176,6 +184,7 @@ mod tests {
             registry_address,
             anvil.ws_endpoint(),
             100,
+            Duration::from_secs(3600),
             started_services.new_service(),
             cancellation_token,
         )
@@ -208,5 +217,55 @@ mod tests {
             .expect("second is_root_valid call should not error");
 
         assert!(valid, "Second call should return true for valid root");
+    }
+
+    #[tokio::test]
+    async fn test_root_not_valid_after_window() {
+        let anvil = TestAnvil::spawn().expect("failed to spawn anvil");
+        let signer = anvil.signer(0).expect("failed to get signer");
+        let registry_address = anvil
+            .deploy_world_id_registry(signer)
+            .await
+            .expect("failed to deploy WorldIDRegistry");
+
+        let mut started_services = StartedServices::default();
+
+        let cancellation_token = CancellationToken::new();
+
+        let merkle_watcher = MerkleWatcher::init(
+            registry_address,
+            anvil.ws_endpoint(),
+            100,
+            Duration::from_secs(1),
+            started_services.new_service(),
+            cancellation_token,
+        )
+        .await
+        .expect("failed to init MerkleWatcher");
+
+        let valid_root = WorldIdRegistry::new(registry_address, anvil.provider().unwrap())
+            .latestRoot()
+            .call()
+            .await
+            .expect("failed to fetch root");
+
+        let valid = merkle_watcher
+            .merkle_root_cache
+            .contains_key(&FieldElement::try_from(valid_root).expect("root in field"));
+        assert!(
+            valid,
+            "Root should be valid immediately after being recorded"
+        );
+
+        // wait for validity window to pass
+        tokio::time::sleep(Duration::from_secs(2)).await;
+
+        let valid = merkle_watcher
+            .merkle_root_cache
+            .contains_key(&FieldElement::try_from(valid_root).expect("root in field"));
+        assert!(
+            !valid,
+            "Root should not be valid after the validity window has passed"
+        );
     }
 }

--- a/services/oprf-node/src/config.rs
+++ b/services/oprf-node/src/config.rs
@@ -21,7 +21,6 @@ pub struct WorldOprfNodeConfig {
         env = "OPRF_NODE_MAX_WAIT_TIME_SHUTDOWN",
         default_value = "10s",
         value_parser = humantime::parse_duration
-
     )]
     pub max_wait_time_shutdown: Duration,
 
@@ -39,6 +38,17 @@ pub struct WorldOprfNodeConfig {
     #[clap(long, env = "OPRF_NODE_MERKLE_CACHE_SIZE", default_value = "100")]
     pub max_merkle_cache_size: u64,
 
+    /// The time to live of a merkle root in the cache.
+    ///
+    /// Will drop merkle roots if this duration elapsed after they were added.
+    #[clap(
+        long,
+        env = "OPRF_NODE_ROOT_VALIDITY_WINDOW",
+        default_value = "1hour",
+        value_parser = humantime::parse_duration
+    )]
+    pub root_validity_window: Duration,
+
     /// The maximum size of the RpRegistry store.
     ///
     /// Will drop old Rps if this capacity is reached.
@@ -51,7 +61,6 @@ pub struct WorldOprfNodeConfig {
         env = "OPRF_NODE_CURRENT_TIME_STAMP_MAX_DIFFERENCE",
         default_value = "5min",
         value_parser = humantime::parse_duration
-
     )]
     pub current_time_stamp_max_difference: Duration,
 

--- a/services/oprf-node/src/lib.rs
+++ b/services/oprf-node/src/lib.rs
@@ -45,6 +45,7 @@ pub async fn start(
         config.world_id_registry_contract,
         node_config.chain_ws_rpc_url.expose_secret(),
         config.max_merkle_cache_size,
+        config.root_validity_window,
         started_services.new_service(),
         cancellation_token.clone(),
     )


### PR DESCRIPTION
this change makes sure that a cached, but invalid (validity window in WorldIdRegistry has elapsed) is not reported as valid by the MerkleWatcher.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements time-bound validation for Merkle roots and wires configurability end-to-end.
> 
> - Add `root_validity_window` to `MerkleWatcher::init` and apply `.time_to_live(...)` on the moka cache so roots expire after the window
> - Extend node config with `root_validity_window` (`OPRF_NODE_ROOT_VALIDITY_WINDOW`) and pass it through startup (`lib.rs`) and test stubs
> - Add test `test_root_not_valid_after_window` verifying cached roots become invalid after the TTL elapses
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c369d6d18b8f706c85a7037c1b286c5f9970bf21. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->