### PR TITLE
chore: expose eddsa keys & sig

### DIFF
--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -71,6 +71,8 @@ pub use request::{
     ProofResponse, RequestItem, RequestVersion, ResponseItem, ValidationError,
 };
 
+pub use eddsa_babyjubjub::{EdDSAPrivateKey, EdDSAPublicKey, EdDSASignature};
+
 /// The scalar field used in the World ID Protocol.
 ///
 /// This is the scalar field of the `BabyJubJub` curve.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Public API surface change only (re-exported types) with no behavioral or cryptographic logic changes; main risk is minor downstream compilation/API coupling.
> 
> **Overview**
> Exposes BabyJubJub EdDSA primitives from `crates/primitives` by re-exporting `EdDSAPrivateKey`, `EdDSAPublicKey`, and `EdDSASignature` in `lib.rs`, making them available to downstream crates via this crate’s public API.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 98c806b61c9c3b23635d2e778a5e41caacc2fc0a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->