### PR TITLE
fix: automate CIRCUIT_COMMIT updates when circuit files change

### DIFF
--- a/crates/proof/build.rs
+++ b/crates/proof/build.rs
@@ -11,7 +11,9 @@ use std::{fs::File, io};
 const GITHUB_REPO: &str = "worldcoin/world-id-protocol";
 
 #[cfg(feature = "embed-zkeys")]
-const CIRCUIT_COMMIT: &str = "d9d61e26ac5802c27a5984875db6c4572af5b24c"; // TODO: Figure out a better way for static commits
+// This commit hash is automatically updated by the update-circuit-commit CI
+// workflow whenever files in circom/ change on main. Do not edit manually.
+const CIRCUIT_COMMIT: &str = "d9d61e26ac5802c27a5984875db6c4572af5b24c";
 
 const CIRCUIT_FILES: &[&str] = &[
     "circom/OPRFQueryGraph.bin",


### PR DESCRIPTION
## Summary

Resolves the TODO in `crates/proof/build.rs` where `CIRCUIT_COMMIT` is hardcoded and must be manually updated whenever circuit files change, causing 404s on crates.io builds when forgotten.

## Changes

### 1. `crates/proof/build.rs` — Remove TODO, add documentation comment
The `// TODO: Figure out a better way for static commits` comment is replaced with documentation explaining the automated CI process.

### 2. New CI workflow: `.github/workflows/update-circuit-commit.yml`
> ⚠️ **This file could not be pushed via the PR branch** due to the PAT lacking `workflow` scope. Please add it manually or commit it via the GitHub web UI after merging.

A GitHub Actions workflow that:
- **Triggers** on pushes to `main` that modify files in `circom/`
- **Computes** the current `github.sha` (the commit that contains the updated circuit files)
- **Updates** the `CIRCUIT_COMMIT` constant in `crates/proof/build.rs` via `sed`
- **Commits and pushes** the change directly to `main` (only if the hash actually changed)

This ensures `CIRCUIT_COMMIT` always points to a commit containing the current circuit files, so crates.io builds (which download circuit files from `raw.githubusercontent.com` by commit SHA) never get 404s.

### How it works end-to-end
1. Developer pushes circuit file changes to `main`
2. CI workflow fires, updates `CIRCUIT_COMMIT` to that commit SHA, pushes to `main`
3. When `release-plz` later publishes the crate, the baked-in commit hash is correct
4. Local development is unaffected (build.rs uses local files when available)

<details>
<summary>📄 Workflow file to add: <code>.github/workflows/update-circuit-commit.yml</code></summary>

```yaml
name: Update CIRCUIT_COMMIT

# Automatically updates the CIRCUIT_COMMIT hash in crates/proof/build.rs
# whenever circuit files change on main. This ensures crates.io builds
# (which download circuit files from GitHub by commit SHA) always reference
# a commit that actually contains the current circuit files.

on:
  push:
    branches:
      - main
    paths:
      - "circom/**"

permissions:
  contents: write

jobs:
  update-circuit-commit:
    name: Update CIRCUIT_COMMIT in build.rs
    runs-on: ubuntu-latest
    steps:
      - name: Checkout code
        uses: actions/checkout@v5
        with:
          token: ${{ secrets.GITHUB_TOKEN }}

      - name: Update CIRCUIT_COMMIT
        run: |
          COMMIT_SHA="${{ github.sha }}"
          BUILD_RS="crates/proof/build.rs"

          # Replace the CIRCUIT_COMMIT line with the current commit SHA
          sed -i "s|const CIRCUIT_COMMIT: &str = \"[a-f0-9]\{40\}\";|const CIRCUIT_COMMIT: &str = \"${COMMIT_SHA}\";|" "$BUILD_RS"

          # Check if anything changed
          if git diff --quiet "$BUILD_RS"; then
            echo "CIRCUIT_COMMIT is already up to date."
            exit 0
          fi

          echo "Updated CIRCUIT_COMMIT to ${COMMIT_SHA}"
          git diff "$BUILD_RS"

      - name: Commit and push
        run: |
          BUILD_RS="crates/proof/build.rs"
          if git diff --quiet "$BUILD_RS"; then
            echo "Nothing to commit."
            exit 0
          fi

          git config user.name "github-actions[bot]"
          git config user.email "github-actions[bot]@users.noreply.github.com"
          git add "$BUILD_RS"
          git commit -m "chore: update CIRCUIT_COMMIT to $(git rev-parse --short HEAD)"
          git push
```

</details>
