### PR TITLE
fix: RpId cannot be 0

### DIFF
--- a/contracts/src/RpRegistry.sol
+++ b/contracts/src/RpRegistry.sol
@@ -182,6 +182,11 @@ contract RpRegistry is Initializable, EIP712Upgradeable, Ownable2StepUpgradeable
      */
     error ZeroAddress();
 
+    /**
+     * @dev Thrown when the passed id is invalid for the operation. Usually this means the `id` used is equal to `0` which is not allowed.
+     */
+    error InvalidId();
+
     ////////////////////////////////////////////////////////////
     //                        Constructor                     //
     ////////////////////////////////////////////////////////////
@@ -422,6 +427,8 @@ contract RpRegistry is Initializable, EIP712Upgradeable, Ownable2StepUpgradeable
 
     function _register(uint64 rpId, address manager, address signer, string memory unverifiedWellKnownDomain) internal {
         if (_relyingParties[rpId].initialized) revert RpIdAlreadyInUse(rpId);
+
+        if (rpId == 0) revert InvalidId();
 
         if (manager == address(0)) revert ManagerCannotBeZeroAddress();
 

--- a/contracts/test/RpRegistry.t.sol
+++ b/contracts/test/RpRegistry.t.sol
@@ -108,6 +108,14 @@ contract RpRegistryTest is Test {
         registry.register(rpId, manager1, address(0), wellKnownDomain);
     }
 
+    function testCannotRegisterWithInvalidId() public {
+        uint64 rpId = 0;
+        string memory wellKnownDomain = "example.world.org";
+
+        vm.expectRevert(abi.encodeWithSelector(RpRegistry.InvalidId.selector));
+        registry.register(rpId, manager1, signer1, wellKnownDomain);
+    }
+
     function testRegisterMany() public {
         uint64[] memory rpIds = new uint64[](3);
         rpIds[0] = 1;
@@ -264,6 +272,27 @@ contract RpRegistryTest is Test {
         domains[1] = "app2.world.org";
 
         vm.expectRevert(abi.encodeWithSelector(RpRegistry.SignerCannotBeZeroAddress.selector));
+        registry.registerMany(rpIds, managers, signers, domains);
+    }
+
+    function testRegisterManyInvalidId() public {
+        uint64[] memory rpIds = new uint64[](2);
+        rpIds[0] = 0;
+        rpIds[1] = 2;
+
+        address[] memory managers = new address[](2);
+        managers[0] = manager1;
+        managers[1] = manager2;
+
+        address[] memory signers = new address[](2);
+        signers[0] = signer1;
+        signers[1] = signer2;
+
+        string[] memory domains = new string[](2);
+        domains[0] = "app1.world.org";
+        domains[1] = "app2.world.org";
+
+        vm.expectRevert(abi.encodeWithSelector(RpRegistry.InvalidId.selector));
         registry.registerMany(rpIds, managers, signers, domains);
     }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Prevents registering relying parties with an invalid ID.
> 
> - Adds `InvalidId` error and enforces `rpId != 0` in `_register` (affects `register` and `registerMany`)
> - Extends tests with single and batch invalid-id cases (`testCannotRegisterWithInvalidId`, `testRegisterManyInvalidId`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fea4483ca35d42a2348f506e75b21d5528e17b97. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->