### PR TITLE
chore: remove unused error variant

### DIFF
--- a/crates/authenticator/src/authenticator.rs
+++ b/crates/authenticator/src/authenticator.rs
@@ -1092,10 +1092,6 @@ pub enum AuthenticatorError {
     #[error("Account is not registered for this authenticator.")]
     AccountDoesNotExist,
 
-    /// The account already exists for this authenticator. Call `leaf_index` to get the leaf index.
-    #[error("Account already exists for this authenticator.")]
-    AccountAlreadyExists,
-
     /// An error occurred while interacting with the EVM contract.
     #[error("Error interacting with EVM contract: {0}")]
     ContractError(#[from] alloy::contract::Error),


### PR DESCRIPTION
`AccountAlreadyExists` is not used. Also, I'm not sure if this error variant actually has any meaning in general. We reject duplicate in-flights at the gateway level. After an account with a specific authenticator has been created, there is nothing stopping the user from using the same authenticator for another account on the protocol level.