### PR TITLE
fix(WorldIdRegistry): update json abi

### DIFF
--- a/crates/core/contracts/out/WorldIDRegistry.sol/WorldIDRegistryAbi.json
+++ b/crates/core/contracts/out/WorldIDRegistry.sol/WorldIDRegistryAbi.json
@@ -45,6 +45,19 @@
   },
   {
     "type": "function",
+    "name": "MAX_AUTHENTICATORS_LIMIT",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
     "name": "RECOVER_ACCOUNT_TYPEHASH",
     "inputs": [],
     "outputs": [


### PR DESCRIPTION
[This PR](https://github.com/worldcoin/world-id-protocol/pull/236) modified the `WorldIdRegistry` contract, but I didn't run `make sol-build` to also update the json abi. This PR fixes it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates the generated ABI for `WorldIDRegistry` to reflect recent contract changes.
> 
> - Adds view function `MAX_AUTHENTICATORS_LIMIT() -> uint256` to `WorldIDRegistryAbi.json`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 61d8504c83d10e6e6985bb4930dec5819e8d2054. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->