### PR TITLE
feat: improve rpc retry behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.3](https://github.com/worldcoin/world-id-protocol/compare/world-id-primitives-v0.4.2...world-id-primitives-v0.4.3) - 2026-02-23
+
+### Added
+
+- *(rp)* include version byte in rp signature message
+
+### Other
+
+- expose eddsa keys & sig ([#467](https://github.com/worldcoin/world-id-protocol/pull/467))
+
 ## [0.4.2](https://github.com/worldcoin/world-id-protocol/compare/world-id-proof-v0.4.1...world-id-proof-v0.4.2) - 2026-02-20
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -433,7 +433,7 @@ dependencies = [
  "lru",
  "parking_lot",
  "pin-project",
- "reqwest 0.12.28",
+ "reqwest",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -502,7 +502,7 @@ dependencies = [
  "alloy-transport-ws",
  "futures",
  "pin-project",
- "reqwest 0.12.28",
+ "reqwest",
  "serde",
  "serde_json",
  "tokio",
@@ -795,7 +795,7 @@ dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
  "itertools 0.14.0",
- "reqwest 0.12.28",
+ "reqwest",
  "serde_json",
  "tower",
  "tracing",
@@ -2387,12 +2387,6 @@ dependencies = [
  "libc",
  "shlex",
 ]
-
-[[package]]
-name = "cesu8"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cfg-if"
@@ -4264,28 +4258,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
-name = "jni"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
-dependencies = [
- "cesu8",
- "cfg-if",
- "combine",
- "jni-sys",
- "log",
- "thiserror 1.0.69",
- "walkdir",
- "windows-sys 0.45.0",
-]
-
-[[package]]
-name = "jni-sys"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
-
-[[package]]
 name = "jobserver"
 version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4952,7 +4924,7 @@ dependencies = [
  "opentelemetry-http 0.26.0",
  "opentelemetry-semantic-conventions 0.26.0",
  "opentelemetry_sdk 0.26.0",
- "reqwest 0.12.28",
+ "reqwest",
  "rmp",
  "ryu",
  "thiserror 1.0.69",
@@ -4973,7 +4945,7 @@ dependencies = [
  "opentelemetry-http 0.31.0",
  "opentelemetry-semantic-conventions 0.31.0",
  "opentelemetry_sdk 0.31.0",
- "reqwest 0.12.28",
+ "reqwest",
  "rmp",
  "ryu",
  "thiserror 2.0.18",
@@ -4990,7 +4962,7 @@ dependencies = [
  "bytes",
  "http 1.4.0",
  "opentelemetry 0.26.0",
- "reqwest 0.12.28",
+ "reqwest",
 ]
 
 [[package]]
@@ -5003,7 +4975,7 @@ dependencies = [
  "bytes",
  "http 1.4.0",
  "opentelemetry 0.31.0",
- "reqwest 0.12.28",
+ "reqwest",
 ]
 
 [[package]]
@@ -5459,7 +5431,6 @@ version = "0.11.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
 dependencies = [
- "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
@@ -5796,45 +5767,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "reqwest"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
-dependencies = [
- "base64",
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "http 1.4.0",
- "http-body 1.0.1",
- "http-body-util",
- "hyper 1.8.1",
- "hyper-rustls 0.27.7",
- "hyper-util",
- "js-sys",
- "log",
- "percent-encoding",
- "pin-project-lite",
- "quinn",
- "rustls 0.23.36",
- "rustls-pki-types",
- "rustls-platform-verifier",
- "serde",
- "serde_json",
- "sync_wrapper",
- "tokio",
- "tokio-rustls 0.26.4",
- "tower",
- "tower-http",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
 name = "rfc6979"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6056,33 +5988,6 @@ dependencies = [
  "web-time",
  "zeroize",
 ]
-
-[[package]]
-name = "rustls-platform-verifier"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
-dependencies = [
- "core-foundation",
- "core-foundation-sys",
- "jni",
- "log",
- "once_cell",
- "rustls 0.23.36",
- "rustls-native-certs",
- "rustls-platform-verifier-android",
- "rustls-webpki 0.103.9",
- "security-framework",
- "security-framework-sys",
- "webpki-root-certs",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "rustls-platform-verifier-android"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -7347,7 +7252,7 @@ dependencies = [
  "parking_lot",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
- "reqwest 0.12.28",
+ "reqwest",
  "serde_json",
  "taceo-ark-babyjubjub",
  "taceo-oprf-core",
@@ -7437,7 +7342,7 @@ dependencies = [
  "opentelemetry-http 0.26.0",
  "opentelemetry_sdk 0.26.0",
  "rand 0.8.5",
- "reqwest 0.12.28",
+ "reqwest",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -7471,7 +7376,7 @@ dependencies = [
  "opentelemetry_sdk 0.31.0",
  "pin-project",
  "rand 0.9.2",
- "reqwest 0.12.28",
+ "reqwest",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -8389,15 +8294,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki-root-certs"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
 name = "webpki-roots"
 version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8532,15 +8428,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
@@ -8573,21 +8460,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -8640,12 +8512,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
@@ -8664,12 +8530,6 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
@@ -8685,12 +8545,6 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -8724,12 +8578,6 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
@@ -8745,12 +8593,6 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -8772,12 +8614,6 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
@@ -8793,12 +8629,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -8917,7 +8747,7 @@ dependencies = [
 
 [[package]]
 name = "world-id-authenticator"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "alloy",
  "anyhow",
@@ -8926,7 +8756,7 @@ dependencies = [
  "eyre",
  "mockito",
  "rand 0.8.5",
- "reqwest 0.13.2",
+ "reqwest",
  "ruint",
  "rustls 0.23.36",
  "secrecy",
@@ -8946,7 +8776,7 @@ dependencies = [
 
 [[package]]
 name = "world-id-core"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "alloy",
  "backon",
@@ -8954,7 +8784,7 @@ dependencies = [
  "eyre",
  "hex",
  "rand 0.8.5",
- "reqwest 0.13.2",
+ "reqwest",
  "rustls 0.23.36",
  "serde_json",
  "taceo-eddsa-babyjubjub",
@@ -9005,7 +8835,7 @@ dependencies = [
  "moka",
  "once_cell",
  "redis",
- "reqwest 0.13.2",
+ "reqwest",
  "serde",
  "serde_json",
  "strum",
@@ -9038,7 +8868,7 @@ dependencies = [
  "http 1.4.0",
  "rand 0.8.5",
  "regex",
- "reqwest 0.13.2",
+ "reqwest",
  "ruint",
  "rustls 0.23.36",
  "semaphore-rs-hasher",
@@ -9067,7 +8897,7 @@ dependencies = [
 
 [[package]]
 name = "world-id-issuer"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "alloy",
  "ark-ff 0.5.0",
@@ -9145,7 +8975,7 @@ dependencies = [
 
 [[package]]
 name = "world-id-primitives"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "alloy",
  "alloy-primitives",
@@ -9182,7 +9012,7 @@ dependencies = [
 
 [[package]]
 name = "world-id-proof"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "ark-bn254 0.5.0",
  "ark-ff 0.5.0",
@@ -9191,7 +9021,7 @@ dependencies = [
  "eyre",
  "rand 0.8.5",
  "rayon",
- "reqwest 0.13.2",
+ "reqwest",
  "taceo-ark-babyjubjub",
  "taceo-circom-types",
  "taceo-eddsa-babyjubjub",
@@ -9241,7 +9071,7 @@ dependencies = [
  "hex",
  "k256",
  "rand 0.8.5",
- "reqwest 0.13.2",
+ "reqwest",
  "semver 1.0.27",
  "serde_json",
  "taceo-ark-babyjubjub",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2024"
-version = "0.4.2"
+version = "0.4.3"
 license = "MIT"
 authors = [
   "World Foundation",
@@ -77,9 +77,9 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 url = { version = "2", features = ["serde"] }
 utoipa = "5"
-reqwest = { version = "0.13", default-features = false, features = [
+reqwest = { version = "0.12", default-features = false, features = [
   "json",
-  "rustls",
+  "rustls-tls",
 ] }
 uuid = { version = "1" }
 webpki-roots = "1.0"
@@ -122,11 +122,11 @@ tokio-util = "0.7"
 tower = "0.5.3"
 
 # Internal
-world-id-core = { version = "0.4.2", default-features = false, path = "crates/core" }
-world-id-issuer = { version = "0.4.2", path = "crates/issuer" }
-world-id-proof = { version = "0.4.2", path = "crates/proof" }
-world-id-authenticator = { version = "0.4.2", path = "crates/authenticator" }
-world-id-primitives = { version = "0.4.2", path = "crates/primitives", default-features = false }
+world-id-core = { version = "0.4.3", default-features = false, path = "crates/core" }
+world-id-issuer = { version = "0.4.3", path = "crates/issuer" }
+world-id-proof = { version = "0.4.3", path = "crates/proof" }
+world-id-authenticator = { version = "0.4.3", path = "crates/authenticator" }
+world-id-primitives = { version = "0.4.3", path = "crates/primitives", default-features = false }
 world-id-oprf-node = { version = "0.1.0", path = "services/oprf-node" }
 world-id-test-utils = { version = "0.1.0", path = "crates/test-utils" }
 world-id-services-common = { path = "services/common" }

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -71,6 +71,8 @@ pub use request::{
     ProofResponse, RequestItem, RequestVersion, ResponseItem, ValidationError,
 };
 
+pub use eddsa_babyjubjub::{EdDSAPrivateKey, EdDSAPublicKey, EdDSASignature};
+
 /// The scalar field used in the World ID Protocol.
 ///
 /// This is the scalar field of the `BabyJubJub` curve.

--- a/crates/primitives/src/request/mod.rs
+++ b/crates/primitives/src/request/mod.rs
@@ -385,7 +385,7 @@ impl ProofRequest {
     /// # Errors
     /// Returns a `PrimitiveError` if `FieldElement` serialization fails (which should never occur in practice).
     ///
-    /// The digest is computed as: `SHA256(nonce || action || created_at || expires_at)`.
+    /// The digest is computed as: `SHA256(version || nonce || created_at || expires_at)`.
     /// This mirrors the RP signature message format from `rp::compute_rp_signature_msg`.
     /// Note: the timestamp is encoded as big-endian to mirror the RP-side signing
     /// performed in test fixtures and the OPRF stub.

--- a/services/common/src/provider_layers.rs
+++ b/services/common/src/provider_layers.rs
@@ -64,10 +64,6 @@ pub struct ThrottleConfig {
     pub burst_size: u32,
 }
 
-// ---------------------------------------------------------------------------
-// RetryConfig
-// ---------------------------------------------------------------------------
-
 #[derive(Args, Debug, Clone, Deserialize)]
 pub struct RetryConfig {
     /// Maximum number of retry attempts for failed RPC requests.


### PR DESCRIPTION
These changes affect the shared provider module. Currently, it only used in parts of the gateway and indexer services. A later PR will unify usage across the code base. 

Changes:
* Add timeouts for rpc calls
* Add custom exponential backoff retry layer. We extend the retry policy and catch transport errors and some HTTP error codes in addition to the RPC related error the default retry policy catches
* Timeouts and retries are activated by default. Retries can be deactivated by setting max_retries to 0.
* Add integration tests for provider