### PR TITLE
fix: test-utils specific version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9314,7 +9314,7 @@ dependencies = [
 
 [[package]]
 name = "world-id-test-utils"
-version = "0.3.0"
+version = "0.1.0"
 dependencies = [
  "alloy",
  "alloy-node-bindings",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,7 +126,7 @@ world-id-issuer = { version = "0.3.0", path = "crates/issuer" }
 world-id-proof = { version = "0.3.0", path = "crates/proof" }
 world-id-authenticator = { version = "0.3.0", path = "crates/authenticator" }
 world-id-primitives = { version = "0.3.0", path = "crates/primitives", default-features = false }
-world-id-oprf-node = { version = "0.1", path = "services/oprf-node" }
-world-id-gateway = { version = "0.1", path = "services/gateway" }
-world-id-test-utils = { version = "0.3.0", path = "crates/test-utils" }
+world-id-oprf-node = { version = "0.1.0", path = "services/oprf-node" }
+world-id-gateway = { version = "0.1.0", path = "services/gateway" }
+world-id-test-utils = { version = "0.1.0", path = "crates/test-utils" }
 world-id-services-common = { path = "services/common" }

--- a/crates/test-utils/Cargo.toml
+++ b/crates/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "world-id-test-utils"
-version.workspace = true
+version = "0.1.0"
 edition.workspace = true
 license.workspace = true
 publish = false


### PR DESCRIPTION
test utils must have a specific version because release-plz no longer handles this release