### PR TITLE
fix(world-id-registry): remove proof from removeAuthenticator fn

### DIFF
--- a/contracts/test/WorldIDRegistry.t.sol
+++ b/contracts/test/WorldIDRegistry.t.sol
@@ -433,14 +433,7 @@ contract WorldIDRegistryTest is Test {
 
         vm.expectRevert(abi.encodeWithSelector(IWorldIDRegistry.MismatchedRecoveryCounter.selector, leafIndex, 1, 0));
         worldIDRegistry.removeAuthenticator(
-            leafIndex,
-            authenticatorAddress1,
-            0,
-            0,
-            recoveredCommitment,
-            removeCommitment,
-            removeSignature,
-            removeNonce
+            leafIndex, authenticatorAddress1, 0, 0, recoveredCommitment, removeCommitment, removeSignature, removeNonce
         );
     }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Test-only signature alignment; no on-chain logic changes, but it may mask mismatches if other call sites weren’t updated elsewhere.
> 
> **Overview**
> Updates `WorldIDRegistry.t.sol` to remove the `proof` argument (and related `emptyProof()` setup) from `removeAuthenticator` calls, and similarly drops the extra `emptyProof()` argument from `recoverAccount` where it was still being passed.
> 
> This is a test-only change to align with the simplified registry API that no longer requires callers to supply a proof for these operations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 17de3a24e2fd37b61822287117b7dc4ce953ce20. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->