### PR TITLE
fix: Fail build if forge missing

### DIFF
--- a/crates/test-utils/build.rs
+++ b/crates/test-utils/build.rs
@@ -20,10 +20,7 @@ fn main() {
         match status {
             Ok(s) if s.success() => {}
             Ok(_) => panic!("forge build failed"),
-            Err(e) => {
-                // Don't fail if forge isn't installed - contracts may already be built
-                println!("cargo:warning=forge not available: {e}");
-            }
+            Err(e) => panic!("forge build failed {}, forge is likely not installed", e),
         }
     }
 


### PR DESCRIPTION
[Some test builds started failing in Walletkit](https://github.com/worldcoin/walletkit/actions/runs/21990206774/job/63534942502?pr=205) - and turns out the reason we're silently failing to build contract ABI JSONS. With this change we'll have an explicit message letting us know that `forge` is missing and needs to be installed.

Note that this only affects builds of `world-id-test-utils`