### PR TITLE
feat(indexer): add deserialization from 0x hex or decimal

### DIFF
--- a/crates/primitives/src/api_types.rs
+++ b/crates/primitives/src/api_types.rs
@@ -1,4 +1,10 @@
 #![allow(clippy::option_if_let_else)]
+//! Shared API request/response payloads for gateway and indexer services.
+//!
+//! Numeric fields that use the `hex_u*` serde helpers follow this contract:
+//! - requests accept decimal strings (no prefix) or hex strings with `0x`/`0X` prefix;
+//! - responses are serialized as canonical `0x`-prefixed hex strings.
+
 pub use crate::merkle::AccountInclusionProof;
 use crate::serde_utils::{hex_u32, hex_u32_opt, hex_u64, hex_u256, hex_u256_opt, hex_u256_vec};
 use alloy_primitives::Address;
@@ -10,6 +16,8 @@ use strum::EnumString;
 use utoipa::{IntoParams, ToSchema};
 
 /// The request to create a new World ID account.
+///
+/// Numeric string fields in this request accept decimal or `0x`/`0X`-prefixed hex.
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 #[derive(Debug, Serialize, Deserialize)]
 pub struct CreateAccountRequest {
@@ -30,6 +38,8 @@ pub struct CreateAccountRequest {
 }
 
 /// The request to update an authenticator.
+///
+/// Numeric string fields in this request accept decimal or `0x`/`0X`-prefixed hex.
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 #[derive(Debug, Serialize, Deserialize)]
 pub struct UpdateAuthenticatorRequest {
@@ -73,6 +83,8 @@ pub struct UpdateAuthenticatorRequest {
 }
 
 /// The request to insert an authenticator.
+///
+/// Numeric string fields in this request accept decimal or `0x`/`0X`-prefixed hex.
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 #[derive(Debug, Serialize, Deserialize)]
 pub struct InsertAuthenticatorRequest {
@@ -113,6 +125,8 @@ pub struct InsertAuthenticatorRequest {
 }
 
 /// The request to remove an authenticator.
+///
+/// Numeric string fields in this request accept decimal or `0x`/`0X`-prefixed hex.
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 #[derive(Debug, Serialize, Deserialize)]
 pub struct RemoveAuthenticatorRequest {
@@ -153,6 +167,8 @@ pub struct RemoveAuthenticatorRequest {
 }
 
 /// The request to recover an account.
+///
+/// Numeric string fields in this request accept decimal or `0x`/`0X`-prefixed hex.
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 #[derive(Debug, Serialize, Deserialize)]
 pub struct RecoverAccountRequest {
@@ -278,7 +294,9 @@ pub struct IndexerPackedAccountRequest {
 #[derive(Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 pub struct IndexerPackedAccountResponse {
-    /// The packed account data [32 bits recoveryCounter][32 bits pubkeyId][192 bits leafIndex]
+    /// The packed account data [32 bits recoveryCounter][32 bits pubkeyId][192 bits leafIndex].
+    ///
+    /// Serialized as a canonical `0x`-prefixed hex string.
     #[serde(with = "hex_u256")]
     #[cfg_attr(feature = "openapi", schema(value_type = String, format = "hex", example = "0x1"))]
     pub packed_account_data: U256,
@@ -290,7 +308,9 @@ pub struct IndexerPackedAccountResponse {
 #[derive(Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 pub struct IndexerQueryRequest {
-    /// The leaf index to query (from the `WorldIDRegistry`)
+    /// The leaf index to query (from the `WorldIDRegistry`).
+    ///
+    /// Accepts decimal or `0x`/`0X`-prefixed hex input.
     #[serde(with = "hex_u64")]
     #[cfg_attr(feature = "openapi", schema(value_type = String, format = "hex", example = "0x1"))]
     pub leaf_index: u64,
@@ -300,7 +320,9 @@ pub struct IndexerQueryRequest {
 #[derive(Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 pub struct IndexerSignatureNonceResponse {
-    /// The signature nonce for the account
+    /// The signature nonce for the account.
+    ///
+    /// Serialized as a canonical `0x`-prefixed hex string.
     #[serde(with = "hex_u256")]
     #[cfg_attr(feature = "openapi", schema(value_type = String, format = "hex", example = "0x0"))]
     pub signature_nonce: U256,


### PR DESCRIPTION
Closes #404 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes deserialization behavior for core numeric API fields, which could affect client compatibility and input validation edge cases; serialization format remains stable.
> 
> **Overview**
> Updates the `hex_u*` serde helpers to **deserialize numeric API fields from either decimal strings or `0x`/`0X`-prefixed hex**, while continuing to serialize responses as canonical `0x`-prefixed hex. This introduces shared parsing/validation (rejecting empty strings and `0x` without digits) and adds unit tests for decimal, prefixed-hex, and invalid unprefixed-hex inputs.
> 
> Refreshes API type docs/comments (including OpenAPI-facing descriptions) to explicitly document the new request/response numeric string contract for gateway/indexer payloads.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d4950e5a5ea0a5295038344b7d9ebb02b97170f6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->