### PR TITLE
chore: remove taceo users from CODEOWNERS wildcard

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-* @worldcoin/protocol-contributors @rw0x0 @fabian1409 @0xThemis @dkales
+* @worldcoin/protocol-contributors
 /services/oprf-node @worldcoin/protocol @fabian1409 @0xThemis @dkales @philsippl
 /services/oprf-dev-client @worldcoin/protocol @fabian1409 @0xThemis @dkales @philsippl
 /circom @worldcoin/protocol @fabian1409 @0xThemis @dkales @philsippl @paolodamico


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Administrative CODEOWNERS-only change; impacts review routing/required approvals but does not affect runtime behavior.
> 
> **Overview**
> Updates `.github/CODEOWNERS` so the top-level `*` wildcard is owned only by `@worldcoin/protocol-contributors`, removing individual user owners from the default rule.
> 
> Path-specific ownership entries (e.g., `services/oprf-*`, `circom`, and the `CODEOWNERS` file itself) remain unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0038f824066d2dddbbd65ec6a028084959920174. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->