### PR TITLE
fix(indexer): reject BATCH_SIZE=0 and log fallback to default

### DIFF
--- a/services/indexer/src/config.rs
+++ b/services/indexer/src/config.rs
@@ -168,15 +168,29 @@ pub struct IndexerConfig {
 
 impl IndexerConfig {
     pub fn from_env() -> Self {
+        let batch_size = std::env::var("BATCH_SIZE")
+            .ok()
+            .and_then(|raw| match raw.parse::<u64>() {
+                Ok(0) => {
+                    tracing::warn!("BATCH_SIZE=0 is not allowed; defaulting to BATCH_SIZE=64");
+                    None
+                }
+                Ok(value) => Some(value),
+                Err(_) => {
+                    tracing::warn!(
+                        "Failed to parse BATCH_SIZE into u64; defaulting to BATCH_SIZE=64"
+                    );
+                    None
+                }
+            })
+            .unwrap_or(64);
+
         let config = Self {
             start_block: std::env::var("START_BLOCK")
                 .ok()
                 .and_then(|s| s.parse().ok())
                 .unwrap_or(0),
-            batch_size: std::env::var("BATCH_SIZE")
-                .ok()
-                .and_then(|s| s.parse().ok())
-                .unwrap_or(64),
+            batch_size,
             tree_max_block_age: std::env::var("TREE_MAX_BLOCK_AGE")
                 .ok()
                 .and_then(|s| s.parse().ok())
@@ -724,6 +738,11 @@ mod tests {
         set_env("BATCH_SIZE", "10000");
         let config = IndexerConfig::from_env();
         assert_eq!(config.batch_size, 10000);
+
+        // Zero is invalid and should fall back to the default.
+        set_env("BATCH_SIZE", "0");
+        let config = IndexerConfig::from_env();
+        assert_eq!(config.batch_size, 64);
     }
 
     #[test]


### PR DESCRIPTION
### Problem

`BATCH_SIZE` accepted 0 from env configuration, but the indexer backfill logic assumes a batch size of at least 1, in particular the `fetch_logs_in_batches` fn. This could lead to invalid range progression behavior. In particular, the `stream::try_unfold` would keep looping over the same `current_block` instead of increasing it every iteration.

### Solution

Updated indexer config parsing to explicitly detect `BATCH_SIZE=0`, log a `tracing::warn!` explaining that 0 is not allowed, and fall back to the default value `64`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes env parsing for `BATCH_SIZE` and extends tests; runtime behavior changes only for invalid/unsupported values (0 or non-numeric).
> 
> **Overview**
> **Prevents invalid indexer batch configuration.** `IndexerConfig::from_env` now treats `BATCH_SIZE=0` as invalid (and improves handling of parse failures), emitting a `tracing::warn!` and falling back to the default `64` instead of accepting `0`.
> 
> Tests are updated to assert the new fallback behavior when `BATCH_SIZE` is set to `0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bc4cc0fa5ddfe3ab212b5742e50c5ef7b4d457ef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->