### PR TITLE
build(deps): update taceo-goth16-material for wasm compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2525,15 +2525,14 @@ dependencies = [
 
 [[package]]
 name = "circom-witness-rs"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef3c1ad2fd98272ce36f3db32543dbeec6497e04c5e71640602e1cda1698c318"
+checksum = "35778373aee12ef3d04966187eeae7a04f1451c9226058311f21488df6f28780"
 dependencies = [
  "ark-bn254 0.5.0",
  "ark-ff 0.5.0",
  "ark-serialize 0.5.0",
  "byteorder",
- "cxx",
  "cxx-build",
  "eyre",
  "hex",
@@ -2894,21 +2893,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cxx"
-version = "1.0.192"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbda285ba6e5866529faf76352bdf73801d9b44a6308d7cd58ca2379f378e994"
-dependencies = [
- "cc",
- "cxx-build",
- "cxxbridge-cmd",
- "cxxbridge-flags",
- "cxxbridge-macro",
- "foldhash 0.2.0",
- "link-cplusplus",
-]
-
-[[package]]
 name = "cxx-build"
 version = "1.0.192"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2920,38 +2904,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn 2.0.114",
-]
-
-[[package]]
-name = "cxxbridge-cmd"
-version = "1.0.192"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3efb93799095bccd4f763ca07997dc39a69e5e61ab52d2c407d4988d21ce144d"
-dependencies = [
- "clap",
- "codespan-reporting",
- "indexmap 2.13.0",
- "proc-macro2",
- "quote",
- "syn 2.0.114",
-]
-
-[[package]]
-name = "cxxbridge-flags"
-version = "1.0.192"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3092010228026e143b32a4463ed9fa8f86dca266af4bf5f3b2a26e113dbe4e45"
-
-[[package]]
-name = "cxxbridge-macro"
-version = "1.0.192"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31d72ebfcd351ae404fb00ff378dfc9571827a00722c9e735c9181aec320ba0a"
-dependencies = [
- "indexmap 2.13.0",
- "proc-macro2",
- "quote",
  "syn 2.0.114",
 ]
 
@@ -4487,15 +4439,6 @@ checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
 dependencies = [
  "pkg-config",
  "vcpkg",
-]
-
-[[package]]
-name = "link-cplusplus"
-version = "1.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f78c730aaa7d0b9336a299029ea49f9ee53b0ed06e9202e8cb7db9bae7b8c82"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -7262,9 +7205,9 @@ dependencies = [
 
 [[package]]
 name = "taceo-groth16-material"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ef020742823d08201ec9f953afa01f30ddb55d00eecbac86264c0da9e1d9d02"
+checksum = "a17ae8dd575660f235c260f3a7918c0dc489e169328fdd83134f93dae40efe23"
 dependencies = [
  "ark-bn254 0.5.0",
  "ark-ec 0.5.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,13 +45,12 @@ ark-ff = "0.5"
 ark-groth16 = "0.5"
 ark-serialize = "0.5"
 backon = "1"
-circom-witness-rs = "0.2.1"
 circom-types = { package = "taceo-circom-types", version = "0.2", default-features = false }
 criterion = "0.7"
 eddsa-babyjubjub = { package = "taceo-eddsa-babyjubjub", version = "0.5.4" }
 eyre = "0.6"
 futures = "0.3"
-groth16-material = { package = "taceo-groth16-material", version = "0.2.1", default-features = false }
+groth16-material = { package = "taceo-groth16-material", version = "0.2.2", default-features = false }
 hex = { version = "0.4" }
 itertools = "0.14"
 k256 = { version = "0.13" }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Primarily a dependency/lockfile update; risk is limited to potential build or proof-generation regressions from upstream crate changes, especially across native vs WASM targets.
> 
> **Overview**
> Updates zk/Groth16 dependency versions by bumping `taceo-groth16-material` to `0.2.2` and pulling in `circom-witness-rs` `0.2.3` via the lockfile.
> 
> As part of the dependency update, `Cargo.lock` no longer includes the `cxx`/`cxxbridge-*`/`link-cplusplus` crates (reducing C++ toolchain coupling), and `Cargo.toml` is adjusted to use the newer `groth16-material` version (and no longer pins `circom-witness-rs` directly).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 473ae66a31fbcb7991bc6c4b71d9bf4e23be82c4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->