### PR TITLE
feat: update poseidon2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7140,7 +7140,7 @@ dependencies = [
  "serde",
  "taceo-ark-babyjubjub",
  "taceo-ark-serde-compat",
- "taceo-poseidon2 0.2.1",
+ "taceo-poseidon2",
  "zeroize",
 ]
 
@@ -7271,7 +7271,7 @@ dependencies = [
  "taceo-ark-babyjubjub",
  "taceo-oprf-core",
  "taceo-oprf-types",
- "taceo-poseidon2 0.2.1",
+ "taceo-poseidon2",
  "thiserror 2.0.17",
  "tokio",
  "tokio-tungstenite 0.28.0",
@@ -7295,7 +7295,7 @@ dependencies = [
  "subtle",
  "taceo-ark-babyjubjub",
  "taceo-ark-serde-compat",
- "taceo-poseidon2 0.2.1",
+ "taceo-poseidon2",
  "uuid",
  "zeroize",
 ]
@@ -7448,19 +7448,6 @@ dependencies = [
 
 [[package]]
 name = "taceo-poseidon2"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce5f09fc2f1c68aafd3f544313fe7e34d33b35aa666bc9e6b7a22e94b9833140"
-dependencies = [
- "ark-bn254 0.5.0",
- "ark-ff 0.5.0",
- "ark-std 0.5.0",
- "num-bigint",
- "num-traits",
-]
-
-[[package]]
-name = "taceo-poseidon2"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac59d3df4c827b3496bff929aebd6440997a5c2e946f46ff4fdd76f318447581"
@@ -7564,7 +7551,7 @@ dependencies = [
  "taceo-oprf",
  "taceo-oprf-key-gen",
  "taceo-oprf-test-utils",
- "taceo-poseidon2 0.1.0",
+ "taceo-poseidon2",
  "tokio",
  "world-id-oprf-node",
  "world-id-primitives",
@@ -8932,7 +8919,7 @@ dependencies = [
  "taceo-groth16-material",
  "taceo-oprf",
  "taceo-oprf-test-utils",
- "taceo-poseidon2 0.1.0",
+ "taceo-poseidon2",
  "test-utils",
  "thiserror 1.0.69",
  "tokio",
@@ -9000,7 +8987,7 @@ dependencies = [
  "serde_json",
  "serial_test",
  "sqlx",
- "taceo-poseidon2 0.1.0",
+ "taceo-poseidon2",
  "take_mut",
  "tempfile",
  "test-utils",
@@ -9103,7 +9090,7 @@ dependencies = [
  "taceo-groth16-material",
  "taceo-groth16-sol",
  "taceo-oprf",
- "taceo-poseidon2 0.1.0",
+ "taceo-poseidon2",
  "thiserror 1.0.69",
  "url",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ taceo-oprf = { version = "0.1", default-features = false }
 taceo-oprf-test-utils = "0.1"
 taceo-oprf-key-gen = "0.1"
 ruint = { version = "1.17", features = ["ark-ff-05"] }
-poseidon2 = { package = "taceo-poseidon2", version = "0.1" }
+poseidon2 = { package = "taceo-poseidon2", version = "0.2" }
 rand = "0.8"
 rand_chacha = "0.3"
 rustls = "0.23"

--- a/crates/core/src/requests/mod.rs
+++ b/crates/core/src/requests/mod.rs
@@ -7,7 +7,6 @@ mod constraints;
 use ark_ff::PrimeField;
 pub use constraints::{ConstraintExpr, ConstraintKind, ConstraintNode, MAX_CONSTRAINT_NODES};
 
-use poseidon2::Poseidon2;
 use serde::{Deserialize, Serialize, de::Error as _};
 use std::collections::HashSet;
 use taceo_oprf::types::{OprfKeyId, ShareEpoch};
@@ -319,8 +318,7 @@ impl ProofRequest {
             *FieldElement::from(self.rp_id),
             *self.computed_action(),
         ];
-        let poseidon2_4: Poseidon2<ark_babyjubjub::Fq, 4, 5> = Poseidon2::default();
-        poseidon2_4.permutation(&input)[1].into()
+        poseidon2::bn254::t4::permutation(&input)[1].into()
     }
 
     /// Gets the action value to use in the proof.

--- a/crates/primitives/src/authenticator.rs
+++ b/crates/primitives/src/authenticator.rs
@@ -7,7 +7,6 @@ use ark_babyjubjub::{EdwardsAffine, Fq};
 use ark_ff::AdditiveGroup;
 use arrayvec::ArrayVec;
 use eddsa_babyjubjub::{EdDSAPublicKey, EdDSASignature};
-use poseidon2::Poseidon2;
 use serde::{Deserialize, Serialize};
 
 use crate::{FieldElement, PrimitiveError};
@@ -111,7 +110,6 @@ impl AuthenticatorPublicKeySet {
     /// Panics if the domain separator constant cannot be converted into an `Fq`.
     #[must_use]
     pub fn leaf_hash(&self) -> Fq {
-        let poseidon2_16: Poseidon2<Fq, 16, 5> = Poseidon2::default();
         let mut input = [Fq::ZERO; 16];
 
         input[0] =
@@ -123,7 +121,7 @@ impl AuthenticatorPublicKeySet {
             input[i * 2 + 2] = pk_array[i].y;
         }
 
-        poseidon2_16.permutation(&input)[1]
+        poseidon2::bn254::t16::permutation(&input)[1]
     }
 }
 

--- a/crates/primitives/src/credential.rs
+++ b/crates/primitives/src/credential.rs
@@ -1,6 +1,5 @@
 use ark_babyjubjub::EdwardsAffine;
 use eddsa_babyjubjub::{EdDSAPublicKey, EdDSASignature};
-use poseidon2::{POSEIDON2_BN254_T3_PARAMS, Poseidon2};
 use rand::Rng;
 use ruint::aliases::U256;
 use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
@@ -189,9 +188,8 @@ impl Credential {
     /// Set the `sub` for the credential computed from `leaf_index` and a `blinding_factor`.
     #[must_use]
     pub fn sub(mut self, leaf_index: u64, blinding_factor: FieldElement) -> Self {
-        let hasher = Poseidon2::new(&POSEIDON2_BN254_T3_PARAMS);
         let mut input = [*self.get_sub_ds(), leaf_index.into(), *blinding_factor];
-        hasher.permutation_in_place(&mut input);
+        poseidon2::bn254::t3::permutation_in_place(&mut input);
         self.sub = input[1].into();
         self
     }

--- a/crates/primitives/src/sponge.rs
+++ b/crates/primitives/src/sponge.rs
@@ -1,6 +1,5 @@
 use ark_babyjubjub::Fq;
 use ark_ff::Zero;
-use poseidon2::{POSEIDON2_BN254_T16_PARAMS, Poseidon2};
 use sha3::{Digest, Sha3_256};
 
 use crate::{FieldElement, PrimitiveError};
@@ -174,8 +173,6 @@ fn hash_bytes_with_poseidon2_t16_r15(
         reason: "data length exceeds supported range (u32::MAX)".to_string(),
     })?;
 
-    let poseidon2: Poseidon2<Fq, 16, 5> = Poseidon2::new(&POSEIDON2_BN254_T16_PARAMS);
-
     // Initialize state with zeros
     let mut state: [Fq; 16] = [Fq::zero(); 16];
 
@@ -198,7 +195,7 @@ fn hash_bytes_with_poseidon2_t16_r15(
         for (i, &elem) in batch.iter().enumerate() {
             state[i] += elem;
         }
-        poseidon2.permutation_in_place(&mut state);
+        poseidon2::bn254::t16::permutation_in_place(&mut state);
     }
 
     // Enforce squeeze step and pattern completion.

--- a/crates/test-utils/src/merkle.rs
+++ b/crates/test-utils/src/merkle.rs
@@ -1,31 +1,29 @@
 use ark_babyjubjub::Fq;
 use ark_ff::AdditiveGroup;
-use poseidon2::Poseidon2;
 use world_id_primitives::{FieldElement, TREE_DEPTH};
 
 /// Builds the default-zero sibling path for index 1 and computes the Merkle root
 /// after inserting the provided `leaf` at that index, using Poseidon2 T2 compress.
 pub fn first_leaf_merkle_path(leaf: Fq) -> ([FieldElement; TREE_DEPTH], FieldElement) {
-    let poseidon2_2: Poseidon2<Fq, 2, 5> = Poseidon2::default();
     let mut siblings = [FieldElement::ZERO; TREE_DEPTH];
     let mut zero = Fq::ZERO;
     for sibling in siblings.iter_mut() {
         *sibling = zero.into();
-        zero = poseidon2_compress(&poseidon2_2, zero, zero);
+        zero = poseidon2_compress(zero, zero);
     }
 
-    let mut current = poseidon2_compress(&poseidon2_2, *siblings[0], leaf);
+    let mut current = poseidon2_compress(*siblings[0], leaf);
     // For the remaining levels, continue hashing with current on the left
     for sibling in &siblings[1..] {
-        current = poseidon2_compress(&poseidon2_2, current, **sibling);
+        current = poseidon2_compress(current, **sibling);
     }
 
     (siblings, current.into())
 }
 
 /// Poseidon2 "compress" for a pair of field elements (left, right).
-fn poseidon2_compress(poseidon2: &Poseidon2<Fq, 2, 5>, left: Fq, right: Fq) -> Fq {
-    let mut state = poseidon2.permutation(&[left, right]);
+fn poseidon2_compress(left: Fq, right: Fq) -> Fq {
+    let mut state = poseidon2::bn254::t2::permutation(&[left, right]);
     state[0] += left;
     state[0]
 }

--- a/services/indexer/src/tree/mod.rs
+++ b/services/indexer/src/tree/mod.rs
@@ -2,7 +2,6 @@ use std::sync::LazyLock;
 
 use alloy::primitives::U256;
 use ark_bn254::Fr;
-use poseidon2::{POSEIDON2_BN254_T2_PARAMS, Poseidon2};
 use semaphore_rs_hasher::Hasher;
 pub use semaphore_rs_trees::lazy::{Canonical, LazyMerkleTree as MerkleTree};
 use tokio::sync::RwLock;
@@ -17,10 +16,6 @@ mod tests;
 
 pub use initializer::TreeInitializer;
 
-// Poseidon2 hasher singleton
-static POSEIDON_HASHER: LazyLock<Poseidon2<Fr, 2, 5>> =
-    LazyLock::new(|| Poseidon2::new(&POSEIDON2_BN254_T2_PARAMS));
-
 pub struct PoseidonHasher {}
 
 impl Hasher for PoseidonHasher {
@@ -31,7 +26,7 @@ impl Hasher for PoseidonHasher {
         let right: Fr = right.try_into().unwrap();
         let mut input = [left, right];
         let feed_forward = input[0];
-        POSEIDON_HASHER.permutation_in_place(&mut input);
+        poseidon2::bn254::t2::permutation_in_place(&mut input);
         input[0] += feed_forward;
         input[0].into()
     }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Updates a cryptographic hash dependency and rewires multiple hashing call sites (credential hashes, OPRF digests, Merkle hashing), which can change outputs and break compatibility with stored commitments/proofs if parameters differ.
> 
> **Overview**
> Upgrades the workspace `poseidon2` dependency from `taceo-poseidon2` v0.1 to v0.2 (and cleans up `Cargo.lock` to drop the old version).
> 
> Refactors Poseidon2 usage across core/primitives/test-utils/indexer from constructing `Poseidon2` instances + params constants to calling the new `poseidon2::bn254::t{2,3,4,8,16}::{permutation,permutation_in_place}` functions, including removal of the indexer’s global hasher singleton.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3041ff89028a237dc00f2f52e9d02dda515427ce. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->