### PR TITLE
feat: ownership proof generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12234,6 +12234,7 @@ dependencies = [
  "webpki-roots 1.0.6",
  "world-id-primitives",
  "world-id-proof",
+ "world-id-test-utils",
 ]
 
 [[package]]

--- a/crates/authenticator/Cargo.toml
+++ b/crates/authenticator/Cargo.toml
@@ -20,6 +20,7 @@ include = [
 [features]
 default = ["embed-zkeys"]
 embed-zkeys = ["world-id-proof/embed-zkeys"]
+provekit = ["world-id-proof/provekit"]
 
 [dependencies]
 # Use WASM-safe base features only

--- a/crates/authenticator/Cargo.toml
+++ b/crates/authenticator/Cargo.toml
@@ -81,3 +81,4 @@ ruint = { workspace = true }
 rand = { workspace = true }
 mockito = { workspace = true }
 testcontainers = { workspace = true }
+world-id-test-utils = { workspace = true }

--- a/crates/authenticator/src/error.rs
+++ b/crates/authenticator/src/error.rs
@@ -67,6 +67,11 @@ pub enum AuthenticatorError {
     #[error("Proof request cannot be fulfilled with the provided credentials.")]
     UnfullfilableRequest,
 
+    /// Used in Ownership Proofs. The provided `blinding_factor` does not match for the
+    /// provided `sub`, ownership cannot be proven.
+    #[error("the sub or blinding factor provided do not match the expected value.")]
+    InvalidSubOrBlindingFactor,
+
     /// Error during the World ID registration process.
     ///
     /// This usually occurs from an on-chain revert.

--- a/crates/authenticator/src/prove.rs
+++ b/crates/authenticator/src/prove.rs
@@ -473,3 +473,110 @@ impl Authenticator {
         Ok(proof.whir_r1cs_proof)
     }
 }
+
+#[cfg(test)]
+#[cfg(feature = "provekit")]
+mod tests {
+    use crate::{
+        authenticator::Authenticator,
+        error::AuthenticatorError,
+        service_client::{ServiceClient, ServiceKind},
+    };
+    use alloy::primitives::address;
+    use ruint::aliases::U256;
+    use taceo_oprf::client::Connector;
+    use world_id_primitives::{
+        Config, Credential, FieldElement, Signer, TREE_DEPTH,
+        merkle::AccountInclusionProof,
+    };
+    use world_id_test_utils::fixtures::single_leaf_merkle_fixture;
+
+    fn build_test_authenticator(
+        seed: &[u8; 32],
+        leaf_index: u64,
+    ) -> (Authenticator, AccountInclusionProof<TREE_DEPTH>) {
+        let signer = Signer::from_seed_bytes(seed).expect("valid seed");
+        let pubkey = signer.offchain_signer_pubkey();
+
+        let fixture =
+            single_leaf_merkle_fixture(vec![pubkey], leaf_index).expect("valid merkle fixture");
+        let account_inclusion_proof =
+            AccountInclusionProof::new(fixture.inclusion_proof, fixture.key_set);
+
+        let config = Config::new(
+            None,
+            1,
+            address!("0x0000000000000000000000000000000000000001"),
+            "http://indexer.example.com".to_string(),
+            "http://gateway.example.com".to_string(),
+            Vec::new(),
+            2,
+        )
+        .expect("valid config");
+
+        let http_client = reqwest::Client::new();
+        let authenticator = Authenticator {
+            config: config.clone(),
+            packed_account_data: U256::from(leaf_index),
+            signer,
+            registry: None,
+            indexer_client: ServiceClient::new(
+                http_client.clone(),
+                ServiceKind::Indexer,
+                config.indexer_url(),
+                None,
+            )
+            .expect("valid indexer client"),
+            gateway_client: ServiceClient::new(
+                http_client,
+                ServiceKind::Gateway,
+                config.gateway_url(),
+                None,
+            )
+            .expect("valid gateway client"),
+            ws_connector: Connector::Plain,
+            query_material: None,
+            nullifier_material: None,
+        };
+
+        (authenticator, account_inclusion_proof)
+    }
+
+    #[tokio::test]
+    async fn test_prove_credential_sub_rejects_wrong_sub() {
+        let leaf_index = 1u64;
+        let (authenticator, inclusion_proof) = build_test_authenticator(&[42u8; 32], leaf_index);
+
+        let blinding_factor = FieldElement::from(999u64);
+        let wrong_sub = FieldElement::from(123u64);
+
+        let result = authenticator
+            .prove_credential_sub(
+                FieldElement::from(1_234_567_890u64),
+                blinding_factor,
+                wrong_sub,
+                Some(inclusion_proof),
+            )
+            .await;
+
+        assert!(matches!(
+            result,
+            Err(AuthenticatorError::InvalidSubOrBlindingFactor)
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_prove_credential_sub_succeeds_with_correct_sub() {
+        let leaf_index = 1u64;
+        let (authenticator, inclusion_proof) = build_test_authenticator(&[42u8; 32], leaf_index);
+
+        let blinding_factor = FieldElement::from(999u64);
+        let correct_sub = Credential::compute_sub(leaf_index, blinding_factor);
+        let nonce = FieldElement::from(1_234_567_890u64);
+
+        authenticator
+            .prove_credential_sub(nonce, blinding_factor, correct_sub, Some(inclusion_proof))
+            .await
+            .expect("proof generation should succeed");
+    }
+}

--- a/crates/authenticator/src/prove.rs
+++ b/crates/authenticator/src/prove.rs
@@ -432,6 +432,10 @@ impl Authenticator {
     /// - `credential_blinding_factor`: The blinding factor generated for the credential.
     /// - `sub`: The expected `sub` of the Credential in question.
     /// - `account_inclusion_proof`: An optionally cached account inclusion proof. If not provided, a new inclusion proof will be fetched.
+    ///
+    /// # Returns
+    /// - The Noir ZKP.
+    /// - The root of the Merkle tree used for inclusion in the `WorldIDRegistry`.
     #[cfg(feature = "provekit")]
     pub async fn prove_credential_sub(
         &self,
@@ -439,7 +443,7 @@ impl Authenticator {
         credential_blinding_factor: FieldElement,
         sub: FieldElement,
         account_inclusion_proof: Option<AccountInclusionProof<TREE_DEPTH>>,
-    ) -> Result<WhirR1CSProof, AuthenticatorError> {
+    ) -> Result<(WhirR1CSProof, FieldElement), AuthenticatorError> {
         use world_id_primitives::circuit_inputs::OwnershipProofCircuitInput;
         use world_id_proof::ownership_proof::generate_ownership_proof;
 
@@ -470,7 +474,8 @@ impl Authenticator {
 
         let proof = generate_ownership_proof(input)?;
 
-        Ok(proof.whir_r1cs_proof)
+        // TODO: Create a unified typed response (requires updates to ProveKit)
+        Ok((proof.whir_r1cs_proof, proof.public_inputs.0[0].into()))
     }
 }
 
@@ -486,8 +491,7 @@ mod tests {
     use ruint::aliases::U256;
     use taceo_oprf::client::Connector;
     use world_id_primitives::{
-        Config, Credential, FieldElement, Signer, TREE_DEPTH,
-        merkle::AccountInclusionProof,
+        Config, Credential, FieldElement, Signer, TREE_DEPTH, merkle::AccountInclusionProof,
     };
     use world_id_test_utils::fixtures::single_leaf_merkle_fixture;
 

--- a/crates/authenticator/src/prove.rs
+++ b/crates/authenticator/src/prove.rs
@@ -423,6 +423,15 @@ impl Authenticator {
         Ok(response_item)
     }
 
+    /// Generates an Ownership Proof (WIP-103) over a Credential's `sub`.
+    ///
+    /// This proof MUST only be shared with each relevant issuer. This is the responsibility of Authenticators.
+    ///
+    /// # Arguments
+    /// - `nonce`: The nonce of the request provided by the Issuer.
+    /// - `credential_blinding_factor`: The blinding factor generated for the credential.
+    /// - `sub`: The expected `sub` of the Credential in question.
+    /// - `account_inclusion_proof`: An optionally cached account inclusion proof. If not provided, a new inclusion proof will be fetched.
     #[cfg(feature = "provekit")]
     pub async fn prove_credential_sub(
         &self,

--- a/crates/authenticator/src/prove.rs
+++ b/crates/authenticator/src/prove.rs
@@ -3,6 +3,8 @@ use world_id_primitives::{
     Credential, FieldElement, ProofRequest, ProofResponse, RequestItem, ResponseItem, SessionId,
     SessionNullifier, ZeroKnowledgeProof,
 };
+#[cfg(feature = "provekit")]
+use world_id_proof::WhirR1CSProof;
 use world_id_proof::{
     AuthenticatorProofInput, FullOprfOutput, OprfEntrypoint, proof::generate_nullifier_proof,
 };
@@ -53,6 +55,23 @@ impl Authenticator {
             .as_ref()
             .ok_or(AuthenticatorError::ProofMaterialsNotLoaded)?;
 
+        let authenticator_input = self
+            .prepare_authenticator_input(account_inclusion_proof)
+            .await?;
+
+        Ok(OprfEntrypoint::new(
+            services,
+            threshold,
+            query_material,
+            authenticator_input,
+            &self.ws_connector,
+        ))
+    }
+
+    async fn prepare_authenticator_input(
+        &self,
+        account_inclusion_proof: Option<AccountInclusionProof<TREE_DEPTH>>,
+    ) -> Result<AuthenticatorProofInput, AuthenticatorError> {
         // Fetch inclusion_proof && authenticator key_set if not provided
         let account_inclusion_proof = if let Some(account_inclusion_proof) = account_inclusion_proof
         {
@@ -80,13 +99,7 @@ impl Authenticator {
             key_index,
         );
 
-        Ok(OprfEntrypoint::new(
-            services,
-            threshold,
-            query_material,
-            authenticator_input,
-            &self.ws_connector,
-        ))
+        Ok(authenticator_input)
     }
 
     /// Generates a nullifier for a World ID Proof (through OPRF Nodes).
@@ -408,5 +421,46 @@ impl Authenticator {
         };
 
         Ok(response_item)
+    }
+
+    #[cfg(feature = "provekit")]
+    pub async fn prove_credential_sub(
+        &self,
+        nonce: FieldElement,
+        credential_blinding_factor: FieldElement,
+        sub: FieldElement,
+        account_inclusion_proof: Option<AccountInclusionProof<TREE_DEPTH>>,
+    ) -> Result<WhirR1CSProof, AuthenticatorError> {
+        use world_id_primitives::circuit_inputs::OwnershipProofCircuitInput;
+        use world_id_proof::ownership_proof::generate_ownership_proof;
+
+        let authenticator_input = self
+            .prepare_authenticator_input(account_inclusion_proof)
+            .await?;
+
+        let commitment = Credential::compute_sub(self.leaf_index(), credential_blinding_factor);
+
+        if commitment != sub {
+            return Err(AuthenticatorError::InvalidSubOrBlindingFactor);
+        }
+
+        let signature = self
+            .signer
+            .offchain_signer_private_key()
+            .expose_secret()
+            .sign(*commitment);
+
+        let input = OwnershipProofCircuitInput {
+            key_index: authenticator_input.key_index,
+            key_set: authenticator_input.key_set.clone(),
+            inclusion_proof: authenticator_input.inclusion_proof.clone(),
+            nonce,
+            signature,
+            commitment_blinder: credential_blinding_factor,
+        };
+
+        let proof = generate_ownership_proof(input)?;
+
+        Ok(proof.whir_r1cs_proof)
     }
 }

--- a/crates/primitives/src/circuit_inputs.rs
+++ b/crates/primitives/src/circuit_inputs.rs
@@ -229,16 +229,16 @@ impl<const MAX_DEPTH: usize> ProofInput for NullifierProofCircuitInput<MAX_DEPTH
 /// Inputs for the "Proof of Ownership" (WIP-103) circuit.
 #[derive(Debug, Clone)]
 pub struct OwnershipProofCircuitInput<const MAX_DEPTH: usize> {
-    /// The index of the authenticator key used to sign the proof request
+    /// Private input. The index of the authenticator key used to sign the proof request
     pub key_index: u64,
-    /// The full authenticator key set for the user's World ID
+    /// Private input. The full authenticator key set for the user's World ID
     pub key_set: AuthenticatorPublicKeySet,
-    /// The inclusion proof in the `WorldIDRegistry`
+    /// Private input (**except** the `root` and `depth`). The inclusion proof in the `WorldIDRegistry`
     pub inclusion_proof: MerkleInclusionProof<MAX_DEPTH>,
-    /// The nonce of the proof request. See `ProofRequest` for more details.
+    /// **Public input**. The nonce of the proof request as provided by the verifier.
     pub nonce: FieldElement,
-    /// Signature from the authenticator on the query.
+    /// Private input. Signature from the authenticator on the query.
     pub signature: EdDSASignature,
-    /// The commitment's `r` blinder
+    /// Private input. The commitment's `r` blinder
     pub commitment_blinder: FieldElement,
 }

--- a/crates/proof/src/lib.rs
+++ b/crates/proof/src/lib.rs
@@ -24,6 +24,9 @@ use world_id_primitives::FieldElement;
 #[cfg(feature = "provekit")]
 pub mod ownership_proof;
 
+#[cfg(feature = "provekit")]
+pub use provekit_common::{NoirProof, WhirR1CSProof};
+
 /// Error type for OPRF operations and proof generation.
 #[derive(Debug, thiserror::Error)]
 pub enum ProofError {
@@ -80,14 +83,14 @@ impl From<taceo_oprf::client::Error> for ProofError {
 pub struct AuthenticatorProofInput {
     /// The set of all public keys for all the user's authenticators.
     #[zeroize(skip)]
-    key_set: AuthenticatorPublicKeySet,
+    pub key_set: AuthenticatorPublicKeySet,
     /// Inclusion proof in the World ID Registry.
     #[zeroize(skip)]
-    inclusion_proof: MerkleInclusionProof<TREE_DEPTH>,
+    pub inclusion_proof: MerkleInclusionProof<TREE_DEPTH>,
     /// The off-chain signer key for the Authenticator.
     private_key: EdDSAPrivateKey,
     /// The index at which the authenticator key is located in the `key_set`.
-    key_index: u64,
+    pub key_index: u64,
 }
 
 impl AuthenticatorProofInput {


### PR DESCRIPTION
Exposes ownership proof generation to the authenticator for proving ownership over a credential's `sub`. Unit tests are AI generated, manually reviewed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new ZKP generation path (ownership proof) and exposes additional proof input fields, which can affect cryptographic correctness and API surface (though gated behind the `provekit` feature). Test-only dependencies and refactoring are low risk, but proving logic changes merit careful review.
> 
> **Overview**
> **Adds ownership proof generation (WIP-103) to the authenticator** behind the `provekit` feature via a new `prove_credential_sub` API that validates `sub`/blinding-factor consistency, signs the derived commitment, and returns a ProveKit `WhirR1CSProof` plus Merkle root.
> 
> Refactors proof setup by extracting `prepare_authenticator_input`, adds a dedicated `InvalidSubOrBlindingFactor` error, and updates `world-id-proof` to publicly re-export ProveKit proof types and make `AuthenticatorProofInput` fields (`key_set`, `inclusion_proof`, `key_index`) public for reuse. Also adds `world-id-test-utils` as a dev dependency and new unit tests for the ownership-proof flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a746f88f0762f92bd909f55bf0c565116dbde81e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->