### PR TITLE
fix: Fix retrieving account data from DB.

### DIFF
--- a/services/indexer/src/db/accounts.rs
+++ b/services/indexer/src/db/accounts.rs
@@ -104,7 +104,7 @@ where
             self.table_name,
         ))
         .bind(leaf_index)
-        .bind(&Self::address_to_u160(recovery_address))
+        .bind(Self::address_to_u160(recovery_address))
         .bind(Json(
             authenticator_addresses
                 .iter()


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it changes how `recovery_address` is encoded/decoded when writing to and reading from Postgres; any mismatch with the actual column type/encoding could break account inserts or reads.
> 
> **Overview**
> Fixes account persistence by switching `recovery_address` DB handling from string-based hex parsing to binary/numeric mapping.
> 
> `insert` now binds `recovery_address` via a new `address_to_u160` helper, and `map_recovery_address` now reads the column as `U160` and converts directly to `Address`, avoiding `String` parsing failures.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit faa804ca319c886a84ae04692b23075edcc624d7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->