### PR TITLE
fix: openapi FF doesn't require authenticator

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -44,7 +44,7 @@ issuer = [
 rp = ["dep:world-id-request"]
 
 # OpenAPI/Swagger docs
-openapi = ["authenticator", "world-id-primitives/openapi"]
+openapi = ["world-id-primitives/openapi"]
 
 [dependencies]
 eddsa-babyjubjub = { workspace = true }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Cargo feature-flag wiring change only; primary risk is unintended feature/dependency activation differences when building with `openapi`.
> 
> **Overview**
> Decouples `world-id-core`'s `openapi` feature from the `authenticator` feature so OpenAPI/Swagger schema support can be enabled without pulling in authenticator-related dependencies.
> 
> This updates `crates/core/Cargo.toml` feature definitions to have `openapi` only enable `world-id-primitives/openapi`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 57705ea67007377e9d7283ea397ba06a1499a2fd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->