### PR TITLE
fix: use changelog_include for single aggregated changelog

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -6,42 +6,47 @@ git_release_type = "auto"
 pr_labels = ["release"]
 release = false # only process specifically defined packages
 publish = false # only process specifically defined packages
-
-# Maintain a single workspace-level changelog that aggregates changes from all
-# published crates.  Previously every [[package]] pointed changelog_path at the
-# same root CHANGELOG.md, which meant the last crate release-plz processed
-# would overwrite all earlier crates' entries for that version – effectively
-# losing changes (the changelog was always "one release behind" for some crates).
-changelog_update = true
-changelog_path = "CHANGELOG.md"
+changelog_update = false
 
 # Publish only specific packages to crates.io
 # Services (indexer, gateway, ...) are not published to crates.io
+
+# world-id-primitives is the "primary" package that owns the root CHANGELOG.md.
+# changelog_include pulls in changes from every other published crate so that
+# we get a single, aggregated changelog at the repo root.  All other packages
+# have changelog_update = false to avoid overwriting the same file.
 [[package]]
 name = "world-id-primitives"
 release = true
 publish = true
+changelog_update = true
+changelog_path = "CHANGELOG.md"
+changelog_include = ["world-id-core", "world-id-authenticator", "world-id-issuer", "world-id-proof"]
 
 
 [[package]]
 name = "world-id-core"
 release = true
 publish = true
+changelog_update = false
 
 
 [[package]]
 name = "world-id-authenticator"
 release = true
 publish = true
+changelog_update = false
 
 
 [[package]]
 name = "world-id-issuer"
 release = true
 publish = true
+changelog_update = false
 
 
 [[package]]
 name = "world-id-proof"
 release = true
 publish = true
+changelog_update = false


### PR DESCRIPTION
## Problem

PR #480 moved `changelog_update` and `changelog_path` to the `[workspace]` section of `release-plz.toml`. However, release-plz workspace-level changelogs **only capture commits not attributed to any specific package** — essentially just workspace `Cargo.toml` dependency bumps. All meaningful crate-level changes (features, fixes) are attributed to their respective packages and excluded from the workspace changelog.

This is why PR #471 shows only:

> ### Other
> - update Cargo.toml dependencies

## Fix

Designate `world-id-primitives` as the changelog owner using per-package `changelog_include` to pull in changes from all other published crates (`world-id-core`, `world-id-authenticator`, `world-id-issuer`, `world-id-proof`). This produces a single root `CHANGELOG.md` that aggregates changes from every published crate. All other packages have `changelog_update = false` so they don't overwrite the shared file.

## Verification

Tested locally with `release-plz update` — the generated changelog now includes all crate-level changes instead of just the generic Cargo.toml update entry.