### PR TITLE
fix(ci): explicit RUSTUP_TMP env variable in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,13 @@ RUN apt-get update && apt-get install -y \
   ca-certificates \
 && rm -rf /var/lib/apt/lists/*   
 
+# Set RUSTUP_TMP to avoid "Invalid cross-device link" errors in Docker
+# This ensures rustup's temp directory is on the same filesystem as RUSTUP_HOME
+ENV RUSTUP_TMP=/root/.rustup/tmp
+
 # Remove the pre-installed toolchain and add the MUSL target
-RUN rustup set profile minimal \
+RUN mkdir -p $RUSTUP_TMP \
+ && rustup set profile minimal \
  && rustup toolchain uninstall stable || true \
  && rustup toolchain install stable --profile minimal \
  && rustup target add x86_64-unknown-linux-musl


### PR DESCRIPTION
This PR should fix the ci issue `Invalid cross-device link (os error 18)`:

```
1.773 error: could not rename component file from '/root/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-musl/lib/self-contained' to '/root/.rustup/tmp/gph9kzddopbxz2pr_dir/bk': Invalid cross-device link (os error 18)
------
Dockerfile:37
--------------------
  35 |     FROM chef AS planner
  36 |     COPY . .
  37 | >>> RUN cargo chef prepare --recipe-path recipe.json
  38 |     
  39 |     FROM chef AS builder
--------------------
ERROR: failed to build: failed to solve: process "/bin/sh -c cargo chef prepare --recipe-path recipe.json" did not complete successfully: exit code: 1
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Addresses rustup temp-file move errors in Docker builds.
> 
> - Adds `ENV RUSTUP_TMP=/root/.rustup/tmp` to align rustup temp path with `RUSTUP_HOME`
> - Ensures the temp directory exists with `mkdir -p $RUSTUP_TMP` before rustup operations
> - Keeps existing MUSL toolchain setup and build steps unchanged
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ec787a55e6776872f4f7210137cb7495cf958cbf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->