### PR TITLE
chore: Split inclusion proof fetching and nullifier generation

### DIFF
--- a/crates/authenticator/src/authenticator.rs
+++ b/crates/authenticator/src/authenticator.rs
@@ -517,10 +517,10 @@ impl Authenticator {
     pub async fn generate_nullifier(
         &self,
         proof_request: &ProofRequest,
+        inclusion_proof: MerkleInclusionProof<TREE_DEPTH>,
+        key_set: AuthenticatorPublicKeySet,
     ) -> Result<OprfNullifier, AuthenticatorError> {
         let (services, threshold) = self.check_oprf_config()?;
-
-        let (inclusion_proof, key_set) = self.fetch_inclusion_proof().await?;
         let key_index = key_set
             .iter()
             .position(|pk| pk.pk == self.offchain_pubkey().pk)

--- a/crates/core/examples/authenticator.rs
+++ b/crates/core/examples/authenticator.rs
@@ -64,7 +64,10 @@ async fn main() -> Result<()> {
         .find_request_by_issuer_schema_id(credential.issuer_schema_id)
         .expect("the credential is not valid for the ProofRequest");
 
-    let nullifier = authenticator.generate_nullifier(&proof_request).await?;
+    let (inclusion_proof, key_set) = authenticator.fetch_inclusion_proof().await?;
+    let nullifier = authenticator
+        .generate_nullifier(&proof_request, inclusion_proof, key_set)
+        .await?;
 
     let proof_response = authenticator.generate_single_proof(
         nullifier,

--- a/crates/core/tests/generate_proof.rs
+++ b/crates/core/tests/generate_proof.rs
@@ -274,7 +274,10 @@ async fn e2e_authenticator_generate_proof() -> Result<()> {
         .find_request_by_issuer_schema_id(issuer_schema_id)
         .unwrap();
 
-    let nullifier = authenticator.generate_nullifier(&proof_request).await?;
+    let (inclusion_proof, key_set) = authenticator.fetch_inclusion_proof().await?;
+    let nullifier = authenticator
+        .generate_nullifier(&proof_request, inclusion_proof, key_set)
+        .await?;
     let raw_nullifier = FieldElement::from(nullifier.verifiable_oprf_output.output);
     assert_ne!(raw_nullifier, FieldElement::ZERO);
 

--- a/services/oprf-dev-client/src/bin/world-id-oprf-dev-client.rs
+++ b/services/oprf-dev-client/src/bin/world-id-oprf-dev-client.rs
@@ -244,8 +244,13 @@ async fn run_nullifier(
         .find_request_by_issuer_schema_id(issuer_schema_id)
         .ok_or_eyre("unexpectedly not found relevant request_item")?;
 
+    let (inclusion_proof, key_set) = authenticator
+        .fetch_inclusion_proof()
+        .await
+        .context("while fetching inclusion proof")?;
+
     let nullifier = authenticator
-        .generate_nullifier(&proof_request)
+        .generate_nullifier(&proof_request, inclusion_proof, key_set)
         .await
         .context("while generating nullifier")?;
 


### PR DESCRIPTION
So that we can cache the inclusion proof in WalletKit