### PR TITLE
fix: bump circuit commit

### DIFF
--- a/crates/proof/build.rs
+++ b/crates/proof/build.rs
@@ -1,4 +1,4 @@
-use eyre::{OptionExt, bail};
+use eyre::OptionExt;
 use std::{
     env, fs,
     path::{Path, PathBuf},
@@ -186,7 +186,7 @@ fn ark_compress_zkeys(out_dir: &Path) -> eyre::Result<()> {
     let circom_dir = workspace_root.join("circom");
 
     if !circom_dir.is_dir() {
-        bail!("circom directory not found at {}", circom_dir.display());
+        fs::create_dir_all(&circom_dir)?;
     }
 
     // Watch the directory itself for new/removed files


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small build-script-only change; main risk is unintentionally fetching different circuit artifacts due to the commit bump.
> 
> **Overview**
> Updates `crates/proof/build.rs` to fetch circuit files from a newer `CIRCUIT_COMMIT` in `worldcoin/world-id-protocol`.
> 
> Adjusts `ark_compress_zkeys` to *create* the workspace `circom/` directory when absent (instead of erroring via `bail!`), and removes the now-unused `bail` import.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2d03df911cd3f5c74e4302bc1e24b31442ab8b81. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->