### PR TITLE
fix: ohttp qemu emulation for local dev

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -106,6 +106,7 @@ services:
       - POSTGRES_DB=postgres
   ohttp-gateway:
     image: ghcr.io/worldcoin/world-id-protocol/ohttp-gateway:latest
+    platform: linux/amd64
     ports:
       - "9090:8080"
     environment:


### PR DESCRIPTION
Use qemu emulation for local dev on macOS. Upstream image requires amd64.