### PR TITLE
fix(indexer): Fix alloy dependency.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,6 +55,7 @@ dependencies = [
  "alloy-contract",
  "alloy-core",
  "alloy-eips",
+ "alloy-genesis",
  "alloy-json-rpc",
  "alloy-network",
  "alloy-node-bindings",
@@ -262,7 +263,9 @@ dependencies = [
  "alloy-primitives",
  "alloy-serde",
  "alloy-trie",
+ "borsh",
  "serde",
+ "serde_with",
 ]
 
 [[package]]

--- a/services/indexer/Cargo.toml
+++ b/services/indexer/Cargo.toml
@@ -14,7 +14,7 @@ telemetry-batteries = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 poseidon2 = { workspace = true }
-alloy = { workspace = true, features = ["rpc-types", "provider-ws"] }
+alloy = { workspace = true, default-features = true, features = ["rpc-types", "provider-ws"] }
 dotenvy = "0.15"
 url = "2"
 hex = "0.4"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk dependency configuration change; primarily affects build resolution and the transitive dependency set for the indexer.
> 
> **Overview**
> Fixes the indexer’s `alloy` dependency configuration by explicitly enabling `default-features` alongside the existing `rpc-types`/`provider-ws` features.
> 
> This updates the lockfile to pull in `alloy-genesis` (and new transitive deps like `borsh`/`serde_with`), aligning the resolved dependency graph with the expected `alloy` feature set.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 954a2cb4f9feabe5c824cfd8ec2a68d0317aece8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->