### PR TITLE
fix: natspec for authenticator removal

### DIFF
--- a/contracts/src/core/interfaces/IWorldIDRegistry.sol
+++ b/contracts/src/core/interfaces/IWorldIDRegistry.sol
@@ -394,7 +394,7 @@ interface IWorldIDRegistry {
      * @param authenticatorPubkey The public key of the authenticator being removed.
      * @param oldOffchainSignerCommitment The current offchain signer commitment.
      * @param newOffchainSignerCommitment The new offchain signer commitment after removal.
-     * @param signature The signature from the authenticator being removed authorizing the removal.
+     * @param signature The signature from a valid authenticator authorizing the removal.
      * @param nonce The signature nonce for replay protection.
      */
     function removeAuthenticator(


### PR DESCRIPTION
Any valid authenticator can remove another authenticator for the same World ID. All authenticators have the same permissions and this allows users to remove stale/lost authenticators.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to interface comments; no contract logic or ABI changes.
> 
> **Overview**
> Updates `IWorldIDRegistry.removeAuthenticator` NatSpec to state the provided `signature` must come from *any valid authenticator* authorizing the removal, rather than implying it must be signed by the authenticator being removed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2f9aa0ed6ea7055b7405c60063afccff43e51bc1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->