### PR TITLE
chore: update multi-region indexer url

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Deployments are tracked in [`contracts/deployments/`](contracts/deployments/)
 
 | Service            | URL                                                   |
 | ------------------ | ----------------------------------------------------- |
-| `world-id-indexer` | `https://world-id-indexer.stage-crypto.worldcoin.org` |
+| `world-id-indexer` | `https://indexer.us.id-infra.worldcoin.dev`<br />`https://indexer.eu.id-infra.worldcoin.dev`<br />`https://indexer.ap.id-infra.worldcoin.dev` |
 | `world-id-gateway` | `https://world-id-gateway.stage-crypto.worldcoin.org` |
 
 ## 🏗️ Project Structure


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change updating service URLs; no runtime or security-impacting code changes.
> 
> **Overview**
> Updates `README.md` to replace the single staging `world-id-indexer` URL with three region-specific endpoints (US/EU/AP) listed in the services table.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 01bd389672600478b5d5ec51367fae495870d660. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->