### PR TITLE
perf(WorldIdRegistry): small gas saving

### DIFF
--- a/contracts/src/WorldIDRegistry.sol
+++ b/contracts/src/WorldIDRegistry.sol
@@ -563,7 +563,6 @@ contract WorldIDRegistry is Initializable, EIP712Upgradeable, Ownable2StepUpgrad
 
         uint256 leafIndex = nextLeafIndex;
 
-        uint256 bitmap = 0;
         for (uint32 i = 0; i < authenticatorAddresses.length; i++) {
             address authenticatorAddress = authenticatorAddresses[i];
             if (authenticatorAddress == address(0)) {
@@ -572,8 +571,8 @@ contract WorldIDRegistry is Initializable, EIP712Upgradeable, Ownable2StepUpgrad
 
             _validateNewAuthenticatorAddress(authenticatorAddress);
             authenticatorAddressToPackedAccountData[authenticatorAddress] = PackedAccountData.pack(leafIndex, 0, i);
-            bitmap = bitmap | (1 << i);
         }
+        uint256 bitmap = (1 << authenticatorAddresses.length) - 1;
         _setRecoveryAddressAndBitmap(leafIndex, recoveryAddress, bitmap);
 
         emit AccountCreated(


### PR DESCRIPTION
Closes #252 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Optimizes bitmap initialization during account registration for minor gas savings.
> 
> - In `WorldIDRegistry._registerAccount`, removes per-iteration bitmap OR-ing and sets the bitmap once using `(1 << authenticatorAddresses.length) - 1`
> - No external interfaces or behaviors changed; affects `createAccount` and `createManyAccounts` paths only
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b7625c17c5f4452072f59f6af6a25fd13c9d0675. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->