### PR TITLE
fix(world-id-registry): fix removeAuthenticator fn

### DIFF
--- a/contracts/src/WorldIDRegistry.sol
+++ b/contracts/src/WorldIDRegistry.sol
@@ -642,6 +642,11 @@ contract WorldIDRegistry is WorldIDBase, IWorldIDRegistry {
         if (actualPubkeyId != pubkeyId) {
             revert MismatchedPubkeyId(pubkeyId, actualPubkeyId);
         }
+        uint256 actualRecoveryCounter = PackedAccountData.recoveryCounter(packedToRemove);
+        uint256 expectedRecoveryCounter = _leafIndexToRecoveryCounter[leafIndex];
+        if (actualRecoveryCounter != expectedRecoveryCounter) {
+            revert MismatchedRecoveryCounter(leafIndex, expectedRecoveryCounter, actualRecoveryCounter);
+        }
 
         // Delete authenticator
         delete _authenticatorAddressToPackedAccountData[authenticatorAddress];


### PR DESCRIPTION
This PR fixes a low vulnerability on the `removeAuthenticator` fn.

The `removeAuthenticator` function fails to validate the target authenticator's recovery counter allowing bitmap corruption.

I've added a check that compare the expected recovery counter with the actual value and revert the tx if they mismatch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core registry state transitions (authenticator removal and pubkey bitmap updates); logic is small but incorrect behavior could corrupt account authenticator state.
> 
> **Overview**
> Fixes `WorldIDRegistry.removeAuthenticator` to **validate the target authenticator’s `recoveryCounter`** against the account’s current `_leafIndexToRecoveryCounter`, reverting with `MismatchedRecoveryCounter` when attempting to remove an authenticator from a pre-recovery state.
> 
> Adds a regression test covering the recovery flow and asserting that removing a stale authenticator after `recoverAccount` now reverts, preventing pubkey bitmap corruption.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9a8124bed13f765d0f79f43b1b692aa95e433941. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->