### PR TITLE
fix: assertion for orphaned error message in sweeper integration tests

### DIFF
--- a/services/gateway/tests/test_orphan_sweeper.rs
+++ b/services/gateway/tests/test_orphan_sweeper.rs
@@ -443,7 +443,7 @@ async fn sweep_stale_queued_request() {
     let record = read_record(&mut redis, "stale-queued").await.unwrap();
     match &record.status {
         GatewayRequestState::Failed { error, .. } => {
-            assert!(error.contains("orphaned"));
+            assert!(error.contains("timed out in queued state"));
         }
         other => panic!("expected Failed, got {other:?}"),
     }


### PR DESCRIPTION
This PR fixes an issue introduced by https://github.com/worldcoin/world-id-protocol/pull/536, which causes one of the sweeper test to fail due a mismatch of assertion and error test.