### PR TITLE
feat: expose compression in authenticator crate

### DIFF
--- a/crates/authenticator/Cargo.toml
+++ b/crates/authenticator/Cargo.toml
@@ -21,6 +21,10 @@ include = [
 default = ["embed-zkeys"]
 embed-zkeys = ["world-id-proof/embed-zkeys"]
 provekit = ["world-id-proof/provekit"]
+# Compress the embedded zkeys to reduce binary size (ARK point compression)
+compress-zkeys = ["embed-zkeys", "world-id-proof/compress-zkeys"]
+# Compress the tar archive with zstd
+zstd-compress-zkeys = ["embed-zkeys", "world-id-proof/zstd-compress-zkeys"]
 
 [dependencies]
 # Use WASM-safe base features only


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: this only adds Cargo feature flags wiring to enable optional zkey compression behavior in a dependency, without changing runtime logic by default.
> 
> **Overview**
> Exposes optional zkey compression controls in `world-id-authenticator` by adding `compress-zkeys` (ARK point compression) and `zstd-compress-zkeys` feature flags.
> 
> Both features are wired through to the corresponding `world-id-proof` features and imply `embed-zkeys`, allowing consumers to opt into smaller binaries via feature selection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6933dca2093dae5f8e8816b5bc284cea70638cfc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->