### PR TITLE
chore: codeowners clean up

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 * @worldcoin/protocol-contributors
-/services/oprf-node @worldcoin/protocol @fabian1409 @0xThemis @dkales
-/services/oprf-dev-client @worldcoin/protocol @fabian1409 @0xThemis @dkales
+/services/oprf-node @fabian1409 @0xThemis @dkales @philsippl
+/services/oprf-dev-client @fabian1409 @0xThemis @dkales @philsippl
 /circom @worldcoin/protocol @fabian1409 @0xThemis @dkales
 /.github/CODEOWNERS @paolodamico @philsippl @murph


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Only updates review/approval routing via CODEOWNERS; no product code or runtime behavior changes.
> 
> **Overview**
> Simplifies `.github/CODEOWNERS` by removing redundant `@worldcoin/protocol` ownership from `services/oprf-*` and trimming `@paolodamico` from `/circom`, while keeping global ownership via `@worldcoin/protocol-contributors`.
> 
> Also narrows direct ownership for `.github/CODEOWNERS` itself to `@paolodamico`, `@philsippl`, and `@murph`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a4fab3586d03d155ed4300c5c275385e50031470. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->