### PR TITLE
fix(gateway): deprecate legacy batch policy

### DIFF
--- a/services/gateway/src/batch_policy.rs
+++ b/services/gateway/src/batch_policy.rs
@@ -344,7 +344,6 @@ mod tests {
 
     fn cfg() -> BatchPolicyConfig {
         BatchPolicyConfig {
-            enabled: true,
             reeval_ms: 2_000,
             max_wait_secs: 30,
             cost_ema_alpha: 0.2,

--- a/services/gateway/src/create_batcher.rs
+++ b/services/gateway/src/create_batcher.rs
@@ -65,11 +65,7 @@ impl CreateBatcherRunner {
     }
 
     pub async fn run(mut self) {
-        if self.batch_policy.enabled {
-            self.run_policy_loop().await;
-        } else {
-            self.run_legacy_loop().await;
-        }
+        self.run_policy_loop().await;
     }
 
     async fn drop_local_queue_and_inflight(

--- a/services/gateway/src/ops_batcher.rs
+++ b/services/gateway/src/ops_batcher.rs
@@ -82,11 +82,7 @@ impl OpsBatcherRunner {
     }
 
     pub async fn run(mut self) {
-        if self.batch_policy.enabled {
-            self.run_policy_loop().await;
-        } else {
-            self.run_legacy_loop().await;
-        }
+        self.run_policy_loop().await;
     }
 
     async fn submit_ops_batch(&self, batch: Vec<OpsEnvelope>) {

--- a/services/gateway/src/routes.rs
+++ b/services/gateway/src/routes.rs
@@ -71,13 +71,11 @@ pub(crate) async fn build_app(
     let tracker = RequestTracker::new(redis_url, rate_limit).await;
     let base_fee_cache = BaseFeeCache::default();
 
-    if batch_policy_config.enabled {
-        spawn_base_fee_sampler(
-            registry.provider().clone(),
-            Duration::from_millis(batch_policy_config.reeval_ms),
-            base_fee_cache.clone(),
-        );
-    }
+    spawn_base_fee_sampler(
+        registry.provider().clone(),
+        Duration::from_millis(batch_policy_config.reeval_ms),
+        base_fee_cache.clone(),
+    );
 
     let (tx, rx) = mpsc::channel(CREATE_BATCHER_CHANNEL_CAPACITY);
     let batcher = CreateBatcherHandle { tx };


### PR DESCRIPTION
Closes #511 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Removes the legacy batching path and makes policy-driven batching always-on, which changes gateway request dispatch timing and can impact throughput/latency under load. Also changes config/CLI surface area by removing `BATCH_POLICY_ENABLED`, which could break existing deployments relying on that flag.
> 
> **Overview**
> Gateway batching is now **policy-driven only**: the `enabled` toggle is removed from `BatchPolicyConfig`, legacy batching loops are deleted, and both `CreateBatcherRunner` and `OpsBatcherRunner` always run `run_policy_loop()`.
> 
> The gateway now **always** spawns the base-fee sampler used for cost/urgency decisions, and config validation no longer gates `STALE_QUEUED_THRESHOLD_SECS > BATCH_MAX_WAIT_SECS` on a feature flag (with a new test covering this constraint).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7b3ceded1b524a26c658c12b7100b67dfac50e29. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->