### PR TITLE
feat: Add indexer endpoint for pending recovery agent

### DIFF
--- a/crates/primitives/src/api_types.rs
+++ b/crates/primitives/src/api_types.rs
@@ -439,6 +439,19 @@ pub struct IndexerRecoveryAgentResponse {
     pub recovery_agent: Address,
 }
 
+/// Response containing the pending recovery agent from the indexer.
+#[derive(Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+pub struct IndexerPendingRecoveryAgentResponse {
+    /// The pending recovery agent for the World ID.
+    ///
+    /// Please note this may be the zero address if no recovery agent update is pending.
+    ///
+    /// Serialized as a canonical `0x`-prefixed hex string.
+    #[cfg_attr(feature = "openapi", schema(value_type = String, format = "hex", example = "0x0"))]
+    pub pending_recovery_agent: Address,
+}
+
 /// Response containing authenticator public keys for an account from the indexer.
 #[derive(Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]

--- a/crates/primitives/src/api_types.rs
+++ b/crates/primitives/src/api_types.rs
@@ -450,6 +450,15 @@ pub struct IndexerPendingRecoveryAgentResponse {
     /// Serialized as a canonical `0x`-prefixed hex string.
     #[cfg_attr(feature = "openapi", schema(value_type = String, format = "hex", example = "0x0"))]
     pub pending_recovery_agent: Address,
+
+    /// The earliest timestamp at which the pending recovery agent update may be executed.
+    ///
+    /// Please note this may be zero if no recovery agent update is pending.
+    ///
+    /// Serialized as a canonical `0x`-prefixed hex string.
+    #[serde(with = "hex_u256")]
+    #[cfg_attr(feature = "openapi", schema(value_type = String, format = "hex", example = "0x0"))]
+    pub execute_after: U256,
 }
 
 /// Response containing authenticator public keys for an account from the indexer.

--- a/services/indexer/src/routes.rs
+++ b/services/indexer/src/routes.rs
@@ -3,13 +3,14 @@ use axum::{Json, Router, middleware::from_fn, response::IntoResponse};
 use utoipa::OpenApi;
 use world_id_core::api_types::{
     AccountInclusionProofSchema, IndexerAuthenticatorPubkeysResponse, IndexerPackedAccountRequest,
-    IndexerPackedAccountResponse, IndexerQueryRequest, IndexerRecoveryAgentResponse,
-    IndexerSignatureNonceResponse,
+    IndexerPackedAccountResponse, IndexerPendingRecoveryAgentResponse, IndexerQueryRequest,
+    IndexerRecoveryAgentResponse, IndexerSignatureNonceResponse,
 };
 
 use crate::config::AppState;
 mod get_authenticator_pubkeys;
 mod get_packed_account;
+mod get_pending_recovery_agent;
 mod get_recovery_agent;
 mod get_signature_nonce;
 mod health;
@@ -23,6 +24,7 @@ mod middleware;
         get_packed_account::handler,
         get_signature_nonce::handler,
         get_recovery_agent::handler,
+        get_pending_recovery_agent::handler,
         inclusion_proof::handler,
     ),
     components(schemas(
@@ -32,6 +34,7 @@ mod middleware;
         IndexerQueryRequest,
         IndexerSignatureNonceResponse,
         IndexerRecoveryAgentResponse,
+        IndexerPendingRecoveryAgentResponse,
         AccountInclusionProofSchema,
         IndexerErrorBody,
     )),
