### PR TITLE
fix(indexer): prevent panics in inclusion-proof handler

### DIFF
--- a/crates/core/tests/e2e_authenticator_insert_update_remove.rs
+++ b/crates/core/tests/e2e_authenticator_insert_update_remove.rs
@@ -72,7 +72,7 @@ fn make_inclusion_proof(
         inclusion_proof,
         ..
     } = single_leaf_merkle_fixture(pubkeys, leaf_index).unwrap();
-    AccountInclusionProof::<{ TREE_DEPTH }>::new(inclusion_proof, key_set).unwrap()
+    AccountInclusionProof::<{ TREE_DEPTH }>::new(inclusion_proof, key_set)
 }
 
 // Derives keys from seed using same logic as Authenticator's internal Signer

--- a/crates/core/tests/generate_proof.rs
+++ b/crates/core/tests/generate_proof.rs
@@ -181,8 +181,7 @@ async fn e2e_authenticator_generate_proof() -> Result<()> {
         .wrap_err("failed to construct merkle fixture")?;
 
     let inclusion_proof =
-        AccountInclusionProof::<{ TREE_DEPTH }>::new(merkle_inclusion_proof, key_set.clone())
-            .wrap_err("failed to build inclusion proof")?;
+        AccountInclusionProof::<{ TREE_DEPTH }>::new(merkle_inclusion_proof, key_set.clone());
 
     let (indexer_url, indexer_handle) = spawn_indexer_stub(leaf_index, inclusion_proof.clone())
         .await

--- a/crates/primitives/src/merkle.rs
+++ b/crates/primitives/src/merkle.rs
@@ -1,6 +1,4 @@
-use crate::{
-    FieldElement, PrimitiveError, authenticator::AuthenticatorPublicKeySet, serde_utils::hex_u64,
-};
+use crate::{FieldElement, authenticator::AuthenticatorPublicKeySet, serde_utils::hex_u64};
 use ark_bn254::Fr;
 use serde::{Deserialize, Deserializer, Serialize, Serializer, de::Error as _};
 
@@ -96,18 +94,14 @@ pub struct AccountInclusionProof<const TREE_DEPTH: usize> {
 
 impl<const TREE_DEPTH: usize> AccountInclusionProof<TREE_DEPTH> {
     /// Creates a new account inclusion proof.
-    ///
-    /// # Errors
-    /// Returns an error if the number of authenticator public keys exceeds `MAX_AUTHENTICATOR_KEYS`.
-    #[allow(clippy::missing_const_for_fn)]
-    pub fn new(
+    pub const fn new(
         inclusion_proof: MerkleInclusionProof<TREE_DEPTH>,
         authenticator_pubkeys: AuthenticatorPublicKeySet,
-    ) -> Result<Self, PrimitiveError> {
-        Ok(Self {
+    ) -> Self {
+        Self {
             inclusion_proof,
             authenticator_pubkeys,
-        })
+        }
     }
 }
 

--- a/services/gateway/tests/test_inflight.rs
+++ b/services/gateway/tests/test_inflight.rs
@@ -165,7 +165,7 @@ fn make_inclusion_proof(
         inclusion_proof,
         ..
     } = single_leaf_merkle_fixture(pubkeys, leaf_index).unwrap();
-    AccountInclusionProof::<{ TREE_DEPTH }>::new(inclusion_proof, key_set).unwrap()
+    AccountInclusionProof::<{ TREE_DEPTH }>::new(inclusion_proof, key_set)
 }
 
 fn derive_keys_from_seed(seed: [u8; 32]) -> (EdDSAPublicKey, Address) {

--- a/services/indexer/src/routes/inclusion_proof.rs
+++ b/services/indexer/src/routes/inclusion_proof.rs
@@ -117,8 +117,19 @@ pub(crate) async fn handler(
     // Convert proof siblings to FieldElement array
     let siblings_vec: Vec<FieldElement> = proof_to_vec(&proof)
         .into_iter()
-        .map(|u| u.try_into().unwrap())
-        .collect();
+        .enumerate()
+        .map(|(sibling_index, sibling)| {
+            sibling.try_into().map_err(|err| {
+                tracing::error!(
+                    leaf_index = %leaf_index,
+                    sibling_index,
+                    sibling = %sibling,
+                    "Failed to convert sibling hash to field element: {err}"
+                );
+                IndexerErrorResponse::internal_server_error()
+            })
+        })
+        .collect::<Result<_, _>>()?;
 
     // Pad the siblings array to TREE_DEPTH (the compile-time constant used in the type system)
     // This is needed because the actual tree may have a smaller depth (e.g., 6 in tests)
@@ -130,10 +141,17 @@ pub(crate) async fn handler(
         }
     }
 
-    let merkle_proof = MerkleInclusionProof::new(root.try_into().unwrap(), leaf_index, siblings);
+    let root = root.try_into().map_err(|err| {
+        tracing::error!(
+            leaf_index = %leaf_index,
+            root = %root,
+            "Failed to convert Merkle root to field element: {err}"
+        );
+        IndexerErrorResponse::internal_server_error()
+    })?;
+    let merkle_proof = MerkleInclusionProof::new(root, leaf_index, siblings);
 
-    let resp = AccountInclusionProof::new(merkle_proof, authenticator_pubkeys)
-        .expect("authenticator_pubkeys already validated");
+    let resp = AccountInclusionProof::new(merkle_proof, authenticator_pubkeys);
     Ok(Json(resp))
 }
 

--- a/tools/generate-solidity-fixtures/src/main.rs
+++ b/tools/generate-solidity-fixtures/src/main.rs
@@ -145,8 +145,7 @@ async fn main() -> Result<()> {
         .wrap_err("failed to construct merkle fixture")?;
 
     let inclusion_proof =
-        AccountInclusionProof::<{ TREE_DEPTH }>::new(merkle_inclusion_proof, key_set.clone())
-            .wrap_err("failed to build inclusion proof")?;
+        AccountInclusionProof::<{ TREE_DEPTH }>::new(merkle_inclusion_proof, key_set.clone());
 
     let (indexer_url, indexer_handle) = spawn_indexer_stub(leaf_index, inclusion_proof.clone())
         .await


### PR DESCRIPTION
### Problem

The `/inclusion-proof` route had `unwrap`/`expect` calls in the request path (sibling conversion, root conversion, and response construction). Unexpected invalid internal data could panic the handler.

### Solution

Replaced panic paths with fallible conversions and `IndexerErrorResponse::internal_server_error()` returns, and added contextual error logs (leaf_index, sibling index/value, root) to preserve observability without crashing.

### Side Note

I made the `AccountInclusionProof::new` to return `Self` instead of a `Result` because there wasn't any error handling in that fn.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the `AccountInclusionProof::new` API from fallible to infallible and adjusts multiple call sites, which could affect downstream compilation/assumptions. Runtime risk is low and primarily improves robustness by turning previous panic paths into 500 responses with logs.
> 
> **Overview**
> Prevents panics in the indexer `/inclusion-proof` route by replacing `unwrap`/`expect` conversions (siblings and root) with fallible `try_into` handling that logs context (`leaf_index`, `sibling_index`/value, `root`) and returns `internal_server_error`.
> 
> Makes `AccountInclusionProof::new` an infallible `const fn` returning `Self` (removing the unused error path), and updates tests/fixture generators to stop unwrapping/wrapping errors when constructing inclusion proofs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e6709ec120b92008be52725e6f401dfa2d6304a4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->