### PR TITLE
fix(indexer): add backtrace to errors

### DIFF
--- a/services/indexer/src/error.rs
+++ b/services/indexer/src/error.rs
@@ -1,21 +1,81 @@
-use thiserror::Error;
-
 use crate::{blockchain::BlockchainError, config::ConfigError, db::DBError, tree::TreeError};
+use std::backtrace::Backtrace;
+use thiserror::Error;
 
 pub type IndexerResult<T> = Result<T, IndexerError>;
 
 #[derive(Debug, Error)]
 pub enum IndexerError {
-    #[error(transparent)]
-    Blockchain(#[from] BlockchainError),
-    #[error(transparent)]
-    Config(#[from] ConfigError),
-    #[error(transparent)]
-    Db(#[from] DBError),
-    #[error(transparent)]
-    Tree(#[from] TreeError),
-    #[error("http server error: {0}")]
-    HttpServer(#[from] std::io::Error),
-    #[error("http service error: {0}")]
-    HttpService(#[source] Box<dyn std::error::Error + Send + Sync>),
+    #[error("blockchain error: {source}")]
+    Blockchain {
+        #[source]
+        source: BlockchainError,
+        backtrace: String,
+    },
+    #[error("config error: {source}")]
+    Config {
+        #[source]
+        source: ConfigError,
+        backtrace: String,
+    },
+    #[error("database error: {source}")]
+    Db {
+        #[source]
+        source: DBError,
+        backtrace: String,
+    },
+    #[error("tree error: {source}")]
+    Tree {
+        #[source]
+        source: TreeError,
+        backtrace: String,
+    },
+    #[error("failed to bind listener: {source}")]
+    Bind {
+        #[source]
+        source: std::io::Error,
+        backtrace: String,
+    },
+    #[error("server error: {source}")]
+    Serve {
+        #[source]
+        source: std::io::Error,
+        backtrace: String,
+    },
+}
+
+impl From<BlockchainError> for IndexerError {
+    fn from(source: BlockchainError) -> Self {
+        Self::Blockchain {
+            source,
+            backtrace: Backtrace::capture().to_string(),
+        }
+    }
+}
+
+impl From<ConfigError> for IndexerError {
+    fn from(source: ConfigError) -> Self {
+        Self::Config {
+            source,
+            backtrace: Backtrace::capture().to_string(),
+        }
+    }
+}
+
+impl From<DBError> for IndexerError {
+    fn from(source: DBError) -> Self {
+        Self::Db {
+            source,
+            backtrace: Backtrace::capture().to_string(),
+        }
+    }
+}
+
+impl From<TreeError> for IndexerError {
+    fn from(source: TreeError) -> Self {
+        Self::Tree {
+            source,
+            backtrace: Backtrace::capture().to_string(),
+        }
+    }
 }

--- a/services/indexer/src/main.rs
+++ b/services/indexer/src/main.rs
@@ -12,7 +12,10 @@ async fn main() -> IndexerResult<()> {
     tracing::info!("Starting world-id-indexer...");
 
     let config = GlobalConfig::from_env()?;
-    world_id_indexer::run_indexer(config).await?;
+    if let Err(error) = world_id_indexer::run_indexer(config).await {
+        tracing::error!(error = ?error, "indexer terminated with error");
+        return Err(error);
+    }
 
     tracing::info!("⚠️ Exiting world-id-indexer...");
     Ok(())


### PR DESCRIPTION
Similar to #346 but for the indexer

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the shape of `IndexerError` (including new variants) and adds eager backtrace capture, which can affect downstream error matching and slightly impact performance/allocations on error paths.
> 
> **Overview**
> **Improves indexer error diagnostics** by replacing the transparent `IndexerError` wrappers with structured variants that capture a `Backtrace` string for blockchain/config/db/tree failures.
> 
> HTTP startup failures are now split into `Bind` vs `Serve` errors (both with backtraces), and `main` logs the terminal error via `tracing::error!(error=?error, ...)` before returning it.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b8fb6d7d0638d5bf646610acaf4e36df90ef02cb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->