### PR TITLE
fix(CI): don't specify version for workspace crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,19 +92,19 @@ mockito = "1"
 ciborium = "0.2"
 
 # Internal
-world-id-core = { version = "0.3.0", default-features = false, path = "crates/core" }
-world-id-issuer = { version = "0.3.0", path = "crates/issuer" }
-world-id-signer = { version = "0.3.0", path = "crates/signer" }
-world-id-types = { version = "0.3.0", path = "crates/types" }
-world-id-request = { version = "0.3.0", path = "crates/request" }
-world-id-registry = { version = "0.3.0", path = "crates/registry" }
-world-id-proof = { version = "0.3.0", path = "crates/proof" }
-world-id-credential = { version = "0.3.0", path = "crates/credential" }
-world-id-authenticator = { version = "0.3.0", path = "crates/authenticator" }
-world-id-primitives = { version = "0.3.0", path = "crates/primitives" }
-world-id-oprf-node = { version = "0.1", path = "services/oprf-node" }
-world-id-gateway = { version = "0.1", path = "services/gateway" }
-test-utils = { version = "0.3.0", path = "crates/test-utils" }
+world-id-core = { default-features = false, path = "crates/core" }
+world-id-issuer = { path = "crates/issuer" }
+world-id-signer = { path = "crates/signer" }
+world-id-types = { path = "crates/types" }
+world-id-request = { path = "crates/request" }
+world-id-registry = { path = "crates/registry" }
+world-id-proof = { path = "crates/proof" }
+world-id-credential = { path = "crates/credential" }
+world-id-authenticator = { path = "crates/authenticator" }
+world-id-primitives = { path = "crates/primitives" }
+world-id-oprf-node = { path = "services/oprf-node" }
+world-id-gateway = { path = "services/gateway" }
+test-utils = { path = "crates/test-utils" }
 
 
 [patch.crates-io]


### PR DESCRIPTION
### Problem

The `Release Crates` CI is constantly failing with a dependency mismatch error. The reason is that we hard code specific version of workspace crates in the general `Cargo.toml` and they conflict with the general version. Something like this:

```
2026-02-02T15:41:50.829284Z ERROR failed to update packages

Caused by:
    cargo update failed. stdout: ; stderr: \x1b[1m\x1b[92m    Updating\x1b[0m crates.io index
    \x1b[1m\x1b[91merror\x1b[0m: failed to select a version for the requirement `test-utils = "^0.3.0"`
    candidate versions found which didn't match: 0.4.0
    location searched: /tmp/.tmpVPN35x/world-id-protocol/crates/test-utils
    required by package `world-id-core v0.4.0 (/tmp/.tmpVPN35x/world-id-protocol/crates/core)`
    
Error: failed to update packages

Caused by:
    cargo update failed. stdout: ; stderr:     Updating crates.io index
    error: failed to select a version for the requirement `test-utils = "^0.3.0"`
    candidate versions found which didn't match: 0.4.0
    location searched: /tmp/.tmpVPN35x/world-id-protocol/crates/test-utils
    required by package `world-id-core v0.4.0 (/tmp/.tmpVPN35x/world-id-protocol/crates/core)`
```

### Solution

Don't specify version for workspace crates in general `Cargo.toml` and let them inherit the same version used in `Cargo.toml`. This will also fix CI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a workspace dependency metadata change that should only affect crate resolution/publishing, with no runtime code changes.
> 
> **Overview**
> Removes explicit `version = "0.3.0"` pins from internal workspace dependencies in the root `Cargo.toml`, relying on `path` (and workspace package versioning) instead.
> 
> This prevents version-mismatch issues during CI release/publish workflows when workspace crate versions drift from the root manifest.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cfad7e26ca778247b9dd783b3db650ab73efded7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->