### PR TITLE
chore: reduce unnecessary clone()

### DIFF
--- a/crates/authenticator/src/authenticator.rs
+++ b/crates/authenticator/src/authenticator.rs
@@ -605,11 +605,10 @@ impl Authenticator {
         let nonce = self.signing_nonce().await?;
         let (inclusion_proof, mut key_set) = self.fetch_inclusion_proof().await?;
         let old_offchain_signer_commitment = key_set.leaf_hash();
-        key_set.try_push(new_authenticator_pubkey.clone())?;
+        let encoded_offchain_pubkey = new_authenticator_pubkey.to_ethereum_representation()?;
+        key_set.try_push(new_authenticator_pubkey)?;
         let index = key_set.len() - 1;
         let new_offchain_signer_commitment = key_set.leaf_hash();
-
-        let encoded_offchain_pubkey = new_authenticator_pubkey.to_ethereum_representation()?;
 
         let eip712_domain = domain(self.config.chain_id(), *self.config.registry_address());
 
@@ -690,10 +689,9 @@ impl Authenticator {
         let nonce = self.signing_nonce().await?;
         let (inclusion_proof, mut key_set) = self.fetch_inclusion_proof().await?;
         let old_commitment: U256 = key_set.leaf_hash().into();
-        key_set.try_set_at_index(index as usize, new_authenticator_pubkey.clone())?;
-        let new_commitment: U256 = key_set.leaf_hash().into();
-
         let encoded_offchain_pubkey = new_authenticator_pubkey.to_ethereum_representation()?;
+        key_set.try_set_at_index(index as usize, new_authenticator_pubkey)?;
+        let new_commitment: U256 = key_set.leaf_hash().into();
 
         let eip712_domain = domain(self.config.chain_id(), *self.config.registry_address());
 

--- a/services/gateway/src/create_batcher.rs
+++ b/services/gateway/src/create_batcher.rs
@@ -94,12 +94,12 @@ impl CreateBatcherRunner {
 
             // Collect all authenticator addresses from this batch for cache cleanup
             let mut all_addresses: Vec<Address> = Vec::new();
-            for env in &batch {
-                recovery_addresses.push(env.req.recovery_address.unwrap_or(Address::ZERO));
-                auths.push(env.req.authenticator_addresses.clone());
-                pubkeys.push(env.req.authenticator_pubkeys.clone());
-                commits.push(env.req.offchain_signer_commitment);
+            for env in batch {
                 all_addresses.extend(env.req.authenticator_addresses.iter());
+                recovery_addresses.push(env.req.recovery_address.unwrap_or(Address::ZERO));
+                auths.push(env.req.authenticator_addresses);
+                pubkeys.push(env.req.authenticator_pubkeys);
+                commits.push(env.req.offchain_signer_commitment);
             }
 
             let call =
@@ -125,8 +125,8 @@ impl CreateBatcherRunner {
                         .await;
 
                     let tracker = self.tracker.clone();
-                    let ids_for_receipt = ids.clone();
-                    let addresses_for_cleanup = all_addresses.clone();
+                    let ids_for_receipt = ids;
+                    let addresses_for_cleanup = all_addresses;
                     tokio::spawn(async move {
                         match builder.get_receipt().await {
                             Ok(receipt) => {

--- a/services/gateway/src/ops_batcher.rs
+++ b/services/gateway/src/ops_batcher.rs
@@ -108,11 +108,11 @@ impl OpsBatcherRunner {
                 .await;
 
             let calls: Vec<Multicall3::Call3> = batch
-                .iter()
+                .into_iter()
                 .map(|env| Multicall3::Call3 {
                     target: *self.registry.address(),
                     allowFailure: false,
-                    callData: env.calldata.clone(),
+                    callData: env.calldata,
                 })
                 .collect();
 
@@ -136,7 +136,7 @@ impl OpsBatcherRunner {
                         .await;
 
                     let tracker = self.tracker.clone();
-                    let ids_for_receipt = ids.clone();
+                    let ids_for_receipt = ids;
                     tokio::spawn(async move {
                         match builder.get_receipt().await {
                             Ok(receipt) => {

--- a/services/gateway/src/request_tracker.rs
+++ b/services/gateway/src/request_tracker.rs
@@ -148,7 +148,7 @@ impl RequestTracker {
                 .map_err(handle_redis_error)?;
         } else {
             // No Redis, use local cache as storage
-            self.cache.insert(id.clone(), record.clone()).await;
+            self.cache.insert(id, record).await;
         }
 
         Ok(())


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Primarily a move/ownership refactor to avoid `clone()` in request batching and key updates; risk is limited to potential ownership/lifetime mistakes, but behavior should remain the same.
> 
> **Overview**
> Removes several unnecessary `clone()` calls by switching to move-based flows.
> 
> In `Authenticator::insert_authenticator` and `Authenticator::update_authenticator`, the offchain pubkey is encoded before mutating the key set so the `EdDSAPublicKey` can be moved into `try_push`/`try_set_at_index` without cloning.
> 
> In the gateway `create_batcher` and `ops_batcher`, batch processing now consumes envelopes (`into_iter`/moved fields) and moves `ids`/address lists into the receipt task instead of cloning; `RequestTracker::new_request_with_id` similarly moves `id`/`record` into the in-memory cache path.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 519d69c1744502f99edafa55db55f3d0940fab50. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->