### PR TITLE
fix: initialize tls backend for rustls on indexer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9189,6 +9189,7 @@ dependencies = [
  "regex",
  "reqwest",
  "ruint",
+ "rustls 0.23.36",
  "semaphore-rs-hasher",
  "semaphore-rs-trees",
  "serde",

--- a/services/indexer/Cargo.toml
+++ b/services/indexer/Cargo.toml
@@ -21,6 +21,7 @@ hex = "0.4"
 thiserror = { workspace = true }
 ruint = { workspace = true, features = ["sqlx"] }
 futures-util = "0.3"
+rustls = { workspace = true, features = ["aws-lc-rs"] }
 sqlx = { version = "0.8", features = [
   "runtime-tokio-rustls",
   "postgres",

--- a/services/indexer/src/main.rs
+++ b/services/indexer/src/main.rs
@@ -3,6 +3,8 @@ use world_id_indexer::{GlobalConfig, IndexerResult};
 
 #[tokio::main]
 async fn main() -> IndexerResult<()> {
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
     let env_path = Path::new(env!("CARGO_MANIFEST_DIR")).join(".env"); // load env vars in the root of this service
     let _ = dotenvy::from_path(&env_path);
     let _guard = telemetry_batteries::init();


### PR DESCRIPTION
Getting an error in the worker-only mode deployment because there was TLS config missing

```
Call CryptoProvider::install_default() before this point to select a provider manually, or make sure exactly one of the 'aws-lc-rs' and 'ring' features is enabled.
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes TLS provider initialization and adds a new crypto backend dependency, which can affect outbound TLS behavior and deployment compatibility.
> 
> **Overview**
> Ensures the indexer explicitly selects a Rustls crypto backend by enabling `rustls` with the `aws-lc-rs` feature and installing it at process startup, preventing runtime failures when no default provider is selected.
> 
> Updates dependencies/lockfile accordingly so TLS consumers (e.g., `sqlx` with `runtime-tokio-rustls`) use the configured provider.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d182b839ae5e92d9eb6789187a01c937c7bf0ac7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->