### PR TITLE
chore: update MAX_AUTHENTICATORS_HARD_LIMIT to 96

### DIFF
--- a/contracts/src/WorldIDRegistry.sol
+++ b/contracts/src/WorldIDRegistry.sol
@@ -130,7 +130,7 @@ contract WorldIDRegistry is Initializable, EIP712Upgradeable, Ownable2StepUpgrad
     string public constant EIP712_VERSION = "1.0";
 
     /// @notice Maximum allowed value for maxAuthenticators (limited by pubkey bitmap size)
-    uint256 public constant MAX_AUTHENTICATORS_HARD_LIMIT = 160;
+    uint256 public constant MAX_AUTHENTICATORS_HARD_LIMIT = 96;
 
     ////////////////////////////////////////////////////////////
     //                        Errors                         //
@@ -1012,7 +1012,7 @@ contract WorldIDRegistry is Initializable, EIP712Upgradeable, Ownable2StepUpgrad
      * @dev Set an updated maximum number of authenticators allowed.
      */
     function setMaxAuthenticators(uint256 newMaxAuthenticators) external onlyOwner onlyProxy onlyInitialized {
-        if (newMaxAuthenticators >= MAX_AUTHENTICATORS_HARD_LIMIT) {
+        if (newMaxAuthenticators > MAX_AUTHENTICATORS_HARD_LIMIT) {
             revert OwnerMaxAuthenticatorsOutOfBounds();
         }
         uint256 old = maxAuthenticators;

--- a/contracts/test/WorldIDRegistry.t.sol
+++ b/contracts/test/WorldIDRegistry.t.sol
@@ -679,25 +679,31 @@ contract WorldIDRegistryTest is Test {
         );
     }
 
-    function test_SetMaxAuthenticators_RevertWhen_ValueAtLimit() public {
-        // Should revert when trying to set maxAuthenticators to exactly 160 (the limit)
-        vm.expectRevert(abi.encodeWithSelector(WorldIDRegistry.OwnerMaxAuthenticatorsOutOfBounds.selector));
-        worldIDRegistry.setMaxAuthenticators(160);
-    }
-
     function test_SetMaxAuthenticators_RevertWhen_ValueAboveLimit() public {
-        // Should revert when trying to set maxAuthenticators above 160
+        // Should revert when trying to set maxAuthenticators above 96 (the limit)
         vm.expectRevert(abi.encodeWithSelector(WorldIDRegistry.OwnerMaxAuthenticatorsOutOfBounds.selector));
-        worldIDRegistry.setMaxAuthenticators(200);
+        worldIDRegistry.setMaxAuthenticators(97);
 
         vm.expectRevert(abi.encodeWithSelector(WorldIDRegistry.OwnerMaxAuthenticatorsOutOfBounds.selector));
         worldIDRegistry.setMaxAuthenticators(type(uint256).max);
     }
 
     function test_SetMaxAuthenticators_SucceedsAtMaxValidValue() public {
-        // Should succeed when setting to 159 (one below the limit)
-        worldIDRegistry.setMaxAuthenticators(159);
-        assertEq(worldIDRegistry.getMaxAuthenticators(), 159);
+        // Should succeed when setting to 96 (the maximum allowed value, matching 96-bit bitmap)
+        worldIDRegistry.setMaxAuthenticators(96);
+        assertEq(worldIDRegistry.getMaxAuthenticators(), 96);
+    }
+
+    function test_SetMaxAuthenticators_SucceedsBelowMaxValue() public {
+        // Should succeed when setting to values below 96
+        worldIDRegistry.setMaxAuthenticators(95);
+        assertEq(worldIDRegistry.getMaxAuthenticators(), 95);
+
+        worldIDRegistry.setMaxAuthenticators(50);
+        assertEq(worldIDRegistry.getMaxAuthenticators(), 50);
+
+        worldIDRegistry.setMaxAuthenticators(1);
+        assertEq(worldIDRegistry.getMaxAuthenticators(), 1);
     }
 
     ////////////////////////////////////////////////////////////


### PR DESCRIPTION
Closes https://github.com/worldcoin/world-id-protocol/issues/251

Set MAX_AUTHENTICATORS_HARD_LIMIT to 96 to match bitmap size

Allow setting maxAuthenticator up to the limit (previously was not allowed)