### PR TITLE
chore: bump release-plz action to v0.5.128 (release-plz v0.3.157)

### DIFF
--- a/.github/workflows/release-crates.yml
+++ b/.github/workflows/release-crates.yml
@@ -28,6 +28,6 @@ jobs:
           toolchain: stable
 
       - name: Run release-plz
-        uses: release-plz/action@1efcf74dfcd6e500990dad806e286899ae384064 # v0.5.119 (https://github.com/release-plz/action/releases/tag/v0.5.119)
+        uses: release-plz/action@1528104d2ca23787631a1c1f022abb64b34c1e11 # v0.5.128 (https://github.com/release-plz/action/releases/tag/v0.5.128)
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
There is a bug in release-plz https://github.com/release-plz/release-plz/pull/2649, that caused https://github.com/worldcoin/world-id-protocol/actions/runs/24422398416.