### PR TITLE
fix: restore public visibility for get_packed_account_data

### DIFF
--- a/crates/authenticator/src/authenticator.rs
+++ b/crates/authenticator/src/authenticator.rs
@@ -364,6 +364,20 @@ impl Authenticator {
         }
     }
 
+    /// Re-fetches the packed account data for this authenticator from the indexer or registry.
+    ///
+    /// # Errors
+    /// Will error if the network call fails or if the account does not exist.
+    pub async fn refresh_packed_account_data(&self) -> Result<U256, AuthenticatorError> {
+        Self::get_packed_account_data(
+            self.onchain_address(),
+            self.registry().as_deref(),
+            &self.config,
+            &self.indexer_client,
+        )
+        .await
+    }
+
     /// Returns the packed account data for the holder's World ID.
     ///
     /// The packed account data is a 256 bit integer which includes the World ID's leaf index, their recovery counter,
@@ -371,7 +385,7 @@ impl Authenticator {
     ///
     /// # Errors
     /// Will error if the network call fails or if the account does not exist.
-    pub(crate) async fn get_packed_account_data(
+    async fn get_packed_account_data(
         onchain_signer_address: Address,
         registry: Option<&WorldIdRegistryInstance<DynProvider>>,
         config: &Config,


### PR DESCRIPTION
## Summary
- `get_packed_account_data` was changed from `pub` to `pub(crate)` in #641 and its signature changed to take `&ServiceClient` (a `pub(crate)` type)
- This breaks downstream consumers (walletkit) that need to re-fetch packed account data after init
- Adds a public instance method `refresh_packed_account_data(&self)` that delegates to the private static method using the authenticator's own fields
- Makes `get_packed_account_data` fully private (only used within `init`)

## Test plan
- [ ] CI passes (no behavior change, new public API surface only)