### PR TITLE
feat: add session proof test to WorldIDVerifier

### DIFF
--- a/contracts/test/WorldIDVerifierTest.t.sol
+++ b/contracts/test/WorldIDVerifierTest.t.sol
@@ -13,10 +13,10 @@ import {ICredentialSchemaIssuerRegistry} from "../src/interfaces/ICredentialSche
 uint64 constant credentialIssuerIdCorrect = 1;
 uint64 constant credentialIssuerIdWrong = 2;
 
-uint64 constant rpIdCorrect = 3604927112168642455;
+uint64 constant rpIdCorrect = 0x53a9a80aba3b204;
 uint64 constant rpIdWrong = 2;
 
-uint256 constant rootCorrect = 4959814736111706042728533661656003495359474679272202023690954858781105690707;
+uint256 constant rootCorrect = 0xaf727d9412a9d5c73b685fd09dc39e727064e65b8269b233009edfc105f9853;
 uint256 constant rootWrong = 2;
 
 contract OprfKeyRegistryMock {
@@ -24,8 +24,8 @@ contract OprfKeyRegistryMock {
         // TODO update for mapping of rpId to oprfKeyId
         if (oprfKeyId == rpIdCorrect) {
             return BabyJubJub.Affine({
-                x: 0x1d988b77dfe70c867df95aede734b9c52cd99810f58ff109f9f13d9093cd58e2,
-                y: 0x1c33af244fd6b4d1bec338f99a73b800633fbfa027b2b45811e715cd5b66994b
+                x: 0xf6fd2a88ea804c58be59ad3515982c07b5a6524311906ad69e3ef50f7a32d59,
+                y: 0x17cb049e14cdfd8009641892e6ee9ee33e564e6c675e47a89922c818cc603c68
             });
         } else {
             return BabyJubJub.Affine({
@@ -57,8 +57,8 @@ contract CredentialSchemaIssuerRegistryMock {
     {
         if (issuerSchemaId == credentialIssuerIdCorrect) {
             return ICredentialSchemaIssuerRegistry.Pubkey({
-                x: 0x13792652ea0af01565bbb64d51607bf96447930b33e52d1bae28ad027dfddc15,
-                y: 0x1a03e277ea354e453878e02f6e151a7a497c53e6cd9772ad33829235f89d6496
+                x: 0xae7ba7c51efaa3c6b215c9cf0d148e6c01091bc0001a4da342e4f872591a105,
+                y: 0x24b378870638c68d90b3f7d8acbf540d2262af52ad1bbe64370931c280bab0d
             });
         } else {
             return ICredentialSchemaIssuerRegistry.Pubkey({
@@ -76,20 +76,26 @@ contract ProofVerifier is Test {
 
     uint256 public proofTimestampDelta;
 
-    uint256 nullifier = 0x18a48a7958bc33c7fb3f6351e52a76da4615cd366dabff91fec68e0df1e8cf42;
-    uint256 proofTimestamp = 0x6970f9bf;
-    uint64 rpId = 0x3207461bd9fc9797;
-    uint256 action = 0x29271a44e95107ab7b69f320ea73605f7651ac5ee61927205999662e3f620bd3;
-    uint256 oprfPublicKey_x = 0x1d988b77dfe70c867df95aede734b9c52cd99810f58ff109f9f13d9093cd58e2;
-    uint256 oprfPublicKey_y = 0x1c33af244fd6b4d1bec338f99a73b800633fbfa027b2b45811e715cd5b66994b;
+    uint256 nullifier = 0x104b3a1c8e29cca4c7279df4831ac6c20a4d841e069c3ccdce2c1ac88d55b5a;
+    uint256 proofTimestamp = 0x6980a43f;
+    uint256 action = 0x2e22e1a5485379a647255f72583f9120788c61e9c42413b7555f20d75cd34408;
     uint256 signalHash = 0x1578ed0de47522ad0b38e87031739c6a65caecc39ce3410bf3799e756a220f;
-    uint256 nonce = 0x2c42d5fb6f893752c1f8e6a7178a3400762a64039ded1af1190109a3f5e63a1b;
+    uint256 nonce = 0x2882e7cb420e5424bf554832447223dc43aae09b1cf5b50de8d8385e7d43d0f;
+    uint256 sessionId = 0x28a183c30acb760a226de203ddff3f2d50a79e589446841f010590e0794434ed;
 
     uint256[5] proof = [
-        0x3282817e430906e0a5f73e22d404971f1e8701d4d4270f3d531f07d0d8819db8,
-        0x79a6dee01c030080298a09adfd0294edc84f1650b68763d0aab5d6a1c1bbd8,
-        0x850d06c33658c9d2cc0e873cb45ad5375a31a6661cd4a11d833466ffe79b8bdd,
-        0x2c4257a1f6ab47e8432f815b1a48e8e760b541d92a1bbd7cedf1fa2ec51b4eed,
+        0x381236ea6b2ef1d3697ab7fb5f285505b52e7ed3a3b0155ef0a01d0922cb3480,
+        0xd525669a85aee300ba1cd02257e371fb1f49b16cd00318a5826450ad5f44ac8,
+        0xa3d8307cee3d1ece3d803ce27d46e36788e6862f18487e88e01b1e6ef6e83f25,
+        0x3c57db0c9868886c91766850dd42acc4f3fdf4d4f9750304319a7da6352602c5,
+        rootCorrect
+    ];
+
+    uint256[5] sessionProof = [
+        0x518ec7114c28f1243086bc82e79d97fea23087dc26e33d324585e8a4315952d5,
+        0x25420bc78b243ece38fe9e219014ad4eb5fe89852f52853b3430da1ef85f74bb,
+        0x6c036f6f88f00e371e69c0c5b99d0331ad131721b74f1bd1fb478b44513082c5,
+        0xe0a6a530acf85c094b52e46a7be17f43ef5c960383c76e989a1b9487066662,
         rootCorrect
     ];
 
@@ -119,6 +125,21 @@ contract ProofVerifier is Test {
         vm.warp(proofTimestamp + 1 hours);
         worldIDVerifier.verify(
             nullifier, action, rpIdCorrect, nonce, signalHash, proofTimestamp, credentialIssuerIdCorrect, 0, proof
+        );
+    }
+
+    function test_SessionSuccess() public {
+        vm.warp(proofTimestamp + 1 hours);
+        worldIDVerifier.verifySession(
+            rpIdCorrect,
+            nonce,
+            signalHash,
+            proofTimestamp,
+            credentialIssuerIdCorrect,
+            0,
+            sessionId,
+            [nullifier, action],
+            sessionProof
         );
     }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Test-only change that adds coverage for `verifySession` and updates hardcoded proof vectors; no production contract logic is modified.
> 
> **Overview**
> Adds a new happy-path test for `WorldIDVerifier.verifySession`, exercising session-specific inputs (`sessionId` and `[nullifier, action]`) and a dedicated `sessionProof`.
> 
> Updates the test fixture values (rpId, Merkle root, mock OPRF/issuer pubkeys, and proof vectors) to match the new proof data used by both the existing `verify` success test and the new session-proof test.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit df2147b42ff731109a8e696f7f900a7d319e288f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->