### PR TITLE
fix(indexer): better error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8997,7 +8997,6 @@ name = "world-id-indexer"
 version = "0.1.0"
 dependencies = [
  "alloy",
- "anyhow",
  "ark-bn254 0.5.0",
  "ark-ff 0.5.0",
  "axum",
@@ -9019,6 +9018,7 @@ dependencies = [
  "take_mut",
  "tempfile",
  "test-utils",
+ "thiserror 1.0.69",
  "tokio",
  "tracing",
  "tracing-subscriber 0.3.22",

--- a/services/indexer/Cargo.toml
+++ b/services/indexer/Cargo.toml
@@ -16,7 +16,7 @@ alloy = { workspace = true, features = ["rpc-types", "provider-ws"] }
 dotenvy = "0.15"
 url = "2"
 hex = "0.4"
-anyhow = { workspace = true }
+thiserror.workspace = true
 ruint = { workspace = true, features = ["sqlx"] }
 futures-util = "0.3"
 sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "postgres", "macros", "json" , "migrate"] }

--- a/services/indexer/src/blockchain/mod.rs
+++ b/services/indexer/src/blockchain/mod.rs
@@ -9,6 +9,7 @@ use futures_util::{Stream, StreamExt, stream};
 use url::Url;
 
 pub use crate::blockchain::events::{BlockchainEvent, RegistryEvent};
+use crate::error::IndexerResult;
 
 mod events;
 
