### PR TITLE
feat!: update names of OPRF node auth modules and types for new OprfModule names

### DIFF
--- a/crates/primitives/src/oprf.rs
+++ b/crates/primitives/src/oprf.rs
@@ -23,9 +23,9 @@ impl std::fmt::Display for OprfModule {
     }
 }
 
-/// A request sent by a client to perform an OPRF evaluation.
+/// A request sent by a client for OPRF nullifier authentication.
 #[derive(Clone, Serialize, Deserialize)]
-pub struct RpOprfRequestAuthV1 {
+pub struct NullifierOprfRequestAuthV1 {
     /// Zero-knowledge proof provided by the user.
     pub proof: Proof<Bn254>,
     /// The action
@@ -50,9 +50,9 @@ pub struct RpOprfRequestAuthV1 {
     pub rp_id: RpId,
 }
 
-/// A request sent by a client to perform an OPRF evaluation.
+/// A request sent by a client for OPRF credential blinding factor authentication.
 #[derive(Clone, Serialize, Deserialize)]
-pub struct SchemaIssuerOprfRequestAuthV1 {
+pub struct CredentialBlindingFactorOprfRequestAuthV1 {
     /// Zero-knowledge proof provided by the user.
     pub proof: Proof<Bn254>,
     /// The action

--- a/crates/proof/src/credential_blinding_factor.rs
+++ b/crates/proof/src/credential_blinding_factor.rs
@@ -12,7 +12,7 @@ use taceo_oprf::{
 use world_id_primitives::{
     FieldElement, TREE_DEPTH,
     circuit_inputs::QueryProofCircuitInput,
-    oprf::{OprfModule, SchemaIssuerOprfRequestAuthV1},
+    oprf::{CredentialBlindingFactorOprfRequestAuthV1, OprfModule},
 };
 
 use crate::{
@@ -98,7 +98,7 @@ impl OprfCredentialBlindingFactor {
         query_material.verify_proof(&proof, &public_inputs)?;
         tracing::debug!("generated query proof");
 
-        let auth = SchemaIssuerOprfRequestAuthV1 {
+        let auth = CredentialBlindingFactorOprfRequestAuthV1 {
             proof: proof.into(),
             action: *action,
             nonce: *nonce,

--- a/crates/proof/src/nullifier.rs
+++ b/crates/proof/src/nullifier.rs
@@ -11,7 +11,7 @@ use taceo_oprf::{
 use world_id_primitives::{
     FieldElement, TREE_DEPTH,
     circuit_inputs::QueryProofCircuitInput,
-    oprf::{OprfModule, RpOprfRequestAuthV1},
+    oprf::{NullifierOprfRequestAuthV1, OprfModule},
 };
 use world_id_request::ProofRequest;
 
@@ -92,7 +92,7 @@ impl OprfNullifier {
         query_material.verify_proof(&proof, &public_inputs)?;
         tracing::debug!("generated query proof");
 
-        let auth = RpOprfRequestAuthV1 {
+        let auth = NullifierOprfRequestAuthV1 {
             proof: proof.into(),
             action,
             nonce: *proof_request.nonce,

--- a/services/oprf-dev-client/src/bin/world-id-oprf-dev-client.rs
+++ b/services/oprf-dev-client/src/bin/world-id-oprf-dev-client.rs
@@ -52,7 +52,7 @@ use world_id_primitives::{
     authenticator::AuthenticatorPublicKeySet,
     circuit_inputs::{NullifierProofCircuitInput, QueryProofCircuitInput},
     merkle::MerkleInclusionProof,
-    oprf::{OprfModule, RpOprfRequestAuthV1},
+    oprf::{NullifierOprfRequestAuthV1, OprfModule},
     rp::RpId,
 };
 
@@ -285,7 +285,7 @@ struct NullifierStressTestItem {
     id: Uuid,
     query_input: QueryProofCircuitInput<TREE_DEPTH>,
     oprf_blinding_factor: BlindingFactor,
-    oprf_request: OprfRequest<RpOprfRequestAuthV1>,
+    oprf_request: OprfRequest<NullifierOprfRequestAuthV1>,
     credential: Credential,
     credential_sub_blinding_factor: FieldElement,
     session_id_r_seed: FieldElement,
@@ -300,7 +300,10 @@ fn generate_oprf_auth_request(
     key_index: u64,
     inclusion_proof: MerkleInclusionProof<TREE_DEPTH>,
     query_material: &CircomGroth16Material,
-) -> eyre::Result<(RpOprfRequestAuthV1, QueryProofCircuitInput<TREE_DEPTH>)> {
+) -> eyre::Result<(
+    NullifierOprfRequestAuthV1,
+    QueryProofCircuitInput<TREE_DEPTH>,
+)> {
     let mut rng = rand_chacha::ChaCha12Rng::from_entropy();
 
     let siblings: [ark_babyjubjub::Fq; TREE_DEPTH] = inclusion_proof.siblings.map(|s| *s);
@@ -325,7 +328,7 @@ fn generate_oprf_auth_request(
         .verify_proof(&proof, &public_inputs)
         .expect("proof verifies");
 
-    let auth = RpOprfRequestAuthV1 {
+    let auth = NullifierOprfRequestAuthV1 {
         proof: proof.into(),
         action: *proof_request.computed_action(),
         nonce: *proof_request.nonce,

--- a/services/oprf-node/src/auth.rs
+++ b/services/oprf-node/src/auth.rs
@@ -4,9 +4,9 @@
 //!
 //! Additionally, it defines two sub-modules necessary for the authentication process.
 //!
-//! - [`issuer`] – implements authentication for Schema Issuers.
+//! - [`credential_blinding_factor`] – implements authentication for OPRF credential blinding factor generation.
 //! - [`merkle_watcher`] – watches the blockchain for merkle-root update events.
-//! - [`rp`] – implements authentication for Relying Parties (RPs).
+//! - [`nullifier`] – implements authentication for OPRF nullifier generation.
 //! - [`rp_registry_watcher`] – keeps track of registered RPs
 //! - [`schema_issuer_registry_watcher`] – keeps track of registered Credential Schema Issuers
 //! - [`signature_history`] – keeps track of nonce + time_stamp signatures to detect replays
@@ -24,14 +24,14 @@ use crate::auth::merkle_watcher::{MerkleWatcher, MerkleWatcherError};
 /// The embedded Groth16 verification key for OPRF query proofs.
 const QUERY_VERIFICATION_KEY: &str = include_str!("../../../circom/OPRFQuery.vk.json");
 
-pub(crate) mod issuer;
+pub(crate) mod credential_blinding_factor;
 pub(crate) mod merkle_watcher;
-pub(crate) mod rp;
+pub(crate) mod nullifier;
 pub(crate) mod rp_registry_watcher;
 pub(crate) mod schema_issuer_registry_watcher;
 pub(crate) mod signature_history;
 
-/// Common errors returned by the [`RpOprfRequestAuthenticator`] and [`SchemaIssuerOprfRequestAuthenticator`].
+/// Common errors returned by the [`NullifierOprfRequestAuthenticator`] and [`CredentialBlindingFactorOprfRequestAuthenticator`].
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum OprfRequestAuthError {
     /// The client Groth16 proof did not verify.
@@ -62,7 +62,7 @@ impl IntoResponse for OprfRequestAuthError {
     }
 }
 
-/// Common authentication for [`RpOprfRequestAuthenticator`] and [`SchemaIssuerOprfRequestAuthenticator`].
+/// Common authentication for [`NullifierOprfRequestAuthenticator`] and [`CredentialBlindingFactorOprfRequestAuthenticator`].
 pub(crate) struct OprfRequestAuthenticator {
     merkle_watcher: MerkleWatcher,
     vk: Arc<ark_groth16::PreparedVerifyingKey<Bn254>>,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Mostly a rename/refactor, but it touches OPRF request authentication plumbing and public Rust types, which can break downstream integrations and miswiring would impact security-critical request validation.
> 
> **Overview**
> Aligns OPRF authentication naming with `OprfModule` by renaming request auth payload types to `NullifierOprfRequestAuthV1` and `CredentialBlindingFactorOprfRequestAuthV1`.
> 
> Renames/rewires the OPRF node auth modules and authenticators (`rp`→`nullifier`, `issuer`→`credential_blinding_factor`) and updates the node startup wiring so the `/nullifier` and `/credential_blinding_factor` modules use the corresponding authenticators.
> 
> Updates all callers (proof generation and the `oprf-dev-client`) to construct and send the newly named auth request types.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 13ec36ab061ae944b4bb0c7945148b4faf803e0d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->