### PR TITLE
perf(indexer): avoid cloning BlockchainEvent in event processing loop

### DIFF
--- a/services/indexer/src/lib.rs
+++ b/services/indexer/src/lib.rs
@@ -342,9 +342,9 @@ async fn run_both(
 
 pub async fn handle_registry_event<'a>(
     events_committer: &mut EventsCommitter<'a>,
-    event: &BlockchainEvent<RegistryEvent>,
+    event: BlockchainEvent<RegistryEvent>,
 ) -> IndexerResult<()> {
-    events_committer.handle_event(event.clone()).await?;
+    events_committer.handle_event(event).await?;
     Ok(())
 }
 
@@ -387,46 +387,49 @@ pub async fn process_registry_events(
 
         while let Some(event) = stream.next().await {
             match event {
-                Ok(event) => match handle_registry_event(&mut events_committer, &event).await {
-                    Ok(()) => {
-                        crate::metrics::set_chain_processed_block(event.block_number);
-                    }
-                    Err(IndexerError::ReorgDetected {
-                        block_number,
-                        reason,
-                    }) => {
-                        tracing::warn!(
+                Ok(event) => {
+                    let block_number = event.block_number;
+                    match handle_registry_event(&mut events_committer, event).await {
+                        Ok(()) => {
+                            crate::metrics::set_chain_processed_block(block_number);
+                        }
+                        Err(IndexerError::ReorgDetected {
                             block_number,
                             reason,
-                            "Reorg detected during event commit, rolling back"
-                        );
-                        match rollback_to_last_valid_root(
-                            db,
-                            &http_provider,
-                            registry_address,
-                            &versioned_tree,
-                        )
-                        .await
-                        {
-                            Ok(Some(target)) => {
-                                tracing::info!(?target, "rolled back successfully");
-                                return Err(IndexerError::ReorgDetected {
-                                    block_number: target.block_number,
-                                    reason: "rolled back to last valid root, restart required"
-                                        .to_string(),
-                                });
+                        }) => {
+                            tracing::warn!(
+                                block_number,
+                                reason,
+                                "Reorg detected during event commit, rolling back"
+                            );
+                            match rollback_to_last_valid_root(
+                                db,
+                                &http_provider,
+                                registry_address,
+                                &versioned_tree,
+                            )
+                            .await
+                            {
+                                Ok(Some(target)) => {
+                                    tracing::info!(?target, "rolled back successfully");
+                                    return Err(IndexerError::ReorgDetected {
+                                        block_number: target.block_number,
+                                        reason: "rolled back to last valid root, restart required"
+                                            .to_string(),
+                                    });
+                                }
+                                Ok(None) => {
+                                    return Err(IndexerError::ReorgDetected {
+                                        block_number,
+                                        reason: "no valid root found during rollback".to_string(),
+                                    });
+                                }
+                                Err(e) => return Err(e),
                             }
-                            Ok(None) => {
-                                return Err(IndexerError::ReorgDetected {
-                                    block_number,
-                                    reason: "no valid root found during rollback".to_string(),
-                                });
-                            }
-                            Err(e) => return Err(e),
                         }
+                        Err(e) => return Err(e),
                     }
-                    Err(e) => return Err(e),
-                },
+                }
                 Err(e) => {
                     tracing::error!(?e, "blockchain event stream error");
                     break;

--- a/services/indexer/tests/test_tree_unit.rs
+++ b/services/indexer/tests/test_tree_unit.rs
@@ -496,11 +496,11 @@ async fn test_handle_registry_event_root_mismatch() {
     };
 
     // Process the create event (just buffers, no commit)
-    let result = handle_registry_event(&mut committer, &create_event).await;
+    let result = handle_registry_event(&mut committer, create_event).await;
     assert!(result.is_ok());
 
     // Process the root event — triggers commit + sync + root check
-    let result = handle_registry_event(&mut committer, &root_event).await;
+    let result = handle_registry_event(&mut committer, root_event).await;
     assert!(
         result.is_err(),
         "should fail because tree root doesn't match any DB root"
@@ -556,10 +556,10 @@ async fn test_handle_registry_event_root_match() {
         }),
     };
 
-    let result = handle_registry_event(&mut committer, &create_event).await;
+    let result = handle_registry_event(&mut committer, create_event).await;
     assert!(result.is_ok());
 
-    let result = handle_registry_event(&mut committer, &root_event).await;
+    let result = handle_registry_event(&mut committer, root_event).await;
     assert!(
         result.is_ok(),
         "should succeed because tree root matches a known DB root, got: {:?}",


### PR DESCRIPTION
### Problem

The indexer hot path cloned each `BlockchainEvent` in `handle_registry_event` fn, adding unnecessary allocations.

### Solution

Changed `handle_registry_event` to take `BlockchainEvent<RegistryEvent>` by value and pass ownership through the loop.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk perf-focused change that only adjusts event ownership/borrowing in the indexer hot path; main risk is inadvertent behavior change from moving the event (e.g., log/metric fields needing to be captured before the move).
> 
> **Overview**
> Avoids cloning `BlockchainEvent` on the indexer hot path by changing `handle_registry_event` to take the event by value and passing ownership from the stream loop.
> 
> Updates `process_registry_events` to capture `block_number` before moving the event, and adjusts unit tests to pass events by value accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cf7d6f10ef6d88ca51bac9f0b938131e7d046ba2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->