### PR TITLE
fix(services): configure TraceLayer to emit spans at INFO level

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2675,6 +2675,7 @@ dependencies = [
  "tempfile",
  "thiserror 1.0.69",
  "tower",
+ "tower-http 0.5.2",
  "tracing",
  "url",
 ]
@@ -9178,6 +9179,7 @@ dependencies = [
  "ark-bn254 0.5.0",
  "ark-ff 0.5.0",
  "axum",
+ "common",
  "dotenvy",
  "futures-util",
  "hex",
@@ -9200,7 +9202,6 @@ dependencies = [
  "test-utils",
  "thiserror 1.0.69",
  "tokio",
- "tower-http 0.5.2",
  "tracing",
  "tracing-subscriber 0.3.22",
  "url",

--- a/services/common/Cargo.toml
+++ b/services/common/Cargo.toml
@@ -9,6 +9,8 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
+tower-http = { workspace = true }
+
 alloy = { workspace = true, features = [
     "json-rpc",
     "network",

--- a/services/common/src/lib.rs
+++ b/services/common/src/lib.rs
@@ -1,7 +1,9 @@
 //! Common utilities and types shared across multiple services.
 
 mod provider;
+mod tracing;
 
 // TODO: FIXME: Provider Metrics
 
 pub use provider::{ProviderArgs, ProviderError, ProviderResult, SignerArgs, SignerConfig};
+pub use tracing::trace_layer;

--- a/services/common/src/tracing.rs
+++ b/services/common/src/tracing.rs
@@ -1,0 +1,20 @@
+use tower_http::trace::{DefaultMakeSpan, DefaultOnRequest, DefaultOnResponse, TraceLayer};
+use tracing::Level;
+
+/// Creates a [`TraceLayer`] configured to emit spans at INFO level.
+///
+/// By default, `TraceLayer::new_for_http()` emits spans at DEBUG level,
+/// which are filtered out by the default `info` log level filter.
+/// This function configures all trace components to use INFO level
+/// so HTTP traces are visible in Datadog and other collectors.
+pub fn trace_layer() -> TraceLayer<
+    tower_http::classify::SharedClassifier<tower_http::classify::ServerErrorsAsFailures>,
+    DefaultMakeSpan,
+    DefaultOnRequest,
+    DefaultOnResponse,
+> {
+    TraceLayer::new_for_http()
+        .make_span_with(DefaultMakeSpan::new().level(Level::INFO))
+        .on_request(DefaultOnRequest::new().level(Level::INFO))
+        .on_response(DefaultOnResponse::new().level(Level::INFO))
+}

--- a/services/gateway/src/routes.rs
+++ b/services/gateway/src/routes.rs
@@ -30,7 +30,6 @@ use axum::{
 };
 use moka::future::Cache;
 use tokio::sync::mpsc;
-use tower_http::trace::TraceLayer;
 use utoipa::OpenApi;
 use world_id_core::{
     types::{
@@ -124,7 +123,7 @@ pub(crate) async fn build_app(
         .layer(tower_http::timeout::TimeoutLayer::new(Duration::from_secs(
             30,
         )))
-        .layer(TraceLayer::new_for_http()))
+        .layer(common::trace_layer()))
 }
 
 #[utoipa::path(

--- a/services/indexer/Cargo.toml
+++ b/services/indexer/Cargo.toml
@@ -6,8 +6,8 @@ edition.workspace = true
 publish = false
 
 [dependencies]
+common = { path = "../common" }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
-tower-http = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["json"] }
 telemetry-batteries = { workspace = true }

--- a/services/indexer/src/routes.rs
+++ b/services/indexer/src/routes.rs
@@ -1,5 +1,4 @@
 use axum::{Json, Router, response::IntoResponse};
-use tower_http::trace::TraceLayer;
 use utoipa::OpenApi;
 use world_id_core::types::{
     AccountInclusionProofSchema, IndexerErrorBody, IndexerPackedAccountRequest,
@@ -54,5 +53,5 @@ pub(crate) fn handler(state: AppState) -> Router {
         .route("/health", axum::routing::get(health::handler))
         .route("/openapi.json", axum::routing::get(openapi))
         .with_state(state)
-        .layer(TraceLayer::new_for_http())
+        .layer(common::trace_layer())
 }


### PR DESCRIPTION
## Summary

- `TraceLayer::new_for_http()` defaults to DEBUG level spans, which are filtered out by telemetry-batteries' default `info` log level
- This caused HTTP traces to not appear in Datadog while `#[instrument]` spans (which default to INFO) worked fine
- Extract `trace_layer()` helper to `services/common` for reuse across gateway and indexer

## Test plan

- [ ] Deploy to staging and verify HTTP request traces appear in Datadog
- [ ] Confirm existing `#[instrument]` traces still work


🤖 Generated with [Claude Code](https://claude.com/claude-code)