### PR TITLE
feat: introduce V2 verifier enforcing action check

### DIFF
--- a/contracts/src/core/WorldIDVerifierV2Unreleased.sol
+++ b/contracts/src/core/WorldIDVerifierV2Unreleased.sol
@@ -17,9 +17,9 @@ import {IWorldIDVerifier} from "./interfaces/IWorldIDVerifier.sol";
  */
 contract WorldIDVerifierV2 is WorldIDVerifier {
     /**
-     * @dev Thrown when the inner action of the sessionNullifier is not valid. The prefix is enforced
+     * @dev Thrown when the action is not valid for the type of proof. The prefix is enforced
      *  to ensure any nullifier request for a Uniqueness Proof is signed by the RP (actions
-     *  without this prefix, i.e. for sessions, don't need to be signed).
+     *  without this prefix, i.e. for sessions, it doesn't need to be signed).
      */
     error InvalidAction();
 
@@ -51,6 +51,37 @@ contract WorldIDVerifierV2 is WorldIDVerifier {
             // For Uniqueness Proofs, the `session_id` is not used, hence the constraint defaults to 0
             // To verify a Session Proof use `verifySession` instead.
             0,
+            zeroKnowledgeProof
+        );
+    }
+
+    /// @inheritdoc IWorldIDVerifier
+    function verifySession(
+        uint64 rpId,
+        uint256 nonce,
+        uint256 signalHash,
+        uint64 expiresAtMin,
+        uint64 issuerSchemaId,
+        uint256 credentialGenesisIssuedAtMin,
+        uint256 sessionId,
+        uint256[2] calldata sessionNullifier,
+        uint256[5] calldata zeroKnowledgeProof
+    ) external view virtual override onlyProxy onlyInitialized {
+        uint256 action = sessionNullifier[1];
+        if (uint8(action >> 248) != uint8(2)) {
+            revert InvalidAction();
+        }
+
+        verifyProofAndSignals(
+            sessionNullifier[0],
+            action,
+            rpId,
+            nonce,
+            signalHash,
+            expiresAtMin,
+            issuerSchemaId,
+            credentialGenesisIssuedAtMin,
+            sessionId,
             zeroKnowledgeProof
         );
     }

--- a/contracts/test/core/WorldIDVerifierV2Test.t.sol
+++ b/contracts/test/core/WorldIDVerifierV2Test.t.sol
@@ -77,6 +77,65 @@ contract WorldIDVerifierV2Test is Test {
         );
     }
 
+    function test_SessionRevertsWhenActionMissing0x02Prefix() public {
+        // Action with 0x00 prefix (valid for uniqueness, not for session)
+        uint256 action = 0x00d4b66e5417cb9875f6a2b5be9814dca80651d7c74b3b21685fdd494566e7;
+        uint256 sessionId = 1;
+
+        vm.warp(expiresAtMin + 1 hours);
+        vm.expectRevert(abi.encodeWithSelector(WorldIDVerifierV2.InvalidAction.selector));
+        verifier.verifySession(
+            rpIdCorrect,
+            nonce,
+            signalHash,
+            expiresAtMin,
+            credentialIssuerIdCorrect,
+            0,
+            sessionId,
+            [nullifier, action],
+            proof
+        );
+    }
+
+    function testFuzz_SessionRevertsWhenActionPrefixNot0x02(uint256 action) public {
+        vm.assume(uint8(action >> 248) != 2);
+        uint256 sessionId = 1;
+
+        vm.warp(expiresAtMin + 1 hours);
+        vm.expectRevert(abi.encodeWithSelector(WorldIDVerifierV2.InvalidAction.selector));
+        verifier.verifySession(
+            rpIdCorrect,
+            nonce,
+            signalHash,
+            expiresAtMin,
+            credentialIssuerIdCorrect,
+            0,
+            sessionId,
+            [nullifier, action],
+            proof
+        );
+    }
+
+    function test_SessionPassesActionCheckWhenFirstByte0x02() public {
+        // Action with correct 0x02 prefix — passes prefix check but fails proof verification
+        uint256 action = 0x0200000000000000000000000000000000000000000000000000000000000001;
+        uint256 sessionId = 1;
+
+        vm.warp(expiresAtMin + 1 hours);
+        vm.expectRevert(abi.encodeWithSelector(Verifier.ProofInvalid.selector));
+        verifier.verifySession(
+            rpIdCorrect,
+            nonce,
+            signalHash,
+            expiresAtMin,
+            credentialIssuerIdCorrect,
+            0,
+            sessionId,
+            [nullifier, action],
+            proof
+        );
+    }
+
     function test_PassesActionCheckWhenFirstByteZero() public {
         // passes the prefix check but fails proof verification
         uint256 action = 0x00d4b66e5417cb9875f6a2b5be9814dca80651d7c74b3b21685fdd494566e7;


### PR DESCRIPTION
- When verifying a uniqueness proof, check the action has the right prefix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new verifier logic in a core proof-validation contract (even if marked unreleased), where incorrect prefix checks could reject valid proofs or accept unintended actions once deployed/upgraded.
> 
> **Overview**
> Adds an *unreleased* `WorldIDVerifierV2` contract that tightens input validation by enforcing an `action` prefix: `verify` (uniqueness) now requires the top byte to be `0x00`, while `verifySession` requires `0x02` and extracts `action` from `sessionNullifier[1]`, reverting with `InvalidAction` otherwise.
> 
> Adds a new Foundry test suite (`WorldIDVerifierV2Test`) that deploys the verifier behind an `ERC1967Proxy` and asserts the new prefix checks revert appropriately (including fuzz cases) and that correctly-prefixed actions proceed to normal proof verification.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d5f4534e7e25a4bef924ca2f67a61339c5d897ad. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->