@@ -66,6 +69,10 @@ pub(crate) fn handler(state: AppState, request_timeout_secs: u64) -> Router {
         .route(
             "/recovery-agent",
             axum::routing::post(get_recovery_agent::handler),
+        )
+        .route(
+            "/pending-recovery-agent",
+            axum::routing::post(get_pending_recovery_agent::handler),
         )
         .route("/health", axum::routing::get(health::handler))
         .route("/openapi.json", axum::routing::get(openapi))

--- a/services/indexer/src/routes/get_pending_recovery_agent.rs
+++ b/services/indexer/src/routes/get_pending_recovery_agent.rs
@@ -1,0 +1,61 @@
+use crate::error::IndexerErrorResponse;
+use axum::{Json, extract::State};
+use world_id_core::api_types::{
+    IndexerErrorCode, IndexerPendingRecoveryAgentResponse, IndexerQueryRequest,
+};
+
+use crate::config::AppState;
+
+/// Get the pending recovery agent for a particular World ID given its leaf index.
+///
+/// If no recovery agent update is pending, the zero address is returned.
+#[utoipa::path(
+    post,
+    path = "/pending-recovery-agent",
+    request_body = IndexerQueryRequest,
+    responses(
+        (status = 200, body = IndexerPendingRecoveryAgentResponse),
+    ),
+    tag = "indexer"
+)]
+pub(crate) async fn handler(
+    State(state): State<AppState>,
+    Json(req): Json<IndexerQueryRequest>,
+) -> Result<Json<IndexerPendingRecoveryAgentResponse>, IndexerErrorResponse> {
+    if req.leaf_index == 0 {
+        return Err(IndexerErrorResponse::bad_request(
+            IndexerErrorCode::InvalidLeafIndex,
+            "Account index cannot be zero".to_string(),
+        ));
+    }
+
+    if !state
+        .db
+        .accounts()
+        .get_account_exists(req.leaf_index)
+        .await
+        .map_err(|e| {
+            tracing::error!("DB error checking account existence: {}", e);
+            IndexerErrorResponse::internal_server_error()
+        })?
+    {
+        return Err(IndexerErrorResponse::bad_request(
+            IndexerErrorCode::AccountDoesNotExist,
+            "Leaf index does not exist.".to_string(),
+        ));
+    }
+
+    let pending_recovery_agent_update = state
+        .registry
+        .getPendingRecoveryAgentUpdate(req.leaf_index)
+        .call()
+        .await
+        .map_err(|e| {
+            tracing::error!("RPC error getting pending recovery agent: {}", e);
+            IndexerErrorResponse::internal_server_error()
+        })?;
+
+    Ok(Json(IndexerPendingRecoveryAgentResponse {
+        pending_recovery_agent: pending_recovery_agent_update.newRecoveryAgent,
+    }))
+}