@@ -23,7 +24,7 @@ impl Blockchain {
         http_rpc_url: &str,
         ws_rpc_url: &str,
         world_id_registry: Address,
-    ) -> anyhow::Result<Self> {
+    ) -> IndexerResult<Self> {
         let http_provider =
             DynProvider::new(ProviderBuilder::new().connect_http(Url::parse(http_rpc_url)?));
 
@@ -43,7 +44,7 @@ impl Blockchain {
     pub async fn stream_world_tree_events(
         &self,
         from_block: u64,
-    ) -> anyhow::Result<impl Stream<Item = anyhow::Result<BlockchainEvent<RegistryEvent>>>> {
+    ) -> IndexerResult<impl Stream<Item = IndexerResult<BlockchainEvent<RegistryEvent>>>> {
         let filter = Filter::new()
             .address(self.world_id_registry)
             .event_signature(RegistryEvent::signatures());
@@ -72,7 +73,7 @@ impl Blockchain {
             .map(|log| RegistryEvent::decode(&log)))
     }
 
-    pub async fn get_block_number(&self) -> anyhow::Result<u64> {
+    pub async fn get_block_number(&self) -> IndexerResult<u64> {
         Ok(self.http_provider.get_block_number().await?)
     }
 }

--- a/services/indexer/src/db/accounts.rs
+++ b/services/indexer/src/db/accounts.rs
@@ -1,6 +1,8 @@
 use alloy::primitives::{Address, U256};
 use sqlx::{PgPool, Row, types::Json};
 
+use crate::error::IndexerResult;
+
 pub struct Accounts<'a> {
     pool: &'a PgPool,
     table_name: String,
@@ -17,7 +19,7 @@ impl<'a> Accounts<'a> {
     pub async fn get_offchain_signer_commitment_and_authenticator_pubkeys_by_leaf_index(
         &self,
         leaf_index: &U256,
-    ) -> anyhow::Result<Option<(U256, Vec<U256>)>> {
+    ) -> IndexerResult<Option<(U256, Vec<U256>)>> {
         let result = sqlx::query(&format!(
             r#"
                                 SELECT
@@ -52,7 +54,7 @@ impl<'a> Accounts<'a> {
         authenticator_addresses: &[Address],
         authenticator_pubkeys: &[U256],
         offchain_signer_commitment: &U256,
-    ) -> anyhow::Result<()> {
+    ) -> IndexerResult<()> {
         sqlx::query(&format!(
             r#"
                 INSERT INTO {} (
@@ -92,7 +94,7 @@ impl<'a> Accounts<'a> {
         new_address: &Address,
         new_pubkey: &U256,
         new_commitment: &U256,
-    ) -> anyhow::Result<()> {
+    ) -> IndexerResult<()> {
         // Update authenticator at specific index (pubkey_id)
         sqlx::query(&format!(
             r#"
@@ -122,7 +124,7 @@ impl<'a> Accounts<'a> {
         new_address: &Address,
         new_pubkey: &U256,
         new_commitment: &U256,
-    ) -> anyhow::Result<()> {
+    ) -> IndexerResult<()> {
         // Ensure arrays are large enough and insert at specific index
         sqlx::query(&format!(
             r#"
@@ -150,7 +152,7 @@ impl<'a> Accounts<'a> {
         leaf_index: &U256,
         pubkey_id: u32,
         new_commitment: &U256,
-    ) -> anyhow::Result<()> {
+    ) -> IndexerResult<()> {
         // Remove authenticator at specific index by setting to null
         sqlx::query(&format!(
             r#"

--- a/services/indexer/src/error.rs
+++ b/services/indexer/src/error.rs
@@ -1,0 +1,78 @@
+use std::path::PathBuf;
+
+use alloy::primitives::{FixedBytes, U256};
+use semaphore_rs_trees::lazy::DenseMMapError;
+use thiserror::Error;
+
+pub type IndexerResult<T, E = IndexerError> = Result<T, E>;
+
+#[derive(Debug, Error)]
+pub enum IndexerError {
+    #[error("missing environment variable: {var}")]
+    MissingEnvVar { var: &'static str },
+    #[error("invalid log for decoding")]
+    InvalidLogForDecoding,
+    #[error("log has no topics")]
+    MissingLogTopics,
+    #[error("missing block number")]
+    MissingBlockNumber,
+    #[error("missing transaction hash")]
+    MissingTransactionHash,
+    #[error("missing log index")]
+    MissingLogIndex,
+    #[error("unknown event signature: {signature:?}")]
+    UnknownEventSignature { signature: FixedBytes<32> },
+    #[error("leaf index {leaf_index} out of range for tree depth {depth}")]
+    LeafIndexOutOfRange { leaf_index: U256, depth: usize },
+    #[error("account index cannot be zero")]
+    AccountIndexZero,
+    #[error("invalid cache file path")]
+    InvalidCacheFilePath,
+    #[error("failed to restore tree from cache")]
+    MmapRestoreFailed { source: DenseMMapError },
+    #[error("failed to create mmap tree")]
+    MmapCreateFailed { source: DenseMMapError },
+    #[error("root mismatch: expected {expected}, got {actual}")]
+    RootMismatch { expected: String, actual: String },
+    #[error("metadata file does not exist: {path}")]
+    MetadataFileMissing { path: PathBuf },
+    #[error("failed to read metadata file: {path}")]
+    MetadataRead {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+    #[error("failed to parse metadata file: {path}")]
+    MetadataParse {
+        path: PathBuf,
+        source: serde_json::Error,
+    },
+    #[error("failed to serialize metadata")]
+    MetadataSerialize { source: serde_json::Error },
+    #[error("failed to write metadata file: {path}")]
+    MetadataWrite {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+    #[error("failed to rename {from} to {to}")]
+    MetadataRename {
+        from: PathBuf,
+        to: PathBuf,
+        source: std::io::Error,
+    },
+    #[error("unknown world tree event type: {value}")]
+    UnknownWorldTreeEventType { value: String },
+    #[error("unknown world tree root event type: {value}")]
+    UnknownWorldTreeRootEventType { value: String },
+    #[error(transparent)]
+    Sqlx(#[from] sqlx::Error),
+    #[error(transparent)]
+    SqlxMigrate(#[from] sqlx::migrate::MigrateError),
+    #[error(transparent)]
+    Transport(#[from] alloy::transports::TransportError),
+    #[error(transparent)]
+    UrlParse(#[from] url::ParseError),
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+    #[error(transparent)]
+    SolType(#[from] alloy::sol_types::Error),
+}

--- a/services/indexer/src/routes/get_packed_account.rs
+++ b/services/indexer/src/routes/get_packed_account.rs
@@ -5,7 +5,7 @@ use world_id_core::types::{
     IndexerPackedAccountResponse,
 };
 
-use crate::config::AppState;
+use crate::{config::AppState, error::IndexerResult};
 
 /// Get Packed Account Data
 ///
@@ -24,7 +24,7 @@ use crate::config::AppState;
 pub(crate) async fn handler(
     State(state): State<AppState>,
     Json(req): Json<IndexerPackedAccountRequest>,
-) -> Result<Json<IndexerPackedAccountResponse>, IndexerErrorResponse> {
+) -> IndexerResult<Json<IndexerPackedAccountResponse>, IndexerErrorResponse> {
     let packed_account_data = state
         .registry
         .getPackedAccountData(req.authenticator_address)

--- a/services/indexer/src/routes/get_signature_nonce.rs
+++ b/services/indexer/src/routes/get_signature_nonce.rs
@@ -4,7 +4,7 @@ use world_id_core::types::{
     IndexerErrorCode, IndexerErrorResponse, IndexerQueryRequest, IndexerSignatureNonceResponse,
 };
 
-use crate::config::AppState;
+use crate::{config::AppState, error::IndexerResult};
 
 /// Get Signature Nonce
 ///
@@ -24,7 +24,7 @@ use crate::config::AppState;
 pub(crate) async fn handler(
     State(state): State<AppState>,
     Json(req): Json<IndexerQueryRequest>,
-) -> Result<Json<IndexerSignatureNonceResponse>, IndexerErrorResponse> {
+) -> IndexerResult<Json<IndexerSignatureNonceResponse>, IndexerErrorResponse> {
     if req.leaf_index == U256::ZERO {
         return Err(IndexerErrorResponse::bad_request(
             IndexerErrorCode::InvalidLeafIndex,

--- a/services/indexer/src/routes/health.rs
+++ b/services/indexer/src/routes/health.rs
@@ -1,10 +1,10 @@
-use crate::config::AppState;
+use crate::{config::AppState, error::IndexerResult};
 use axum::{Json, extract::State};
 use world_id_core::types::{HealthResponse, IndexerErrorResponse};
 
 pub(crate) async fn handler(
     State(state): State<AppState>,
-) -> Result<Json<HealthResponse>, IndexerErrorResponse> {
+) -> IndexerResult<Json<HealthResponse>, IndexerErrorResponse> {
     state.db.ping().await.map_err(|e| {
         tracing::error!("error pinging the database: {}", e);
         IndexerErrorResponse::internal_server_error()

--- a/services/indexer/src/routes/inclusion_proof.rs
+++ b/services/indexer/src/routes/inclusion_proof.rs
@@ -1,4 +1,4 @@
-use crate::config::AppState;
+use crate::{config::AppState, error::IndexerResult};
 use alloy::primitives::U256;
 use axum::{Json, extract::State};
 use http::StatusCode;
@@ -47,7 +47,7 @@ pub(crate) struct AccountInclusionProofSchema {
 pub(crate) async fn handler(
     State(state): State<AppState>,
     Json(req): Json<IndexerQueryRequest>,
-) -> Result<Json<AccountInclusionProof<TREE_DEPTH>>, IndexerErrorResponse> {
+) -> IndexerResult<Json<AccountInclusionProof<TREE_DEPTH>>, IndexerErrorResponse> {
     let leaf_index = req.leaf_index;
 
     if leaf_index == U256::ZERO {

--- a/services/indexer/src/sanity_check.rs
+++ b/services/indexer/src/sanity_check.rs
@@ -6,14 +6,14 @@ use alloy::{
 };
 use world_id_core::world_id_registry::WorldIdRegistry;
 
-use crate::tree::GLOBAL_TREE;
+use crate::{error::IndexerResult, tree::GLOBAL_TREE};
 
 /// Periodically checks that the local in-memory Merkle root remains valid on-chain.
 pub async fn root_sanity_check_loop(
     rpc_url: String,
     registry: Address,
     interval_secs: u64,
-) -> anyhow::Result<()> {
+) -> IndexerResult<()> {
     let provider = ProviderBuilder::new().connect_http(rpc_url.parse().expect("invalid RPC URL"));
     let contract = WorldIdRegistry::new(registry, provider.clone());
 

--- a/services/indexer/src/tree/initializer.rs
+++ b/services/indexer/src/tree/initializer.rs
@@ -4,7 +4,10 @@ use alloy::primitives::U256;
 use tracing::{info, warn};
 
 use super::{builder::TreeBuilder, metadata};
-use crate::db::{DB, WorldTreeEventId};
+use crate::{
+    db::{DB, WorldTreeEventId},
+    error::{IndexerError, IndexerResult},
+};
 
 /// State of cache files on disk
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -73,7 +76,7 @@ impl TreeInitializer {
 
     /// Initialize tree: try restore + replay, fallback to full rebuild.
     /// Updates GLOBAL_TREE atomically and returns nothing.
-    pub async fn initialize(&self, db: &DB) -> anyhow::Result<()> {
+    pub async fn initialize(&self, db: &DB) -> IndexerResult<()> {
         let start = Instant::now();
 
         let cache_state = self.check_cache_files();
@@ -101,7 +104,7 @@ impl TreeInitializer {
 
     /// Try to restore from cache and replay missed events.
     /// Updates GLOBAL_TREE atomically.
-    async fn try_restore_and_replay(&self, db: &DB) -> anyhow::Result<()> {
+    async fn try_restore_and_replay(&self, db: &DB) -> IndexerResult<()> {
         use crate::tree::GLOBAL_TREE;
 
         // 1. Read metadata
@@ -143,11 +146,10 @@ impl TreeInitializer {
         // 4. Verify restored root matches metadata
         let restored_root = format!("0x{:x}", tree.root());
         if restored_root != metadata.root_hash {
-            anyhow::bail!(
-                "Root mismatch: expected {}, got {}",
-                metadata.root_hash,
-                restored_root
-            );
+            return Err(IndexerError::RootMismatch {
+                expected: metadata.root_hash,
+                actual: restored_root,
+            });
         }
 
         // 5. Replay events if needed (based on event ID, not block number)
@@ -202,7 +204,7 @@ impl TreeInitializer {
 
     /// Full rebuild from database and atomically replace GLOBAL_TREE.
     /// Used during initialization and for recovery when cache is corrupted.
-    async fn full_rebuild_and_update_global_tree(&self, db: &DB) -> anyhow::Result<()> {
+    async fn full_rebuild_and_update_global_tree(&self, db: &DB) -> IndexerResult<()> {
         use crate::tree::GLOBAL_TREE;
 
         info!("Starting full tree rebuild with cache");
@@ -252,7 +254,7 @@ impl TreeInitializer {
     /// Most pages are already in memory if the tree was recently used.
     ///
     /// Returns the number of events applied to the tree.
-    pub async fn sync_with_db(&self, db: &DB) -> anyhow::Result<(u64, u64)> {
+    pub async fn sync_with_db(&self, db: &DB) -> IndexerResult<(u64, u64)> {
         use crate::tree::GLOBAL_TREE;
 
         // 1. Read current metadata to get last_event_id


### PR DESCRIPTION
Closes https://github.com/worldcoin/world-id-protocol/issues/299

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes error types and propagation across most indexer codepaths (blockchain log decoding, DB, tree cache/metadata), which can subtly alter failure behavior and logging despite minimal functional logic changes.
> 
> **Overview**
> **Standardizes indexer error handling** by removing `anyhow` and introducing `services/indexer/src/error.rs` with `IndexerError` + `IndexerResult` (powered by `thiserror`).
> 
> This threads typed errors through the main surfaces—blockchain event decoding (explicit missing-field/unknown-signature errors), DB accessors, tree cache restore/build/metadata I/O, and HTTP route handlers—replacing generic stringy failures with structured variants and `From` conversions for common underlying errors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e2f2a86089790efbdeed4c9a547f4ddd32f0f3f3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->