### PR TITLE
fix: RUSTSEC-2026-0097 ack

### DIFF
--- a/.github/workflows/noir-ci.yml
+++ b/.github/workflows/noir-ci.yml
@@ -18,6 +18,8 @@ jobs:
         working-directory: ./noir
     steps:
       - uses: actions/checkout@v6
-      - run: curl -L https://raw.githubusercontent.com/noir-lang/noirup/main/install | bash
-      - run: ~/.nargo/bin/noirup
+      - uses: noir-lang/noirup@7dbe69ccc78877f0200ffa5a40836c953d2cfd8f # v0.1.4
+        with:
+          # See https://github.com/worldfnd/provekit, a specific nargo toolchain version is required
+          toolchain: v1.0.0-beta.11
       - run: cd ownership-proof && ~/.nargo/bin/nargo fmt --check && ~/.nargo/bin/nargo test

--- a/deny.toml
+++ b/deny.toml
@@ -45,5 +45,5 @@ ignore = [
     "RUSTSEC-2024-0436", # Unmaintained `paste` (2025-04-04)
     "RUSTSEC-2025-0055", # `tracing-subscriber` < 0.3.20, requires bumps on `semaphore-rs` (and Ark deps) (2025-09-09)
     "RUSTSEC-2023-0089", # Unmaintained `atomic-polyfill` (2025-04-29)
-    "RUSTSEC-2026-0049", # `rustls-webpki` (requires upstream dep updates); low severity, requires compromised CA (2026-03-23)
+    "RUSTSEC-2026-0097"  # Unsoundness in `rand@0.8.5` (2026-04-11), multiple upstream deps on `rand`. Not directly using custom logger
 ]

--- a/noir/ownership-proof/Nargo.toml
+++ b/noir/ownership-proof/Nargo.toml
@@ -8,4 +8,4 @@ backend = "provekit"
 
 [dependencies]
 poseidon2 = { tag = "v0.5.0-beta.0", git = "https://github.com/TaceoLabs/noir-poseidon", directory = "poseidon2" }
-eddsa_poseidon2 = { git = "https://github.com/TaceoLabs/oprf-service.git", tag = "taceo-oprf-v0.12.0", directory = "noir/eddsa_poseidon2" }
+eddsa_poseidon2 = { tag = "taceo-oprf-v0.12.0", git = "https://github.com/TaceoLabs/oprf-service.git", directory = "noir/eddsa_poseidon2" }

--- a/noir/ownership-proof/Nargo.toml
+++ b/noir/ownership-proof/Nargo.toml
@@ -8,4 +8,4 @@ backend = "provekit"
 
 [dependencies]
 poseidon2 = { tag = "v0.5.0-beta.0", git = "https://github.com/TaceoLabs/noir-poseidon", directory = "poseidon2" }
-eddsa_poseidon2 = { git = "https://github.com/TaceoLabs/oprf-service.git", tag = "taceo-oprf-v0.11.0", directory = "noir/eddsa_poseidon2" }
+eddsa_poseidon2 = { git = "https://github.com/TaceoLabs/oprf-service.git", tag = "taceo-oprf-v0.12.0", directory = "noir/eddsa_poseidon2" }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Pins the CI’s Noir toolchain installation and updates a cryptography-related Noir dependency; this can change test behavior and circuit outputs if versions differ. Also suppresses a new RustSec advisory, which may mask dependency unsoundness until upstream upgrades land.
> 
> **Overview**
> **Noir CI now uses a pinned `noir-lang/noirup` GitHub Action** (instead of a curl-based installer) and explicitly installs `toolchain: v1.0.0-beta.11` to match `provekit` requirements.
> 
> Updates the `ownership-proof` circuit’s `eddsa_poseidon2` dependency to `taceo-oprf-v0.12.0`, and adjusts `cargo-deny` configuration to ignore `RUSTSEC-2026-0097` (rand unsoundness) so advisory checks pass.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 530689b30813511a7f6862aadff301a33941f1fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->