### PR TITLE
fix(core): fix `compute_action` to handle both action or session_id

### DIFF
--- a/crates/core/src/requests/mod.rs
+++ b/crates/core/src/requests/mod.rs
@@ -328,7 +328,8 @@ impl ProofRequest {
     /// this returns the `session_id` as the action binding value.
     ///
     /// # Panics
-    /// Panics if both `action` and `session_id` are `None`, as this represents an invalid request.
+    /// Panics if both `action` and `session_id` are `None`, or if both are provided,
+    /// as either case represents an invalid request.
     #[must_use]
     pub fn computed_action(&self) -> FieldElement {
         match (self.action, self.session_id) {


### PR DESCRIPTION
Closes #298 

Please let me know if this makes sense to you. I think it does by reading the docs but I'm open to feedbacks.