### PR TITLE
fix: tree cache config is http only

### DIFF
--- a/services/indexer/src/config.rs
+++ b/services/indexer/src/config.rs
@@ -81,7 +81,6 @@ pub struct GlobalConfig {
     pub http_rpc_url: String,
     pub ws_rpc_url: String,
     pub registry_address: Address,
-    pub tree_cache: TreeCacheConfig,
 }
 
 #[derive(Debug)]
@@ -92,6 +91,7 @@ pub struct HttpConfig {
     ///
     /// The sanity check calls the `isValidRoot` function on the `WorldIDRegistry` contract to ensure the local Merkle root is valid.
     pub sanity_check_interval_secs: Option<u64>,
+    pub tree_cache: TreeCacheConfig,
 }
 
 impl HttpConfig {
@@ -108,6 +108,8 @@ impl HttpConfig {
             ConfigError::InvalidDbPollInterval(format!("{}: {}", db_poll_interval_str, e))
         })?;
 
+        let tree_cache = TreeCacheConfig::from_env()?;
+
         let config = Self {
             http_addr,
             db_poll_interval_secs,
@@ -117,6 +119,7 @@ impl HttpConfig {
                     if val == 0 { None } else { Some(val) }
                 },
             ),
+            tree_cache,
         };
 
         if config.http_addr.port() != 8080 {
@@ -251,8 +254,6 @@ impl GlobalConfig {
             ConfigError::InvalidRegistryAddress(format!("{}: {}", registry_address_str, e))
         })?;
 
-        let tree_cache = TreeCacheConfig::from_env()?;
-
         Ok(Self {
             environment,
             run_mode,
@@ -260,7 +261,6 @@ impl GlobalConfig {
             http_rpc_url,
             ws_rpc_url,
             registry_address,
-            tree_cache,
         })
     }
 }

--- a/services/indexer/tests/test_get_packed_account.rs
+++ b/services/indexer/tests/test_get_packed_account.rs
@@ -40,18 +40,18 @@ async fn test_packed_account_endpoint() {
                 http_addr: "0.0.0.0:8083".parse().unwrap(),
                 db_poll_interval_secs: 1,
                 sanity_check_interval_secs: None,
+                tree_cache: TreeCacheConfig {
+                    cache_file_path: temp_cache_path.to_str().unwrap().to_string(),
+                    tree_depth: 6,
+                    dense_tree_prefix_depth: 2,
+                    http_cache_refresh_interval_secs: 30,
+                },
             },
         },
         db_url: setup.db_url.clone(),
         http_rpc_url: setup.rpc_url(),
         ws_rpc_url: setup.ws_url(),
         registry_address: setup.registry_address,
