### PR TITLE
fix: make OPRF dev client bash function work for deployed setup

### DIFF
--- a/local-setup.sh
+++ b/local-setup.sh
@@ -138,12 +138,21 @@ setup() {
 }
 
 client() {
-    oprf_key_registry=$(jq -r '.transactions[] | select(.contractName == "ERC1967Proxy") | .contractAddress' ./contracts/broadcast/OprfKeyRegistryWithDeps.s.sol/31337/run-latest.json)
-    world_id_registry=$(jq -r ".worldIDRegistry.proxy" ./contracts/deployments/local.json)
-    rp_registry=$(jq -r ".rpRegistry.proxy" ./contracts/deployments/local.json)
-    credential_schema_issuer_registry=$(jq -r ".credentialSchemaIssuerRegistry.proxy" ./contracts/deployments/local.json)
-    # use addresses from deploy logs or use existing env vars
-    OPRF_DEV_CLIENT_OPRF_KEY_REGISTRY_CONTRACT=${OPRF_DEV_CLIENT_OPRF_KEY_REGISTRY_CONTRACT:-$oprf_key_registry} OPRF_DEV_CLIENT_WORLD_ID_REGISTRY_CONTRACT=${OPRF_DEV_CLIENT_WORLD_ID_REGISTRY_CONTRACT:-$world_id_registry} OPRF_DEV_CLIENT_RP_REGISTRY_CONTRACT=${OPRF_DEV_CLIENT_RP_REGISTRY_CONTRACT:-$rp_registry} OPRF_DEV_CLIENT_CREDENTIAL_SCHEMA_ISSUER_REGISTRY_CONTRACT=${OPRF_DEV_CLIENT_CREDENTIAL_SCHEMA_ISSUER_REGISTRY_CONTRACT:-$credential_schema_issuer_registry} cargo run --release --bin world-id-oprf-dev-client -- "$@"
+    # Set env vars only if they are not already set
+    if [ -z "${OPRF_DEV_CLIENT_OPRF_KEY_REGISTRY_CONTRACT+x}" ]; then
+        export OPRF_DEV_CLIENT_OPRF_KEY_REGISTRY_CONTRACT=$(jq -r '.transactions[] | select(.contractName == "ERC1967Proxy") | .contractAddress' ./contracts/broadcast/OprfKeyRegistryWithDeps.s.sol/31337/run-latest.json)
+    fi
+    if [ -z "${OPRF_DEV_CLIENT_WORLD_ID_REGISTRY_CONTRACT+x}" ]; then
+        export OPRF_DEV_CLIENT_WORLD_ID_REGISTRY_CONTRACT=$(jq -r ".worldIDRegistry.proxy" ./contracts/deployments/local.json)
+    fi
+    if [ -z "${OPRF_DEV_CLIENT_RP_REGISTRY_CONTRACT+x}" ]; then
+        export OPRF_DEV_CLIENT_RP_REGISTRY_CONTRACT=$(jq -r ".rpRegistry.proxy" ./contracts/deployments/local.json)
+    fi
+    if [ -z "${OPRF_DEV_CLIENT_CREDENTIAL_SCHEMA_ISSUER_REGISTRY_CONTRACT+x}" ]; then
+        export OPRF_DEV_CLIENT_CREDENTIAL_SCHEMA_ISSUER_REGISTRY_CONTRACT=$(jq -r ".credentialSchemaIssuerRegistry.proxy" ./contracts/deployments/local.json)
+    fi
+
+    cargo run --release --bin world-id-oprf-dev-client -- "$@"
 }
 
 main() {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small bash-script change limited to local/dev workflow; main risk is mis-detecting “unset vs empty” env vars and leaving a required address blank.
> 
> **Overview**
> Fixes the `local-setup.sh` `client()` helper to work with already-deployed setups by **not overriding** `OPRF_DEV_CLIENT_*_CONTRACT` env vars when they are pre-set.
> 
> The script now conditionally exports each contract address (derived via `jq` from local deployment artifacts) only when the corresponding variable is missing, then runs `world-id-oprf-dev-client` normally.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 374f9cc7d67a7c4e91b883923af5155d825ccf2d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->