### PR TITLE
fix: update CIRCUIT_COMMIT to point to correct commit with circuit artifacts

### DIFF
--- a/crates/proof/build.rs
+++ b/crates/proof/build.rs
@@ -11,7 +11,7 @@ use std::{fs::File, io};
 const GITHUB_REPO: &str = "worldcoin/world-id-protocol";
 
 #[cfg(feature = "embed-zkeys")]
-const CIRCUIT_COMMIT: &str = "d9d61e26ac5802c27a5984875db6c4572af5b24c"; // TODO: Figure out a better way for static commits
+const CIRCUIT_COMMIT: &str = "aaf8f2650b003a8bb06feb26bed6277629d4c0bf"; // TODO: Figure out a better way for static commits
 
 const CIRCUIT_FILES: &[&str] = &[
     "circom/OPRFQueryGraph.bin",


### PR DESCRIPTION
## Problem

The `release-crates` CI workflow fails when `release-plz` tries to verify the `world-id-proof` crate package. The build script (`crates/proof/build.rs`) downloads compiled circuit files from `raw.githubusercontent.com` using a hardcoded `CIRCUIT_COMMIT`.

The current value `d9d61e26ac5802c27a5984875db6c4572af5b24c` points to a commit where the binary circuit artifacts (`.bin`, `.zkey` files in `circom/`) did **not** exist — only circom source subdirectories existed at that point.

This causes 404 errors during crate publish verification:
```
Error: HTTP error 404 Not Found: https://raw.githubusercontent.com/worldcoin/world-id-protocol/d9d61e26ac5802c27a5984875db6c4572af5b24c/circom/OPRFQueryGraph.bin
```

## Fix

Update `CIRCUIT_COMMIT` to `aaf8f2650b003a8bb06feb26bed6277629d4c0bf` ("Finalize World ID 4 trusted setup docs, artifacts, and explainer video (#468)"), which contains all 4 required circuit files:
- `circom/OPRFQueryGraph.bin`
- `circom/OPRFNullifierGraph.bin`
- `circom/OPRFQuery.arks.zkey`
- `circom/OPRFNullifier.arks.zkey`

Verified that all files exist at that commit via `git ls-tree`.