### PR TITLE
chore: use default to create empty AuthenticatorPublicKeySet

### DIFF
--- a/crates/authenticator/src/authenticator.rs
+++ b/crates/authenticator/src/authenticator.rs
@@ -950,7 +950,7 @@ impl InitializingAuthenticator {
     ) -> Result<Self, AuthenticatorError> {
         let signer = Signer::from_seed_bytes(seed)?;
 
-        let mut key_set = AuthenticatorPublicKeySet::new(None)?;
+        let mut key_set = AuthenticatorPublicKeySet::default();
         key_set.try_push(signer.offchain_signer_pubkey())?;
         let leaf_hash = key_set.leaf_hash();
 
@@ -1187,12 +1187,9 @@ mod tests {
 
     #[test]
     fn test_insert_or_reuse_authenticator_key_reuses_empty_slot() {
-        let mut key_set = AuthenticatorPublicKeySet::new(Some(vec![
-            test_pubkey(1),
-            test_pubkey(2),
-            test_pubkey(4),
-        ]))
-        .unwrap();
+        let mut key_set =
+            AuthenticatorPublicKeySet::new(vec![test_pubkey(1), test_pubkey(2), test_pubkey(4)])
+                .unwrap();
         key_set[1] = None;
         let new_key = test_pubkey(3);
 
@@ -1206,7 +1203,7 @@ mod tests {
 
     #[test]
     fn test_insert_or_reuse_authenticator_key_appends_when_no_empty_slot() {
-        let mut key_set = AuthenticatorPublicKeySet::new(Some(vec![test_pubkey(1)])).unwrap();
+        let mut key_set = AuthenticatorPublicKeySet::new(vec![test_pubkey(1)]).unwrap();
         let new_key = test_pubkey(2);
 
         let index =

--- a/crates/test-utils/src/fixtures.rs
+++ b/crates/test-utils/src/fixtures.rs
@@ -153,7 +153,7 @@ pub fn single_leaf_merkle_fixture(
     pubkeys: Vec<EdDSAPublicKey>,
     leaf_index: u64,
 ) -> Result<MerkleFixture> {
-    let key_set = AuthenticatorPublicKeySet::new(Some(pubkeys))?;
+    let key_set = AuthenticatorPublicKeySet::new(pubkeys)?;
     let leaf = key_set.leaf_hash();
     let (siblings, root) = first_leaf_merkle_path(leaf);
     let inclusion_proof = MerkleInclusionProof::new(root, leaf_index, siblings);

--- a/services/oprf-node/src/auth.rs
+++ b/services/oprf-node/src/auth.rs
@@ -193,7 +193,7 @@ mod tests {
 
             let signer = Signer::from_seed_bytes(&rng.r#gen::<[u8; 32]>()).unwrap();
 
-            let mut key_set = AuthenticatorPublicKeySet::new(None)?;
+            let mut key_set = AuthenticatorPublicKeySet::default();
             key_set.try_push(signer.offchain_signer_pubkey())?;
             let leaf_hash = key_set.leaf_hash();
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small API change with straightforward call-site updates; low risk aside from potential downstream breakage for any external callers relying on the old `new(None)` signature.
> 
> **Overview**
> Standardizes empty `AuthenticatorPublicKeySet` creation by adding `Default` and switching call sites (authenticator initialization, OPRF-node tests, and fixtures) from `AuthenticatorPublicKeySet::new(None)` to `::default()`.
> 
> Refactors `AuthenticatorPublicKeySet::new` to accept `Vec<EdDSAPublicKey>` instead of `Option<Vec<_>>`, and updates affected unit tests accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dbfe9edd204d436074367cc0508d221f3c59eed7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->