-        tree_cache: TreeCacheConfig {
-            cache_file_path: temp_cache_path.to_str().unwrap().to_string(),
-            tree_depth: 6,
-            dense_tree_prefix_depth: 2,
-            http_cache_refresh_interval_secs: 30,
-        },
     };
 
     let indexer_task = tokio::spawn(async move {

--- a/services/indexer/tests/test_get_signature_nonce.rs
+++ b/services/indexer/tests/test_get_signature_nonce.rs
@@ -40,18 +40,18 @@ async fn test_signature_nonce_endpoint() {
                 http_addr: "0.0.0.0:8084".parse().unwrap(),
                 db_poll_interval_secs: 1,
                 sanity_check_interval_secs: None,
+                tree_cache: TreeCacheConfig {
+                    cache_file_path: temp_cache_path.to_str().unwrap().to_string(),
+                    tree_depth: 6,
+                    dense_tree_prefix_depth: 2,
+                    http_cache_refresh_interval_secs: 30,
+                },
             },
         },
         db_url: setup.db_url.clone(),
         http_rpc_url: setup.rpc_url(),
         ws_rpc_url: setup.ws_url(),
         registry_address: setup.registry_address,
-        tree_cache: TreeCacheConfig {
-            cache_file_path: temp_cache_path.to_str().unwrap().to_string(),
-            tree_depth: 6,
-            dense_tree_prefix_depth: 2,
-            http_cache_refresh_interval_secs: 30,
-        },
     };
 
     let indexer_task = tokio::spawn(async move {

--- a/services/indexer/tests/test_inclusion_proof.rs
+++ b/services/indexer/tests/test_inclusion_proof.rs
@@ -53,18 +53,18 @@ async fn test_backfill_and_live_sync() {
                 http_addr: "0.0.0.0:8080".parse().unwrap(),
                 db_poll_interval_secs: 1,
                 sanity_check_interval_secs: None,
+                tree_cache: TreeCacheConfig {
+                    cache_file_path: temp_cache_path.to_str().unwrap().to_string(),
+                    tree_depth: 6,
+                    dense_tree_prefix_depth: 2,
+                    http_cache_refresh_interval_secs: 30,
+                },
             },
         },
         db_url: setup.db_url.clone(),
         http_rpc_url: setup.rpc_url(),
         ws_rpc_url: setup.ws_url(),
         registry_address: setup.registry_address,
-        tree_cache: TreeCacheConfig {
-            cache_file_path: temp_cache_path.to_str().unwrap().to_string(),
-            tree_depth: 6,
-            dense_tree_prefix_depth: 2,
-            http_cache_refresh_interval_secs: 30,
-        },
     };
 
     let indexer_task = tokio::spawn(async move {
@@ -165,18 +165,18 @@ async fn test_insertion_cycle_and_avoids_race_condition() {
                 http_addr: "0.0.0.0:8082".parse().unwrap(),
                 db_poll_interval_secs: 1,
                 sanity_check_interval_secs: None,
+                tree_cache: TreeCacheConfig {
+                    cache_file_path: temp_cache_path.to_str().unwrap().to_string(),
+                    tree_depth: 6,
+                    dense_tree_prefix_depth: 2,
+                    http_cache_refresh_interval_secs: 30,
+                },
             },
         },
         db_url: setup.db_url.clone(),
         http_rpc_url: setup.rpc_url(),
         ws_rpc_url: setup.ws_url(),
         registry_address: setup.registry_address,
-        tree_cache: TreeCacheConfig {
-            cache_file_path: temp_cache_path.to_str().unwrap().to_string(),
-            tree_depth: 6,
-            dense_tree_prefix_depth: 2,
-            http_cache_refresh_interval_secs: 30,
-        },
     };
 
     let http_task = tokio::spawn(async move {

--- a/services/indexer/tests/test_tree_cache.rs
+++ b/services/indexer/tests/test_tree_cache.rs
@@ -67,13 +67,13 @@ async fn test_cache_creation_and_restoration() {
                 http_addr: "0.0.0.0:8090".parse().unwrap(),
                 db_poll_interval_secs: 1,
                 sanity_check_interval_secs: None,
+                tree_cache: tree_cache_config.clone(),
             },
         },
         db_url: setup.db_url.clone(),
         http_rpc_url: setup.rpc_url(),
         ws_rpc_url: setup.ws_url(),
         registry_address: setup.registry_address,
-        tree_cache: tree_cache_config.clone(),
     };
 
     let indexer_task = tokio::spawn(async move {
@@ -151,13 +151,13 @@ async fn test_incremental_replay() {
                 http_addr: "0.0.0.0:8091".parse().unwrap(),
                 db_poll_interval_secs: 1,
                 sanity_check_interval_secs: None,
+                tree_cache: tree_cache_config.clone(),
             },
         },
         db_url: setup.db_url.clone(),
         http_rpc_url: setup.rpc_url(),
         ws_rpc_url: setup.ws_url(),
         registry_address: setup.registry_address,
-        tree_cache: tree_cache_config.clone(),
     };
 
     let indexer_task = tokio::spawn(async move {
@@ -208,13 +208,13 @@ async fn test_incremental_replay() {
                 http_addr: "0.0.0.0:8092".parse().unwrap(),
                 db_poll_interval_secs: 1,
                 sanity_check_interval_secs: None,
+                tree_cache: tree_cache_config.clone(),
             },
         },
         db_url: setup.db_url.clone(),
         http_rpc_url: setup.rpc_url(),
         ws_rpc_url: setup.ws_url(),
         registry_address: setup.registry_address,
-        tree_cache: tree_cache_config.clone(),
     };
 
     let indexer_task2 = tokio::spawn(async move {
@@ -281,13 +281,13 @@ async fn test_missing_cache_creates_new() {
                 http_addr: "0.0.0.0:8093".parse().unwrap(),
                 db_poll_interval_secs: 1,
                 sanity_check_interval_secs: None,
+                tree_cache: tree_cache_config.clone(),
             },
         },
         db_url: setup.db_url.clone(),
         http_rpc_url: setup.rpc_url(),
         ws_rpc_url: setup.ws_url(),
         registry_address: setup.registry_address,
-        tree_cache: tree_cache_config.clone(),
     };
 
     let indexer_task = tokio::spawn(async move {
@@ -345,13 +345,13 @@ async fn test_http_only_cache_refresh() {
                 http_addr: "0.0.0.0:8094".parse().unwrap(),
                 db_poll_interval_secs: 1,
                 sanity_check_interval_secs: None,
+                tree_cache: tree_cache_config.clone(),
             },
         },
         db_url: setup.db_url.clone(),
         http_rpc_url: setup.rpc_url(),
         ws_rpc_url: setup.ws_url(),
         registry_address: setup.registry_address,
-        tree_cache: tree_cache_config.clone(),
     };
 
     let both_task = tokio::spawn(async move {
@@ -388,13 +388,13 @@ async fn test_http_only_cache_refresh() {
                 http_addr: "0.0.0.0:8095".parse().unwrap(),
                 db_poll_interval_secs: 1,
                 sanity_check_interval_secs: None,
+                tree_cache: tree_cache_config.clone(),
             },
         },
         db_url: setup.db_url.clone(),
         http_rpc_url: setup.rpc_url(),
         ws_rpc_url: setup.ws_url(),
         registry_address: setup.registry_address,
-        tree_cache: tree_cache_config.clone(),
     };
 
     let http_task = tokio::spawn(async move {
@@ -469,13 +469,13 @@ async fn test_authenticator_removed_replay() {
                 http_addr: "0.0.0.0:8095".parse().unwrap(),
                 db_poll_interval_secs: 1,
                 sanity_check_interval_secs: None,
+                tree_cache: tree_cache_config.clone(),
             },
         },
         db_url: setup.db_url.clone(),
         http_rpc_url: setup.rpc_url(),
         ws_rpc_url: setup.ws_url(),
         registry_address: setup.registry_address,
-        tree_cache: tree_cache_config.clone(),
     };
 
     let indexer_task = tokio::spawn(async move {
@@ -548,13 +548,13 @@ async fn test_authenticator_removed_replay() {
                 http_addr: "0.0.0.0:8096".parse().unwrap(),
                 db_poll_interval_secs: 1,
                 sanity_check_interval_secs: None,
+                tree_cache: tree_cache_config.clone(),
             },
         },
         db_url: setup.db_url.clone(),
         http_rpc_url: setup.rpc_url(),
         ws_rpc_url: setup.ws_url(),
         registry_address: setup.registry_address,
-        tree_cache: tree_cache_config.clone(),
     };
 
     let indexer_task2 = tokio::spawn(async move {
@@ -584,13 +584,13 @@ async fn test_authenticator_removed_replay() {
                 http_addr: "0.0.0.0:8097".parse().unwrap(),
                 db_poll_interval_secs: 1,
                 sanity_check_interval_secs: None,
+                tree_cache: tree_cache_config_fresh.clone(),
             },
         },
         db_url: setup.db_url.clone(),
         http_rpc_url: setup.rpc_url(),
         ws_rpc_url: setup.ws_url(),
         registry_address: setup.registry_address,
-        tree_cache: tree_cache_config_fresh.clone(),
     };
 
     let indexer_task3 = tokio::spawn(async move {
@@ -662,13 +662,13 @@ async fn test_init_root_matches_contract() {
                 http_addr: "0.0.0.0:8100".parse().unwrap(),
                 db_poll_interval_secs: 1,
                 sanity_check_interval_secs: None,
+                tree_cache: tree_cache_config.clone(),
             },
         },
         db_url: setup.db_url.clone(),
         http_rpc_url: setup.rpc_url(),
         ws_rpc_url: setup.ws_url(),
         registry_address: setup.registry_address,
-        tree_cache: tree_cache_config.clone(),
     };
 
     let indexer_task = tokio::spawn(async move {
@@ -740,13 +740,13 @@ async fn test_replay_root_matches_contract() {
                 http_addr: "0.0.0.0:8101".parse().unwrap(),
                 db_poll_interval_secs: 1,
                 sanity_check_interval_secs: None,
+                tree_cache: tree_cache_config.clone(),
             },
         },
         db_url: setup.db_url.clone(),
         http_rpc_url: setup.rpc_url(),
         ws_rpc_url: setup.ws_url(),
         registry_address: setup.registry_address,
-        tree_cache: tree_cache_config.clone(),
     };
 
     let indexer_task1 = tokio::spawn(async move {
@@ -801,13 +801,13 @@ async fn test_replay_root_matches_contract() {
                 http_addr: "0.0.0.0:8102".parse().unwrap(),
                 db_poll_interval_secs: 1,
                 sanity_check_interval_secs: None,
+                tree_cache: tree_cache_config.clone(),
             },
         },
         db_url: setup.db_url.clone(),
         http_rpc_url: setup.rpc_url(),
         ws_rpc_url: setup.ws_url(),
         registry_address: setup.registry_address,
-        tree_cache: tree_cache_config.clone(),
     };
 
     let indexer_task2 = tokio::spawn(async move {
@@ -888,13 +888,13 @@ async fn test_corrupted_cache_triggers_rebuild() {
                 http_addr: "0.0.0.0:8103".parse().unwrap(),
                 db_poll_interval_secs: 1,
                 sanity_check_interval_secs: None,
+                tree_cache: tree_cache_config.clone(),
             },
         },
         db_url: setup.db_url.clone(),
         http_rpc_url: setup.rpc_url(),
         ws_rpc_url: setup.ws_url(),
         registry_address: setup.registry_address,
-        tree_cache: tree_cache_config.clone(),
     };
 
     let indexer_task1 = tokio::spawn(async move {
@@ -956,13 +956,13 @@ async fn test_corrupted_cache_triggers_rebuild() {
                 http_addr: "0.0.0.0:8104".parse().unwrap(),
                 db_poll_interval_secs: 1,
                 sanity_check_interval_secs: None,
+                tree_cache: tree_cache_config.clone(),
             },
         },
         db_url: setup.db_url.clone(),
         http_rpc_url: setup.rpc_url(),
         ws_rpc_url: setup.ws_url(),
         registry_address: setup.registry_address,
-        tree_cache: tree_cache_config.clone(),
     };
 
     let indexer_task2 = tokio::spawn(async move {


### PR DESCRIPTION
The tree_cache config was incorrectly global, it is only used for HTTP mode.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that only moves `tree_cache` configuration ownership; compile-time checks cover most breakages, with the main risk being runtime env/config mismatches for HTTP/Both deployments.
> 
> **Overview**
> **Scopes tree-cache configuration to HTTP modes.** `tree_cache` is removed from `GlobalConfig` and added to `HttpConfig`, and `HttpConfig::from_env()` now loads `TreeCacheConfig`.
> 
> `run_indexer` now initializes the in-memory tree/cache using `http_config.tree_cache` for `HttpOnly`/`Both`, and integration tests are updated to construct `tree_cache` under `HttpConfig` accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f4545070f1156d19314412306ba00c7b66856c50. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->