### PR TITLE
fix: add noir compiler to release CI

### DIFF
--- a/.github/workflows/release-crates.yml
+++ b/.github/workflows/release-crates.yml
@@ -27,6 +27,11 @@ jobs:
         with:
           toolchain: stable
 
+      - uses: noir-lang/noirup@7dbe69ccc78877f0200ffa5a40836c953d2cfd8f # v0.1.4
+        with:
+          # See https://github.com/worldfnd/provekit, a specific nargo toolchain version is required
+          toolchain: v1.0.0-beta.11
+
       - name: Run release-plz
         uses: release-plz/action@1528104d2ca23787631a1c1f022abb64b34c1e11 # v0.5.128 (https://github.com/release-plz/action/releases/tag/v0.5.128)
         env:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: CI-only change that adds a pinned Noir/Nargo toolchain install step; main impact is potential release workflow failures if the toolchain install or version pin breaks.
> 
> **Overview**
> Ensures the `Release Crates` GitHub Actions workflow installs a pinned Noir (`nargo`) toolchain via `noir-lang/noirup` before running `release-plz`, aligning the release pipeline with the required compiler version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ce32625584d21def177512470c9a43196a5ce12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->