### PR TITLE
chore: update CODEOWNERS with new GH team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
-* @worldcoin/protocol @andy-t-wang @Takaros999 @aurel-fr @carlomazzaferro @eaypek-tfh @rw0x0 @fabian1409 @0xThemis @dkales @lukejmann @m1guelpf @cichaczem
+* @worldcoin/protocol-contributors @rw0x0 @fabian1409 @0xThemis @dkales
 /services/oprf-node @fabian1409 @0xThemis @dkales @philsippl
 /services/oprf-dev-client @fabian1409 @0xThemis @dkales @philsippl
 /circom @fabian1409 @0xThemis @dkales @philsippl @paolodamico
-CODEOWNERS @paolodamico @philsippl @murph
+/.github/CODEOWNERS @paolodamico @philsippl @murph


### PR DESCRIPTION
Team is getting created.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates repository ownership rules.
> 
> - Replaces repo-wide owners (`*`) with `@worldcoin/protocol-contributors` plus a reduced maintainer list
> - Updates the CODEOWNERS file path entry from `CODEOWNERS` to `/.github/CODEOWNERS` while keeping other path-specific owners unchanged
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 73d53ce243f5d9d5b214c2a1654c0f98ad8be3cc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->