### PR TITLE
chore(indexer): add error handling instead of panicking

### DIFF
--- a/services/indexer/src/config.rs
+++ b/services/indexer/src/config.rs
@@ -32,23 +32,21 @@ pub enum RunMode {
 }
 
 impl RunMode {
-    pub fn from_env() -> Self {
+    pub fn from_env() -> Result<Self, ConfigError> {
         let str = std::env::var("RUN_MODE").unwrap_or_else(|_| "both".to_string());
 
         match str.to_lowercase().as_str() {
-            "indexer" | "indexer-only" => Self::IndexerOnly {
+            "indexer" | "indexer-only" => Ok(Self::IndexerOnly {
                 indexer_config: IndexerConfig::from_env(),
-            },
-            "http" | "http-only" => Self::HttpOnly {
-                http_config: HttpConfig::from_env(),
-            },
-            "both" | "all" => Self::Both {
+            }),
+            "http" | "http-only" => Ok(Self::HttpOnly {
+                http_config: HttpConfig::from_env()?,
+            }),
+            "both" | "all" => Ok(Self::Both {
                 indexer_config: IndexerConfig::from_env(),
-                http_config: HttpConfig::from_env(),
-            },
-            _ => panic!(
-                "Invalid run mode: '{str}'. Valid options are: 'indexer', 'indexer-only', 'http', 'http-only', 'both', or 'all'",
-            ),
+                http_config: HttpConfig::from_env()?,
+            }),
+            _ => Err(ConfigError::InvalidRunMode(str)),
         }
     }
 }
@@ -97,16 +95,22 @@ pub struct HttpConfig {
 }
 
 impl HttpConfig {
-    pub fn from_env() -> Self {
+    pub fn from_env() -> Result<Self, ConfigError> {
+        let http_addr_str =
+            std::env::var("HTTP_ADDR").unwrap_or_else(|_| "0.0.0.0:8080".to_string());
+        let http_addr = http_addr_str
+            .parse()
+            .map_err(|e| ConfigError::InvalidHttpAddr(format!("{}: {}", http_addr_str, e)))?;
+
+        let db_poll_interval_str =
+            std::env::var("DB_POLL_INTERVAL_SECS").unwrap_or_else(|_| "1".to_string());
+        let db_poll_interval_secs = db_poll_interval_str.parse().map_err(|e| {
+            ConfigError::InvalidDbPollInterval(format!("{}: {}", db_poll_interval_str, e))
+        })?;
+
         let config = Self {
-            http_addr: std::env::var("HTTP_ADDR")
-                .unwrap_or_else(|_| "0.0.0.0:8080".to_string())
-                .parse()
-                .unwrap(),
-            db_poll_interval_secs: std::env::var("DB_POLL_INTERVAL_SECS")
-                .unwrap_or_else(|_| "1".to_string())
-                .parse()
-                .unwrap(),
+            http_addr,
+            db_poll_interval_secs,
             sanity_check_interval_secs: std::env::var("SANITY_CHECK_INTERVAL_SECS").ok().and_then(
                 |s| {
                     let val = s.parse::<u64>().ok().unwrap_or(0);
@@ -125,7 +129,7 @@ impl HttpConfig {
             "✔️ Http config loaded from env. Running on {}",
             config.http_addr
         );
-        config
+        Ok(config)
     }
 }
 
@@ -202,31 +206,54 @@ impl TreeCacheConfig {
 pub enum ConfigError {
     #[error("TREE_CACHE_FILE environment variable is required")]
     MissingTreeCacheFile,
+    #[error("DATABASE_URL environment variable is required")]
+    MissingDatabaseUrl,
+    #[error("RPC_URL environment variable is required")]
+    MissingRpcUrl,
+    #[error("WS_URL environment variable is required")]
+    MissingWsUrl,
+    #[error("REGISTRY_ADDRESS environment variable is required")]
+    MissingRegistryAddress,
+    #[error(
+        "invalid ENVIRONMENT: '{0}'. Valid options are: 'production', 'staging', or 'development'"
+    )]
+    InvalidEnvironment(String),
+    #[error("invalid REGISTRY_ADDRESS: {0}")]
+    InvalidRegistryAddress(String),
+    #[error(
+        "invalid RUN_MODE: '{0}'. Valid options are: 'indexer', 'indexer-only', 'http', 'http-only', 'both', or 'all'"
+    )]
+    InvalidRunMode(String),
+    #[error("invalid HTTP_ADDR: {0}")]
+    InvalidHttpAddr(String),
+    #[error("invalid DB_POLL_INTERVAL_SECS: {0}")]
+    InvalidDbPollInterval(String),
 }
 
 impl GlobalConfig {
-    pub fn from_env() -> Self {
-        let environment = std::env::var("ENVIRONMENT")
-            .unwrap_or_else(|_| "development".to_string())
+    pub fn from_env() -> Result<Self, ConfigError> {
+        let environment_str =
+            std::env::var("ENVIRONMENT").unwrap_or_else(|_| "development".to_string());
+        let environment = environment_str
             .parse()
-            .unwrap();
+            .map_err(|_| ConfigError::InvalidEnvironment(environment_str))?;
 
-        let run_mode = RunMode::from_env();
+        let run_mode = RunMode::from_env()?;
 
-        let db_url = std::env::var("DATABASE_URL").expect("DATABASE_URL must be set.");
+        let db_url = std::env::var("DATABASE_URL").map_err(|_| ConfigError::MissingDatabaseUrl)?;
 
-        let http_rpc_url = std::env::var("RPC_URL").expect("RPC_URL must be set.");
-        let ws_rpc_url = std::env::var("WS_URL").expect("WS_URL must be set.");
+        let http_rpc_url = std::env::var("RPC_URL").map_err(|_| ConfigError::MissingRpcUrl)?;
+        let ws_rpc_url = std::env::var("WS_URL").map_err(|_| ConfigError::MissingWsUrl)?;
 
-        let registry_address = std::env::var("REGISTRY_ADDRESS")
-            .expect("REGISTRY_ADDRESS must be set.")
-            .parse::<Address>()
-            .expect("REGISTRY_ADDRESS must be a valid address");
+        let registry_address_str =
+            std::env::var("REGISTRY_ADDRESS").map_err(|_| ConfigError::MissingRegistryAddress)?;
+        let registry_address = registry_address_str.parse::<Address>().map_err(|e| {
+            ConfigError::InvalidRegistryAddress(format!("{}: {}", registry_address_str, e))
+        })?;
 
-        let tree_cache =
-            TreeCacheConfig::from_env().expect("Failed to load tree cache configuration");
+        let tree_cache = TreeCacheConfig::from_env()?;
 
-        Self {
+        Ok(Self {
             environment,
             run_mode,
             db_url,
@@ -234,6 +261,6 @@ impl GlobalConfig {
             ws_rpc_url,
             registry_address,
             tree_cache,
-        }
+        })
     }
 }

--- a/services/indexer/src/main.rs
+++ b/services/indexer/src/main.rs
@@ -1,18 +1,17 @@
 use std::path::Path;
-use world_id_indexer::GlobalConfig;
+use world_id_indexer::{GlobalConfig, IndexerResult};
 
 #[tokio::main]
-async fn main() {
+async fn main() -> IndexerResult<()> {
     let env_path = Path::new(env!("CARGO_MANIFEST_DIR")).join(".env"); // load env vars in the root of this service
     let _ = dotenvy::from_path(&env_path);
     let _guard = telemetry_batteries::init();
 
     tracing::info!("Starting world-id-indexer...");
 
-    let config = GlobalConfig::from_env();
-    world_id_indexer::run_indexer(config)
-        .await
-        .expect("indexer run failed");
+    let config = GlobalConfig::from_env()?;
+    world_id_indexer::run_indexer(config).await?;
 
     tracing::info!("⚠️ Exiting world-id-indexer...");
+    Ok(())
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to startup configuration parsing and error propagation, mainly replacing `panic!/unwrap/expect` with typed `Result` errors. Main behavior change is the indexer now exits cleanly with actionable config errors instead of crashing on invalid/missing env vars.
> 
> **Overview**
> Improves indexer startup robustness by converting env-based configuration loading to return `Result` and introducing explicit `ConfigError` variants for missing/invalid values (e.g., `RUN_MODE`, `HTTP_ADDR`, `DB_POLL_INTERVAL_SECS`, `ENVIRONMENT`, and required URLs/addresses).
> 
> `main` is updated to return `IndexerResult<()>` and propagate configuration/indexer failures with `?` rather than panicking, so misconfiguration produces structured errors instead of process crashes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aaf1aa538ee6585fef30d72631ba425dad4b2226. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->