### PR TITLE
chore(issuer): preserve contract errors in issuer schema registration

### DIFF
--- a/crates/issuer/src/issuer.rs
+++ b/crates/issuer/src/issuer.rs
@@ -86,7 +86,7 @@ impl Issuer {
             )
             .send()
             .await
-            .map_err(|e| IssuerError::Generic(format!("failed to send transaction: {e}")))?
+            .map_err(IssuerError::SendTransactionError)?
             .get_receipt()
             .await?;
 
@@ -132,6 +132,10 @@ pub enum IssuerError {
     #[error(transparent)]
     PendingTransactionError(#[from] alloy::providers::PendingTransactionError),
 
+    /// Failed to send the registration transaction.
+    #[error("fail to send transaction: {0}")]
+    SendTransactionError(#[from] alloy::contract::Error),
+
     /// Registration failed with revert
     #[error("Registration failed: {0}")]
     RegistrationFailed(String),
@@ -150,8 +154,4 @@ pub enum IssuerError {
         expected_signer: Address,
         actual_signer: Address,
     },
-
-    /// Generic unexpected error
-    #[error("Unexpected error: {0}")]
-    Generic(String),
 }


### PR DESCRIPTION
Very small chore PR that changes the `IssuerError::Generic` into a more specific `SendTransactionError` with transparent alloy error

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small error-type refactor limited to transaction send failure handling; behavior is effectively the same but downstream code may need to match the new `IssuerError` variant.
> 
> **Overview**
> Updates issuer schema registration error handling to **preserve the underlying Alloy contract error** when `.send()` fails, replacing the previous string-wrapped `IssuerError::Generic` path with a typed `IssuerError::SendTransactionError`.
> 
> Removes the `Generic` error variant from `IssuerError`, making transaction-send failures more structured and inspectable by callers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 061a0f5b7ffabb78ae0927dd23d503e7b539138d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->