--- a/services/indexer/src/routes/get_pending_recovery_agent.rs
+++ b/services/indexer/src/routes/get_pending_recovery_agent.rs
@@ -6,9 +6,9 @@ use world_id_core::api_types::{
 
 use crate::config::AppState;
 
-/// Get the pending recovery agent for a particular World ID given its leaf index.
+/// Get the pending recovery agent update for a particular World ID given its leaf index.
 ///
-/// If no recovery agent update is pending, the zero address is returned.
+/// If no recovery agent update is pending, the zero address and zero execute-after timestamp are returned.
 #[utoipa::path(
     post,
     path = "/pending-recovery-agent",
@@ -57,5 +57,6 @@ pub(crate) async fn handler(
 
     Ok(Json(IndexerPendingRecoveryAgentResponse {
         pending_recovery_agent: pending_recovery_agent_update.newRecoveryAgent,
+        execute_after: pending_recovery_agent_update.executeAfter,
     }))
 }

--- a/services/indexer/tests/test_get_pending_recovery_agent.rs
+++ b/services/indexer/tests/test_get_pending_recovery_agent.rs
@@ -9,7 +9,6 @@ use alloy::{
     network::EthereumWallet,
     primitives::{Address, Bytes, U256, address},
     providers::{Provider, ProviderBuilder},
-    signers::local::PrivateKeySigner,
 };
 use http::StatusCode;
 use world_id_core::{
@@ -27,7 +26,10 @@ use world_id_services_common::ProviderArgs;
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_get_pending_recovery_agent_endpoint() {
     let setup = TestSetup::new().await;
-    let signer = PrivateKeySigner::random();
+    let signer = setup
+        ._anvil
+        .signer(1)
+        .expect("failed to obtain funded signer");
     let auth_addr: Address = signer.address();
     let sk = EdDSAPrivateKey::random(&mut rand::thread_rng());
     let pk = sk.public().to_compressed_bytes().unwrap();

--- a/services/indexer/tests/test_get_pending_recovery_agent.rs
+++ b/services/indexer/tests/test_get_pending_recovery_agent.rs
@@ -75,6 +75,12 @@ async fn test_get_pending_recovery_agent_endpoint() {
         .await
         .expect("initiateRecoveryAgentUpdate transaction failed");
 
+    let pending_recovery_agent_update = registry
+        .getPendingRecoveryAgentUpdate(leaf_index)
+        .call()
+        .await
+        .unwrap();
+
     let temp_cache_path =
         std::env::temp_dir().join(format!("test_cache_{}.mmap", uuid::Uuid::new_v4()));
     let global_config = GlobalConfig {
@@ -138,6 +144,12 @@ async fn test_get_pending_recovery_agent_endpoint() {
     assert_eq!(
         pending_recovery_agent.to_lowercase(),
         format!("{new_recovery_agent}").to_lowercase()
+    );
+
+    let execute_after = json["execute_after"].as_str().unwrap();
+    assert_eq!(
+        execute_after.to_lowercase(),
+        format!("0x{:x}", pending_recovery_agent_update.executeAfter).to_lowercase()
     );
 
     let resp = client

--- a/services/indexer/tests/test_get_pending_recovery_agent.rs
+++ b/services/indexer/tests/test_get_pending_recovery_agent.rs
@@ -1,0 +1,170 @@
+#![cfg(feature = "integration-tests")]
+
+mod helpers;
+use helpers::common::{TestSetup, query_count};
+
+use std::time::Duration;
+
+use alloy::{
+    network::EthereumWallet,
+    primitives::{Address, Bytes, U256, address},
+    providers::{Provider, ProviderBuilder},
+    signers::local::PrivateKeySigner,
+};
+use http::StatusCode;
+use world_id_core::{
+    EdDSAPrivateKey,
+    api_types::UpdateRecoveryAgentRequest,
+    world_id_registry::{
+        WorldIdRegistry, domain as ag_domain, sign_initiate_recovery_agent_update,
+    },
+};
+use world_id_indexer::config::{
+    Environment, GlobalConfig, HttpConfig, IndexerConfig, RunMode, TreeCacheConfig,
+};
+use world_id_services_common::ProviderArgs;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_get_pending_recovery_agent_endpoint() {
+    let setup = TestSetup::new().await;
+    let signer = PrivateKeySigner::random();
+    let auth_addr: Address = signer.address();
+    let sk = EdDSAPrivateKey::random(&mut rand::thread_rng());
+    let pk = sk.public().to_compressed_bytes().unwrap();
+    let pk = U256::from_le_slice(&pk);
+
+    setup.create_account(auth_addr, pk, 1).await;
+
+    let provider = ProviderBuilder::new()
+        .wallet(EthereumWallet::from(signer.clone()))
+        .connect_http(setup.rpc_url().parse().unwrap());
+    let registry = WorldIdRegistry::new(setup.registry_address, provider.clone());
+    let chain_id = provider.get_chain_id().await.unwrap();
+    let domain = ag_domain(chain_id, setup.registry_address);
+
+    let leaf_index = 1;
+    let new_recovery_agent = address!("0x000000000000000000000000000000000000beef");
+    let nonce = U256::ZERO;
+    let signature = sign_initiate_recovery_agent_update(
+        &signer,
+        leaf_index,
+        new_recovery_agent,
+        nonce,
+        &domain,
+    )
+    .unwrap();
+
+    let request = UpdateRecoveryAgentRequest {
+        leaf_index,
+        new_recovery_agent,
+        signature,
+        nonce,
+    };
+
+    registry
+        .initiateRecoveryAgentUpdate(
+            request.leaf_index,
+            request.new_recovery_agent,
+            Bytes::copy_from_slice(&request.signature.as_bytes()),
+            request.nonce,
+        )
+        .send()
+        .await
+        .expect("failed to submit initiateRecoveryAgentUpdate transaction")
+        .get_receipt()
+        .await
+        .expect("initiateRecoveryAgentUpdate transaction failed");
+
+    let temp_cache_path =
+        std::env::temp_dir().join(format!("test_cache_{}.mmap", uuid::Uuid::new_v4()));
+    let global_config = GlobalConfig {
+        environment: Environment::Development,
+        run_mode: RunMode::Both {
+            indexer_config: IndexerConfig {
+                start_block: 0,
+                batch_size: 1000,
+                tree_max_block_age: 1000,
+            },
+            http_config: HttpConfig {
+                http_addr: "0.0.0.0:8086".parse().unwrap(),
+                db_poll_interval_secs: 1,
+                request_timeout_secs: 10,
+                sanity_check_interval_secs: None,
+            },
+        },
+        db_url: setup.db_url.clone(),
+        provider: ProviderArgs::new().with_http_urls([setup.rpc_url()]),
+        ws_rpc_url: setup.ws_url(),
+        registry_address: setup.registry_address,
+        tree_cache: TreeCacheConfig {
+            cache_file_path: temp_cache_path.to_str().unwrap().to_string(),
+            tree_depth: 30,
+            http_cache_refresh_interval_secs: 30,
+        },
+    };
+
+    let indexer_task = tokio::spawn(async move {
+        unsafe { world_id_indexer::run_indexer(global_config).await }.unwrap();
+    });
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(15);
+    loop {
+        let c = query_count(&setup.pool).await;
+        if c >= 1 {
+            break;
+        }
+        if std::time::Instant::now() > deadline {
+            panic!("timeout waiting for backfill; count {c}");
+        }
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+
+    TestSetup::wait_for_health("http://127.0.0.1:8086").await;
+
+    let client = reqwest::Client::new();
+
+    let resp = client
+        .post("http://127.0.0.1:8086/pending-recovery-agent")
+        .json(&serde_json::json!({
+            "leaf_index": "0x1"
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let json: serde_json::Value = resp.json().await.unwrap();
+    let pending_recovery_agent = json["pending_recovery_agent"].as_str().unwrap();
+    assert_eq!(
+        pending_recovery_agent.to_lowercase(),
+        format!("{new_recovery_agent}").to_lowercase()
+    );
+
+    let resp = client
+        .post("http://127.0.0.1:8086/pending-recovery-agent")
+        .json(&serde_json::json!({
+            "leaf_index": "0x0"
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    let json: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(json["code"].as_str().unwrap(), "invalid_leaf_index");
+
+    let resp = client
+        .post("http://127.0.0.1:8086/pending-recovery-agent")
+        .json(&serde_json::json!({
+            "leaf_index": "0xFF"
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    let json: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(json["code"].as_str().unwrap(), "account_does_not_exist");
+
+    indexer_task.abort();
+}


### PR DESCRIPTION
## Summary
- add a new indexer endpoint to return the pending recovery agent for a given leaf index
- expose the new response type in shared API types and OpenAPI
- add an integration test covering success and validation failures

## Testing
- cargo check -p world-id-indexer --tests --features integration-tests
- cargo test -p world-id-indexer --features integration-tests test_get_pending_recovery_agent_endpoint -- --nocapture *(fails locally: Postgres PoolTimedOut)*
- cargo test -p world-id-indexer --features integration-tests test_get_recovery_agent_endpoint -- --nocapture *(fails locally: Postgres PoolTimedOut)*