### PR TITLE
fix(indexer): fail on invalid stored authenticator values

### DIFF
--- a/services/indexer/src/db/accounts.rs
+++ b/services/indexer/src/db/accounts.rs
@@ -1,4 +1,4 @@
-use crate::db::DBResult;
+use crate::{db::DBResult, invalid_field};
 use alloy::primitives::{Address, U160, U256};
 use core::fmt;
 use futures_util::{Stream, StreamExt as _};
@@ -396,24 +396,46 @@ where
     ///
     /// Removed authenticators are preserved as `None` entries so caller logic keeps slot positions.
     fn map_authenticator_addresses(row: &PgRow) -> DBResult<Vec<Option<Address>>> {
-        Ok(row
-            .get::<Json<Vec<Option<String>>>, _>("authenticator_addresses")
+        row.get::<Json<Vec<Option<String>>>, _>("authenticator_addresses")
             .0
-            .iter()
-            .map(|opt| opt.as_ref().and_then(|value| value.parse::<Address>().ok()))
-            .collect())
+            .into_iter()
+            .enumerate()
+            .map(|(idx, maybe_addr)| {
+                maybe_addr
+                    .map(|value| {
+                        value.parse::<Address>().map_err(|_| {
+                            invalid_field!(
+                                format!("authenticator_addresses[{idx}]"),
+                                "failed to parse address"
+                            )
+                        })
+                    })
+                    .transpose()
+            })
+            .collect()
     }
 
     /// Maps authenticator public keys from DB JSON into the full slot list stored for the account.
     ///
     /// Removed authenticators are preserved as `None` entries so caller logic keeps slot positions.
     fn map_authenticator_pub_keys(row: &PgRow) -> DBResult<Vec<Option<U256>>> {
-        Ok(row
-            .get::<Json<Vec<Option<String>>>, _>("authenticator_pubkeys")
+        row.get::<Json<Vec<Option<String>>>, _>("authenticator_pubkeys")
             .0
-            .iter()
-            .map(|opt| opt.as_ref().and_then(|value| value.parse::<U256>().ok()))
-            .collect())
+            .into_iter()
+            .enumerate()
+            .map(|(idx, maybe_pubkey)| {
+                maybe_pubkey
+                    .map(|value| {
+                        value.parse::<U256>().map_err(|_| {
+                            invalid_field!(
+                                format!("authenticator_pubkeys[{idx}]"),
+                                "failed to parse U256"
+                            )
+                        })
+                    })
+                    .transpose()
+            })
+            .collect()
     }
 
     fn map_latest_event_id(row: &PgRow) -> DBResult<AccountLatestEventId> {

--- a/services/indexer/tests/db_tests.rs
+++ b/services/indexer/tests/db_tests.rs
@@ -2,7 +2,8 @@ mod helpers;
 
 use alloy::primitives::{Address, U256};
 use helpers::db_helpers::*;
-use world_id_indexer::db::IsolationLevel;
+use serde_json::json;
+use world_id_indexer::db::{DBError, IsolationLevel};
 
 /// Test inserting an account
 #[tokio::test]
@@ -46,6 +47,78 @@ async fn test_insert_account() {
     );
     assert_eq!(account.offchain_signer_commitment, commitment);
     // Cleanup happens automatically when test_db is dropped
+}
+
+/// Invalid non-null authenticator address JSON should fail account decoding.
+#[tokio::test]
+async fn test_get_account_fails_on_invalid_authenticator_address_json() {
+    let test_db = create_unique_test_db().await;
+    let db = &test_db.db;
+
+    let leaf_index = 1u64;
+    db.accounts()
+        .insert(
+            leaf_index,
+            &Address::ZERO,
+            &[Address::from([1u8; 20])],
+            &[U256::from(123)],
+            &U256::from(456),
+            100,
+            0,
+        )
+        .await
+        .unwrap();
+
+    sqlx::query("UPDATE accounts SET authenticator_addresses = $1 WHERE leaf_index = $2")
+        .bind(json!(["not-an-address"]))
+        .bind(leaf_index as i64)
+        .execute(db.pool())
+        .await
+        .unwrap();
+
+    let err = db.accounts().get_account(leaf_index).await.unwrap_err();
+    assert!(matches!(
+        err,
+        DBError::InvalidEventField { field, .. } if field == "authenticator_addresses[0]"
+    ));
+}
+
+/// Invalid non-null authenticator pubkey JSON should fail pubkey decoding.
+#[tokio::test]
+async fn test_get_authenticator_pubkeys_fails_on_invalid_pubkey_json() {
+    let test_db = create_unique_test_db().await;
+    let db = &test_db.db;
+
+    let leaf_index = 1u64;
+    db.accounts()
+        .insert(
+            leaf_index,
+            &Address::ZERO,
+            &[Address::from([1u8; 20])],
+            &[U256::from(123)],
+            &U256::from(456),
+            100,
+            0,
+        )
+        .await
+        .unwrap();
+
+    sqlx::query("UPDATE accounts SET authenticator_pubkeys = $1 WHERE leaf_index = $2")
+        .bind(json!(["not-a-u256"]))
+        .bind(leaf_index as i64)
+        .execute(db.pool())
+        .await
+        .unwrap();
+
+    let err = db
+        .accounts()
+        .get_offchain_signer_commitment_and_authenticator_pubkeys_by_leaf_index(leaf_index)
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        err,
+        DBError::InvalidEventField { field, .. } if field == "authenticator_pubkeys[0]"
+    ));
 }
 
 /// Test duplicate insert is handled gracefully (idempotent)


### PR DESCRIPTION
### Problem

Account decoding in the indexer DB layer treated invalid non-null authenticator entries as `None` by using lossy parsing
`.ok()`, which can hide data corruption as if authenticators were intentionally removed.

### Solution

Made authenticator decoding strict in `accounts` mapping:

- Keep `null` values as `None` to preserve sparse slot semantics.
- Return `DBError::InvalidEventField` when a non-null authenticator address or pubkey fails to parse, including the slot index in the field name for easier debugging.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightens DB decoding to error on previously tolerated malformed authenticator data, which could surface as new runtime failures if any existing rows contain bad JSON strings.
> 
> **Overview**
> **Makes account decoding strict for stored authenticator slots.** `accounts` mapping now preserves `null` entries as `None` but returns `DBError::InvalidEventField` (with slot index like `authenticator_addresses[0]` / `authenticator_pubkeys[0]`) when a non-null JSON string fails to parse.
> 
> **Adds regression coverage.** New DB tests corrupt the stored JSON for authenticator addresses/pubkeys and assert the corresponding indexed `InvalidEventField` error is returned.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cb9f8847bbf9b09d6c83ba4ef77f04531ff28f08. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->