### PR TITLE
docs: add metrics configuration to .env.example files

### DIFF
--- a/services/gateway/.env.example
+++ b/services/gateway/.env.example
@@ -15,5 +15,16 @@ BATCH_BACKLOG_HIGH_WATERMARK=200
 LISTEN_ADDR=0.0.0.0:8081
 
 
+# Metrics Configuration (optional, default: none)
+# TELEMETRY_METRICS_BACKEND=prometheus           # Options: prometheus, statsd, none
+# TELEMETRY_PROMETHEUS_MODE=http                 # Options: http, push
+# TELEMETRY_PROMETHEUS_LISTEN=0.0.0.0:9090       # Listener address for http mode
+# TELEMETRY_PROMETHEUS_ENDPOINT=http://pushgateway:9091  # Required for push mode
+# TELEMETRY_PROMETHEUS_INTERVAL=10               # Push interval in seconds (default: 10)
+# StatsD configuration (when TELEMETRY_METRICS_BACKEND=statsd):
+# TELEMETRY_STATSD_HOST=localhost
+# TELEMETRY_STATSD_PORT=8125
+# TELEMETRY_STATSD_PREFIX=world-id-gateway
+
 # For tests only
 TESTS_RPC_FORK_URL=

--- a/services/indexer/.env.example
+++ b/services/indexer/.env.example
@@ -24,3 +24,14 @@ TREE_DENSE_PREFIX_DEPTH=2
 
 # Optional: HttpOnly mode refresh interval in seconds (default: 30)
 # TREE_HTTP_CACHE_REFRESH_INTERVAL_SECS=30
+
+# Metrics Configuration (optional, default: none)
+# TELEMETRY_METRICS_BACKEND=prometheus           # Options: prometheus, statsd, none
+# TELEMETRY_PROMETHEUS_MODE=http                 # Options: http, push
+# TELEMETRY_PROMETHEUS_LISTEN=0.0.0.0:9090       # Listener address for http mode
+# TELEMETRY_PROMETHEUS_ENDPOINT=http://pushgateway:9091  # Required for push mode
+# TELEMETRY_PROMETHEUS_INTERVAL=10               # Push interval in seconds (default: 10)
+# StatsD configuration (when TELEMETRY_METRICS_BACKEND=statsd):
+# TELEMETRY_STATSD_HOST=localhost
+# TELEMETRY_STATSD_PORT=8125
+# TELEMETRY_STATSD_PREFIX=world-id-indexer


### PR DESCRIPTION
## Summary

Add comprehensive documentation for Prometheus and StatsD metrics configuration options to gateway and indexer .env.example files.

## Changes

Configuration options documented:
- `TELEMETRY_METRICS_BACKEND` (prometheus/statsd/none)
- `TELEMETRY_PROMETHEUS_MODE` (http/push)  
- `TELEMETRY_PROMETHEUS_LISTEN` (listener address for http mode)
- `TELEMETRY_PROMETHEUS_ENDPOINT` (required for push mode)
- `TELEMETRY_PROMETHEUS_INTERVAL` (push interval)
- `TELEMETRY_STATSD_HOST/PORT/PREFIX` (for statsd backend)

These env vars are supported by telemetry-batteries 0.2+ which is already in use by both services.

## Related PRs

- worldcoin/world-id-protocol-deploy#XXX - Deployment configuration to enable metrics in staging/production

## Testing

- ✅ Verified compilation with `cargo check`
- Local testing can be done by setting `TELEMETRY_METRICS_BACKEND=prometheus` and accessing http://localhost:9090/metrics

## Notes

The services already call `telemetry_batteries::init()` which automatically reads these environment variables. No code changes are required - metrics can be enabled purely through configuration.