### PR TITLE
feat(world-id-core): expose IWorldIDVerifier Solidity binding

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -42,6 +42,8 @@ issuer = [
 
 rp = []
 
+contracts = ["dep:alloy"]
+
 [dependencies]
 eddsa-babyjubjub = { workspace = true }
 
@@ -50,6 +52,7 @@ world-id-issuer = { workspace = true, optional = true }
 world-id-proof = { workspace = true, optional = true }
 world-id-authenticator = { workspace = true, optional = true }
 world-id-primitives = { workspace = true }
+alloy = { workspace = true, features = ["sol-types", "contract"], optional = true }
 
 [dev-dependencies]
 alloy = { workspace = true }

--- a/crates/core/src/contracts.rs
+++ b/crates/core/src/contracts.rs
@@ -1,0 +1,95 @@
+//! Solidity contract bindings for the World ID Protocol.
+//!
+//! This module provides auto-generated Rust bindings for the on-chain World ID
+//! contracts via [`alloy::sol!`]. The bindings include full RPC support so
+//! callers can interact with deployed contracts directly.
+//!
+//! # Example
+//!
+//! ```rust,ignore
+//! use world_id_core::contracts::IWorldIDVerifier;
+//!
+//! // Build a call to the on-chain verifier
+//! let contract = IWorldIDVerifier::new(address, provider);
+//! let result = contract.verify(nullifier, action, rp_id, nonce, signal_hash,
+//!     expires_at_min, issuer_schema_id, credential_genesis_issued_at_min,
+//!     zero_knowledge_proof).call().await?;
+//! ```
+
+alloy::sol! {
+    /// Bindings for the `IWorldIDVerifier` interface.
+    ///
+    /// See [`contracts/src/core/interfaces/IWorldIDVerifier.sol`](https://github.com/worldcoin/world-id-protocol/blob/main/contracts/src/core/interfaces/IWorldIDVerifier.sol)
+    /// for the canonical Solidity source.
+    #[sol(rpc)]
+    #[derive(Debug)]
+    interface IWorldIDVerifier {
+        error ExpirationTooOld();
+        error InvalidMerkleRoot();
+        error UnregisteredIssuerSchemaId();
+
+        event CredentialSchemaIssuerRegistryUpdated(
+            address oldCredentialSchemaIssuerRegistry,
+            address newCredentialSchemaIssuerRegistry
+        );
+        event WorldIDRegistryUpdated(address oldWorldIDRegistry, address newWorldIDRegistry);
+        event OprfKeyRegistryUpdated(address oldOprfKeyRegistry, address newOprfKeyRegistry);
+        event VerifierUpdated(address oldVerifier, address newVerifier);
+        event MinExpirationThresholdUpdated(
+            uint64 oldMinExpirationThreshold,
+            uint64 newMinExpirationThreshold
+        );
+
+        function verify(
+            uint256 nullifier,
+            uint256 action,
+            uint64 rpId,
+            uint256 nonce,
+            uint256 signalHash,
+            uint64 expiresAtMin,
+            uint64 issuerSchemaId,
+            uint256 credentialGenesisIssuedAtMin,
+            uint256[5] calldata zeroKnowledgeProof
+        ) external view;
+
+        function verifySession(
+            uint64 rpId,
+            uint256 nonce,
+            uint256 signalHash,
+            uint64 expiresAtMin,
+            uint64 issuerSchemaId,
+            uint256 credentialGenesisIssuedAtMin,
+            uint256 sessionId,
+            uint256[2] calldata sessionNullifier,
+            uint256[5] calldata zeroKnowledgeProof
+        ) external view;
+
+        function verifyProofAndSignals(
+            uint256 nullifier,
+            uint256 action,
+            uint64 rpId,
+            uint256 nonce,
+            uint256 signalHash,
+            uint64 expiresAtMin,
+            uint64 issuerSchemaId,
+            uint256 credentialGenesisIssuedAtMin,
+            uint256 sessionId,
+            uint256[5] calldata zeroKnowledgeProof
+        ) external view;
+
+        function updateCredentialSchemaIssuerRegistry(
+            address newCredentialSchemaIssuerRegistry
+        ) external;
+        function updateWorldIDRegistry(address newWorldIDRegistry) external;
+        function updateOprfKeyRegistry(address newOprfKeyRegistry) external;
+        function updateVerifier(address newVerifier) external;
+        function updateMinExpirationThreshold(uint64 newMinExpirationThreshold) external;
+
+        function getCredentialSchemaIssuerRegistry() external view returns (address);
+        function getWorldIDRegistry() external view returns (address);
+        function getOprfKeyRegistry() external view returns (address);
+        function getVerifier() external view returns (address);
+        function getMinExpirationThreshold() external view returns (uint256);
+        function getTreeDepth() external view returns (uint256);
+    }
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -8,6 +8,13 @@
 
 pub use eddsa_babyjubjub::{EdDSAPrivateKey, EdDSAPublicKey, EdDSASignature};
 
+/// Solidity contract bindings (e.g. `IWorldIDVerifier`) for on-chain
+/// interaction via [`alloy`].
+///
+/// Enable the `contracts` feature to use this module.
+#[cfg(feature = "contracts")]
+pub mod contracts;
+
 #[cfg(feature = "authenticator")]
 pub use world_id_authenticator::{
     Authenticator, AuthenticatorError, InitializingAuthenticator, OnchainKeyRepresentable,


### PR DESCRIPTION
## Summary

Add a public `contracts` module to the `world-id-core` crate that exposes the full `IWorldIDVerifier` interface via `alloy::sol!` with `#[sol(rpc)]` support.

## Motivation

Downstream consumers like [walletkit-core](https://github.com/worldcoin/walletkit) currently define this binding inline in their test files. This PR moves the canonical ABI definition into the protocol crate itself so it can be reused without duplication.

## Changes

- **`crates/core/Cargo.toml`**: Added optional `alloy` dependency (with `sol-types` and `contract` features) gated behind a new `contracts` feature flag.
- **`crates/core/src/contracts.rs`**: New module with `alloy::sol!` bindings for the complete `IWorldIDVerifier` interface (including `verify`, `verifySession`, `verifyProofAndSignals`, admin functions, errors, and events).
- **`crates/core/src/lib.rs`**: Re-exports the `contracts` module when the feature is enabled.

## Usage

```toml
[dependencies]
world-id-core = { version = "0.4", features = ["contracts"] }
```

```rust
use world_id_core::contracts::IWorldIDVerifier;

let contract = IWorldIDVerifier::new(address, provider);
contract.verify(/* ... */).call().await?;
```
