### PR TITLE
feat: add metrics for rejected requests (rate limiting, in-flight)

### DIFF
--- a/services/gateway/src/metrics.rs
+++ b/services/gateway/src/metrics.rs
@@ -19,6 +19,9 @@ pub const METRICS_BATCH_POLICY_DEFER: &str = "batch.policy.defer";
 pub const METRICS_BATCH_POLICY_FORCE_SEND: &str = "batch.policy.force_send";
 pub const METRICS_BATCH_POLICY_TARGET_SIZE: &str = "batch.policy.target_size";
 
+// Request rejection metrics
+pub const METRICS_REQUEST_REJECTED: &str = "request.rejected";
+
 pub fn describe_metrics() {
     ::metrics::describe_histogram!(
         METRICS_HTTP_LATENCY_MS,
@@ -88,6 +91,12 @@ pub fn describe_metrics() {
         ::metrics::Unit::Count,
         "Number of policy deferrals by reason."
     );
+
+    ::metrics::describe_counter!(
+        METRICS_REQUEST_REJECTED,
+        ::metrics::Unit::Count,
+        "Number of rejected requests by reason."
+    );
 }
 
 pub fn record_http_latency_ms(path: &str, status: u16, latency_ms: f64) {
@@ -151,6 +160,10 @@ pub fn increment_policy_force_send(batch_type: &'static str) {
 pub fn increment_policy_defer(batch_type: &'static str, reason: &'static str) {
     ::metrics::counter!(METRICS_BATCH_POLICY_DEFER, "type" => batch_type, "reason" => reason)
         .increment(1);
+}
+
+pub fn increment_request_rejected(reason: &'static str) {
+    ::metrics::counter!(METRICS_REQUEST_REJECTED, "reason" => reason).increment(1);
 }
 
 fn normalize_path(path: &str) -> String {

--- a/services/gateway/src/request_tracker.rs
+++ b/services/gateway/src/request_tracker.rs
@@ -10,6 +10,7 @@ use crate::{
     batch_policy::BacklogUrgencyStats,
     config::RateLimitConfig,
     error::{GatewayErrorResponse, GatewayResult},
+    metrics,
 };
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct RequestRecord {
@@ -179,6 +180,7 @@ impl RequestTracker {
                     key = %duplicate_key,
                     "Duplicate in-flight request detected"
                 );
+                metrics::increment_request_rejected("duplicate_inflight");
                 Err(GatewayErrorResponse::bad_request(
                     GatewayErrorCode::DuplicateRequestInFlight,
                 ))
@@ -515,6 +517,7 @@ impl RequestTracker {
                     request_id = request_id,
                     "Rate limit exceeded"
                 );
+                metrics::increment_request_rejected("rate_limited");
                 Err(GatewayErrorResponse::rate_limit_exceeded(
                     window_secs,
                     max_requests,


### PR DESCRIPTION
Adds metrics for rejected requests due to rate limiting or in-flight duplicate detection.