### PR TITLE
fix: use workspace-level changelog to prevent per-crate overwrites

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -3,10 +3,17 @@
 # This creates tags like: world-id-core-v0.1.4, world-id-primitives-v0.1.2
 git_release_enable = true
 git_release_type = "auto"
-changelog_update = false
 pr_labels = ["release"]
 release = false # only process specifically defined packages
 publish = false # only process specifically defined packages
+
+# Maintain a single workspace-level changelog that aggregates changes from all
+# published crates.  Previously every [[package]] pointed changelog_path at the
+# same root CHANGELOG.md, which meant the last crate release-plz processed
+# would overwrite all earlier crates' entries for that version – effectively
+# losing changes (the changelog was always "one release behind" for some crates).
+changelog_update = true
+changelog_path = "CHANGELOG.md"
 
 # Publish only specific packages to crates.io
 # Services (indexer, gateway, ...) are not published to crates.io
@@ -14,37 +21,27 @@ publish = false # only process specifically defined packages
 name = "world-id-primitives"
 release = true
 publish = true
-changelog_update = true
-changelog_path = "CHANGELOG.md"
 
 
 [[package]]
 name = "world-id-core"
 release = true
 publish = true
-changelog_update = true
-changelog_path = "CHANGELOG.md"
 
 
 [[package]]
 name = "world-id-authenticator"
 release = true
 publish = true
-changelog_update = true
-changelog_path = "CHANGELOG.md"
 
 
 [[package]]
 name = "world-id-issuer"
 release = true
 publish = true
-changelog_update = true
-changelog_path = "CHANGELOG.md"
 
 
 [[package]]
 name = "world-id-proof"
 release = true
 publish = true
-changelog_update = true # each crate maintains its own changelog
-changelog_path = "CHANGELOG.md"


### PR DESCRIPTION
## Problem

The release changelog is always missing changes from some crates — it appears to be "one change behind."

## Root Cause

All five published crates (`world-id-primitives`, `world-id-core`, `world-id-authenticator`, `world-id-issuer`, `world-id-proof`) each had `changelog_update = true` with `changelog_path = "CHANGELOG.md"` in `release-plz.toml`, all pointing to the **same root file**.

When `release-plz` processes each package during the release PR creation, each crate independently generates its changelog entry for the new version and writes it to `CHANGELOG.md`. The last crate to be processed overwrites the entries written by earlier crates. This means only one crate's changes appear in each release version.

### Concrete example

In **v0.4.3**, commit `ba3fd74` ("feat: improve gateway timeout layer #462") modified `crates/core/` and should have appeared in the changelog. However, `world-id-primitives` was processed after `world-id-core` and overwrote the v0.4.3 entry — so only primitives' changes ("include version byte in rp signature message" and "expose eddsa keys & sig") appear.

You can also see this in the compare URLs in CHANGELOG.md — they alternate between different crate tag prefixes (`world-id-primitives-v...`, `world-id-proof-v...`) because whichever crate wrote last determined the link.

## Fix

Move `changelog_update = true` and `changelog_path = "CHANGELOG.md"` to the `[workspace]` section in `release-plz.toml` and remove the per-package changelog settings. This tells release-plz to maintain a **single aggregated workspace changelog** that includes changes from all published crates, rather than having each crate independently (and destructively) write to the same file.