### PR TITLE
refactor(indexer): Refactor DB access in http requests.

### DIFF
--- a/services/indexer/src/db/mod.rs
+++ b/services/indexer/src/db/mod.rs
@@ -44,6 +44,11 @@ impl DB {
     pub fn accounts(&self) -> Accounts<'_> {
         Accounts::new(&self.pool)
     }
+
+    pub async fn ping(&self) -> anyhow::Result<()> {
+        sqlx::query("SELECT 1").fetch_one(&self.pool).await?;
+        Ok(())
+    }
 }
 
 pub async fn fetch_recent_account_updates(

--- a/services/indexer/src/routes/health.rs
+++ b/services/indexer/src/routes/health.rs
@@ -5,18 +5,10 @@ use world_id_core::types::{HealthResponse, IndexerErrorResponse};
 pub(crate) async fn handler(
     State(state): State<AppState>,
 ) -> Result<Json<HealthResponse>, IndexerErrorResponse> {
-    let query = sqlx::query("select 1")
-        .fetch_optional(state.db.pool())
-        .await
-        .map_err(|e| {
-            tracing::error!("error querying the database for accounts: {}", e);
-            IndexerErrorResponse::internal_server_error()
-        })?;
-
-    if query.is_none() {
-        tracing::error!("error querying the database for accounts (empty result)");
-        return Err(IndexerErrorResponse::internal_server_error());
-    }
+    state.db.ping().await.map_err(|e| {
+        tracing::error!("error pinging the database: {}", e);
+        IndexerErrorResponse::internal_server_error()
+    })?;
 
     Ok(Json(HealthResponse { success: true }))
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Consolidates DB queries into the `DB` and `Accounts` layers and updates routes to use them.
> 
> - Adds `DB::ping()` and updates `health` route to use it for a simple connectivity check
> - Introduces `Accounts::get_offchain_signer_commitment_and_authenticator_pubkeys_by_leaf_index` and refactors `inclusion_proof` handler to use it instead of inline SQL
> - Minor correctness/consistency tweaks: compare leaf index with `U256::ZERO` and streamline public key parsing
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5a5a06475bb80f46bb38258f6189b3f317185740. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->