### PR TITLE
feat: WIP-102 

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -395,8 +395,9 @@ jobs:
 
       - name: Run Docker container
         run: |
-          # We run the http-only mode to avoid having to set up the RPC provider
-          docker run -d --network host --env-file services/${{ matrix.service }}/.env.example --env LISTEN_ADDR=0.0.0.0:8080 --env RUN_MODE=http-only --name ${{ matrix.service }}-container ${{ matrix.service }}:latest
+          # We run the http-only mode to avoid having to set up the RPC provider.
+          # RPC_MAX_RETRIES=0 disables RPC retries so the gateway's startup fails fast.
+          docker run -d --network host --env-file services/${{ matrix.service }}/.env.example --env LISTEN_ADDR=0.0.0.0:8080 --env RUN_MODE=http-only --env RPC_MAX_RETRIES=0 --name ${{ matrix.service }}-container ${{ matrix.service }}:latest
 
           # Wait for the application to start
           sleep 10

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -396,7 +396,7 @@ jobs:
       - name: Run Docker container
         run: |
           # We run the http-only mode to avoid having to set up the RPC provider.
-          # RPC_MAX_RETRIES=0 disables RPC retries so the gateway's startup fails fast.
+          # RPC_MAX_RETRIES=0 disables RPC retries so gateway fails fast on start-up.
           docker run -d --network host --env-file services/${{ matrix.service }}/.env.example --env LISTEN_ADDR=0.0.0.0:8080 --env RUN_MODE=http-only --env RPC_MAX_RETRIES=0 --name ${{ matrix.service }}-container ${{ matrix.service }}:latest
 
           # Wait for the application to start

--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,7 @@ sol-build:
 	cd contracts && if git rev-parse --git-dir > /dev/null 2>&1; then forge install; fi && forge build && \
 	mkdir -p ../crates/registries/abi ../crates/issuer/abi ../services/oprf-node/abi && \
 	forge inspect WorldIDRegistry abi --json > ../crates/registries/abi/WorldIDRegistryAbi.json && \
+	forge inspect WorldIDRegistryV2 abi --json > ../crates/registries/abi/WorldIDRegistryV2Abi.json && \
 	forge inspect CredentialSchemaIssuerRegistry abi --json > ../crates/issuer/abi/CredentialSchemaIssuerRegistryAbi.json && \
 	forge inspect CredentialSchemaIssuerRegistry abi --json > ../services/oprf-node/abi/CredentialSchemaIssuerRegistryAbi.json && \
 	forge inspect RpRegistry abi --json > ../services/oprf-node/abi/RpRegistryAbi.json

--- a/contracts/src/core/WorldIDRegistryV2Unreleased.sol
+++ b/contracts/src/core/WorldIDRegistryV2Unreleased.sol
@@ -493,7 +493,9 @@ contract WorldIDRegistryV2 is IWorldIDRegistryV2, WorldIDRegistry {
         // from becoming the effective recovery agent the moment the mask is removed.
         PreviousRecoveryAgentUpdate memory prev = _prevRecoveryAgentUpdates[leafIndex];
         if (prev.invalidAfter != 0 && block.timestamp < prev.invalidAfter) {
+            address revertedAgent = _getRecoveryAgent(leafIndex);
             _setRecoveryAddressAndBitmap(leafIndex, prev.prevRecoveryAgent, _getPubkeyBitmap(leafIndex));
+            emit RecoveryAgentUpdateReverted(leafIndex, prev.prevRecoveryAgent, revertedAgent);
         }
         delete _prevRecoveryAgentUpdates[leafIndex];
 

--- a/contracts/src/core/WorldIDRegistryV2Unreleased.sol
+++ b/contracts/src/core/WorldIDRegistryV2Unreleased.sol
@@ -313,7 +313,6 @@ contract WorldIDRegistryV2 is IWorldIDRegistryV2, WorldIDRegistry {
             revert RecoveryAgentUpdateStillActive(leafIndex, prev.invalidAfter);
         }
 
-        // Reuse `INITIATE_RECOVERY_AGENT_UPDATE_TYPEHASH` to work with existing clients
         bytes32 messageHash = _hashTypedDataV4(
             keccak256(abi.encode(INITIATE_RECOVERY_AGENT_UPDATE_TYPEHASH, leafIndex, newRecoveryAgent, nonce))
         );
@@ -363,7 +362,6 @@ contract WorldIDRegistryV2 is IWorldIDRegistryV2, WorldIDRegistry {
             revert RecoveryAgentUpdateWindowExpired(leafIndex, prev.invalidAfter);
         }
 
-        // Reuse `CANCEL_RECOVERY_AGENT_UPDATE_TYPEHASH` to keep working with existing clients
         bytes32 messageHash =
             _hashTypedDataV4(keccak256(abi.encode(CANCEL_RECOVERY_AGENT_UPDATE_TYPEHASH, leafIndex, nonce)));
 
@@ -489,14 +487,10 @@ contract WorldIDRegistryV2 is IWorldIDRegistryV2, WorldIDRegistry {
             PackedAccountData.pack(leafIndex, uint32(_leafIndexToRecoveryCounter[leafIndex]), uint32(0));
         _setPubkeyBitmap(leafIndex, 1); // Reset to only pubkeyId 0
 
-        // WIP-102 attack mitigation. When recovery succeeds during an active revert
-        // window, the attacker's `newRecoveryAgent` is currently in the recovery slot
-        // but masked by `_getEffectiveRecoveryAgent`. Restoring `prev.prevRecoveryAgent`
-        // here — before clearing the window mapping prevents the attacker's address
+        // When recovery succeeds during an active revert window, 
+        // the attacker's `newRecoveryAgent` is currently in the recovery slot. 
+        // Restoring `prev.prevRecoveryAgent` prevents the attacker's address
         // from becoming the effective recovery agent the moment the mask is removed.
-        // The condition mirrors `_getEffectiveRecoveryAgent`'s window-active check so we
-        // only restore when the recovery actually used the prev agent's authority
-        // (post-window recoveries leave the legitimate new agent in place).
         PreviousRecoveryAgentUpdate memory prev = _prevRecoveryAgentUpdates[leafIndex];
         if (prev.invalidAfter != 0 && block.timestamp < prev.invalidAfter) {
             _setRecoveryAddressAndBitmap(leafIndex, prev.prevRecoveryAgent, _getPubkeyBitmap(leafIndex));
@@ -552,15 +546,7 @@ contract WorldIDRegistryV2 is IWorldIDRegistryV2, WorldIDRegistry {
 
     /// @inheritdoc IWorldIDRegistry
     /// @custom:override Overrides V1 (WIP-102) to translate V2 active-update state into the
-    ///     legacy V1 shape. `newRecoveryAgent` is the scheduled agent sitting in the packed
-    ///     slot awaiting window elapse; the second return value is the timestamp at which
-    ///     that agent becomes the effective recovery signer (equal to V2's `invalidAfter`).
-    ///     Renamed from V1's `executeAfter` because WIP-102 removes the explicit execute
-    ///     step — the new agent becomes valid automatically once the timestamp elapses.
-    ///     Returns `(address(0), 0)` when no active update exists or when the window has
-    ///     already elapsed — matching V1's "no pending update" contract. Orphaned V1
-    ///     `_pendingRecoveryAgentUpdates` entries are correctly invisible (we read the V2
-    ///     mapping, not the V1 one); the indexer notifies affected users off-chain.
+    /// legacy V1 shape.
     function getPendingRecoveryAgentUpdate(uint64 leafIndex)
         external
         view

--- a/contracts/src/core/WorldIDRegistryV2Unreleased.sol
+++ b/contracts/src/core/WorldIDRegistryV2Unreleased.sol
@@ -297,7 +297,8 @@ contract WorldIDRegistryV2 is IWorldIDRegistryV2, WorldIDRegistry {
 
     /// @inheritdoc IWorldIDRegistryV2
     /// @dev WIP-102. Authorization model matches V1's removed `initiateRecoveryAgentUpdate`:
-    ///     any valid authenticator signs the EIP-712 payload.
+    ///     any valid authenticator signs the EIP-712 payload. Reuses the V1 typehash so migrated
+    ///     clients can keep producing the same typed-data signature while the selector changes.
     function updateRecoveryAgent(uint64 leafIndex, address newRecoveryAgent, bytes memory signature, uint256 nonce)
         external
         virtual
@@ -343,7 +344,8 @@ contract WorldIDRegistryV2 is IWorldIDRegistryV2, WorldIDRegistry {
 
     /// @inheritdoc IWorldIDRegistryV2
     /// @dev WIP-102. Authorization model matches V1's removed `cancelRecoveryAgentUpdate`:
-    ///     any valid authenticator signs the EIP-712 payload.
+    ///     any valid authenticator signs the EIP-712 payload. Reuses the V1 typehash so migrated
+    ///     clients can keep producing the same typed-data signature while the selector changes.
     function revertRecoveryAgentUpdate(uint64 leafIndex, bytes memory signature, uint256 nonce)
         external
         virtual

--- a/contracts/src/core/WorldIDRegistryV2Unreleased.sol
+++ b/contracts/src/core/WorldIDRegistryV2Unreleased.sol
@@ -46,14 +46,6 @@ contract WorldIDRegistryV2 is IWorldIDRegistryV2, WorldIDRegistry {
     /// @dev Bit offset within the 96-bit pubkey bitmap where the flag for the class of authenticator begins.
     uint256 internal constant _AUTHENTICATOR_CLASS_OFFSET = 48;
 
-    /// @dev EIP-712 typehash for `updateRecoveryAgent` (WIP-102).
-    bytes32 public constant UPDATE_RECOVERY_AGENT_TYPEHASH =
-        keccak256("UpdateRecoveryAgent(uint64 leafIndex,address newRecoveryAgent,uint256 nonce)");
-
-    /// @dev EIP-712 typehash for `revertRecoveryAgentUpdate` (WIP-102).
-    bytes32 public constant REVERT_RECOVERY_AGENT_UPDATE_TYPEHASH =
-        keccak256("RevertRecoveryAgentUpdate(uint64 leafIndex,uint256 nonce)");
-
     ////////////////////////////////////////////////////////////
     //                    ROOT VALIDITY                       //
     ////////////////////////////////////////////////////////////
@@ -321,8 +313,10 @@ contract WorldIDRegistryV2 is IWorldIDRegistryV2, WorldIDRegistry {
             revert RecoveryAgentUpdateStillActive(leafIndex, prev.invalidAfter);
         }
 
-        bytes32 messageHash =
-            _hashTypedDataV4(keccak256(abi.encode(UPDATE_RECOVERY_AGENT_TYPEHASH, leafIndex, newRecoveryAgent, nonce)));
+        // Reuse `INITIATE_RECOVERY_AGENT_UPDATE_TYPEHASH` to work with existing clients
+        bytes32 messageHash = _hashTypedDataV4(
+            keccak256(abi.encode(INITIATE_RECOVERY_AGENT_UPDATE_TYPEHASH, leafIndex, newRecoveryAgent, nonce))
+        );
 
         (, uint256 packedAccountData) = _recoverAccountDataFromSignature(messageHash, signature);
         uint64 recoveredLeafIndex = PackedAccountData.leafIndex(packedAccountData);
@@ -369,8 +363,9 @@ contract WorldIDRegistryV2 is IWorldIDRegistryV2, WorldIDRegistry {
             revert RecoveryAgentUpdateWindowExpired(leafIndex, prev.invalidAfter);
         }
 
+        // Reuse `CANCEL_RECOVERY_AGENT_UPDATE_TYPEHASH` to keep working with exsiting clients
         bytes32 messageHash =
-            _hashTypedDataV4(keccak256(abi.encode(REVERT_RECOVERY_AGENT_UPDATE_TYPEHASH, leafIndex, nonce)));
+            _hashTypedDataV4(keccak256(abi.encode(CANCEL_RECOVERY_AGENT_UPDATE_TYPEHASH, leafIndex, nonce)));
 
         (, uint256 packedAccountData) = _recoverAccountDataFromSignature(messageHash, signature);
         uint64 recoveredLeafIndex = PackedAccountData.leafIndex(packedAccountData);

--- a/contracts/src/core/WorldIDRegistryV2Unreleased.sol
+++ b/contracts/src/core/WorldIDRegistryV2Unreleased.sol
@@ -363,7 +363,7 @@ contract WorldIDRegistryV2 is IWorldIDRegistryV2, WorldIDRegistry {
             revert RecoveryAgentUpdateWindowExpired(leafIndex, prev.invalidAfter);
         }
 
-        // Reuse `CANCEL_RECOVERY_AGENT_UPDATE_TYPEHASH` to keep working with exsiting clients
+        // Reuse `CANCEL_RECOVERY_AGENT_UPDATE_TYPEHASH` to keep working with existing clients
         bytes32 messageHash =
             _hashTypedDataV4(keccak256(abi.encode(CANCEL_RECOVERY_AGENT_UPDATE_TYPEHASH, leafIndex, nonce)));
 

--- a/contracts/src/core/WorldIDRegistryV2Unreleased.sol
+++ b/contracts/src/core/WorldIDRegistryV2Unreleased.sol
@@ -487,8 +487,8 @@ contract WorldIDRegistryV2 is IWorldIDRegistryV2, WorldIDRegistry {
             PackedAccountData.pack(leafIndex, uint32(_leafIndexToRecoveryCounter[leafIndex]), uint32(0));
         _setPubkeyBitmap(leafIndex, 1); // Reset to only pubkeyId 0
 
-        // When recovery succeeds during an active revert window, 
-        // the attacker's `newRecoveryAgent` is currently in the recovery slot. 
+        // When recovery succeeds during an active revert window,
+        // the attacker's `newRecoveryAgent` is currently in the recovery slot.
         // Restoring `prev.prevRecoveryAgent` prevents the attacker's address
         // from becoming the effective recovery agent the moment the mask is removed.
         PreviousRecoveryAgentUpdate memory prev = _prevRecoveryAgentUpdates[leafIndex];

--- a/contracts/src/core/WorldIDRegistryV2Unreleased.sol
+++ b/contracts/src/core/WorldIDRegistryV2Unreleased.sol
@@ -5,6 +5,7 @@ import {WorldIDRegistry} from "./WorldIDRegistry.sol";
 import {IWorldIDRegistry} from "./interfaces/IWorldIDRegistry.sol";
 import {IWorldIDRegistryV2} from "./interfaces/IWorldIDRegistryV2.sol";
 import {PackedAccountData} from "./libraries/PackedAccountData.sol";
+import {SignatureChecker} from "@openzeppelin/contracts/utils/cryptography/SignatureChecker.sol";
 
 /**
  * @title WorldIDRegistryV2
@@ -25,6 +26,10 @@ contract WorldIDRegistryV2 is IWorldIDRegistryV2, WorldIDRegistry {
     ///      Used by V2's `isValidRoot` to measure TTL from replacement time, not creation time.
     mapping(uint256 => uint256) internal _rootToValidityTimestamp;
 
+    /// @dev leafIndex -> previous Recovery Agent captured during an active update's revert window (WIP-102).
+    ///      `invalidAfter == 0` means no active update.
+    mapping(uint256 => PreviousRecoveryAgentUpdate) internal _prevRecoveryAgentUpdates;
+
     ////////////////////////////////////////////////////////////
     //                        Constants                       //
     ////////////////////////////////////////////////////////////
@@ -40,6 +45,14 @@ contract WorldIDRegistryV2 is IWorldIDRegistryV2, WorldIDRegistry {
 
     /// @dev Bit offset within the 96-bit pubkey bitmap where the flag for the class of authenticator begins.
     uint256 internal constant _AUTHENTICATOR_CLASS_OFFSET = 48;
+
+    /// @dev EIP-712 typehash for `updateRecoveryAgent` (WIP-102).
+    bytes32 public constant UPDATE_RECOVERY_AGENT_TYPEHASH =
+        keccak256("UpdateRecoveryAgent(uint64 leafIndex,address newRecoveryAgent,uint256 nonce)");
+
+    /// @dev EIP-712 typehash for `revertRecoveryAgentUpdate` (WIP-102).
+    bytes32 public constant REVERT_RECOVERY_AGENT_UPDATE_TYPEHASH =
+        keccak256("RevertRecoveryAgentUpdate(uint64 leafIndex,uint256 nonce)");
 
     ////////////////////////////////////////////////////////////
     //                    ROOT VALIDITY                       //
@@ -282,6 +295,266 @@ contract WorldIDRegistryV2 is IWorldIDRegistryV2, WorldIDRegistry {
         virtual
         override(WorldIDRegistry, IWorldIDRegistry)
         onlyProxy
+    {
+        revert MethodUnsupported();
+    }
+
+    ////////////////////////////////////////////////////////////
+    //              RECOVERY AGENT MANAGEMENT                 //
+    ////////////////////////////////////////////////////////////
+
+    /// @inheritdoc IWorldIDRegistryV2
+    /// @dev WIP-102. Authorization model matches V1's removed `initiateRecoveryAgentUpdate`:
+    ///     any valid authenticator signs the EIP-712 payload.
+    function updateRecoveryAgent(uint64 leafIndex, address newRecoveryAgent, bytes memory signature, uint256 nonce)
+        external
+        virtual
+        onlyProxy
+        onlyInitialized
+    {
+        if (leafIndex == 0 || _nextLeafIndex <= leafIndex) {
+            revert AccountDoesNotExist(leafIndex);
+        }
+
+        PreviousRecoveryAgentUpdate memory prev = _prevRecoveryAgentUpdates[leafIndex];
+        if (prev.invalidAfter != 0 && block.timestamp < prev.invalidAfter) {
+            revert RecoveryAgentUpdateStillActive(leafIndex, prev.invalidAfter);
+        }
+
+        bytes32 messageHash = _hashTypedDataV4(
+            keccak256(abi.encode(UPDATE_RECOVERY_AGENT_TYPEHASH, leafIndex, newRecoveryAgent, nonce))
+        );
+
+        (, uint256 packedAccountData) = _recoverAccountDataFromSignature(messageHash, signature);
+        uint64 recoveredLeafIndex = PackedAccountData.leafIndex(packedAccountData);
+        if (leafIndex != recoveredLeafIndex) {
+            revert MismatchedLeafIndex(leafIndex, recoveredLeafIndex);
+        }
+
+        uint256 expectedNonce = _leafIndexToSignatureNonce[leafIndex];
+        if (nonce != expectedNonce) {
+            revert MismatchedSignatureNonce(leafIndex, expectedNonce, nonce);
+        }
+        _leafIndexToSignatureNonce[leafIndex]++;
+
+        address oldAgent = _getRecoveryAgent(leafIndex);
+        uint256 invalidAfter = block.timestamp + _recoveryAgentUpdateCooldown;
+
+        // Record the previous agent for the revert window, then apply the new agent on-chain immediately.
+        // Until `invalidAfter`, `oldAgent` remains the sole valid signer for `recoverAccount`.
+        _prevRecoveryAgentUpdates[leafIndex] =
+            PreviousRecoveryAgentUpdate({prevRecoveryAgent: oldAgent, invalidAfter: invalidAfter});
+        _setRecoveryAddressAndBitmap(leafIndex, newRecoveryAgent, _getPubkeyBitmap(leafIndex));
+
+        emit RecoveryAgentUpdated(leafIndex, oldAgent, newRecoveryAgent, invalidAfter);
+    }
+
+    /// @inheritdoc IWorldIDRegistryV2
+    /// @dev WIP-102. Authorization model matches V1's removed `cancelRecoveryAgentUpdate`:
+    ///     any valid authenticator signs the EIP-712 payload.
+    function revertRecoveryAgentUpdate(uint64 leafIndex, bytes memory signature, uint256 nonce)
+        external
+        virtual
+        onlyProxy
+        onlyInitialized
+    {
+        if (leafIndex == 0 || _nextLeafIndex <= leafIndex) {
+            revert AccountDoesNotExist(leafIndex);
+        }
+
+        PreviousRecoveryAgentUpdate memory prev = _prevRecoveryAgentUpdates[leafIndex];
+        if (prev.invalidAfter == 0) {
+            revert NoActiveRecoveryAgentUpdate(leafIndex);
+        }
+        if (block.timestamp >= prev.invalidAfter) {
+            revert RecoveryAgentUpdateWindowExpired(leafIndex, prev.invalidAfter);
+        }
+
+        bytes32 messageHash =
+            _hashTypedDataV4(keccak256(abi.encode(REVERT_RECOVERY_AGENT_UPDATE_TYPEHASH, leafIndex, nonce)));
+
+        (, uint256 packedAccountData) = _recoverAccountDataFromSignature(messageHash, signature);
+        uint64 recoveredLeafIndex = PackedAccountData.leafIndex(packedAccountData);
+        if (leafIndex != recoveredLeafIndex) {
+            revert MismatchedLeafIndex(leafIndex, recoveredLeafIndex);
+        }
+
+        uint256 expectedNonce = _leafIndexToSignatureNonce[leafIndex];
+        if (nonce != expectedNonce) {
+            revert MismatchedSignatureNonce(leafIndex, expectedNonce, nonce);
+        }
+        _leafIndexToSignatureNonce[leafIndex]++;
+
+        // Restore the previous agent on-chain and close the revert window by clearing the entry.
+        address revertedAgent = _getRecoveryAgent(leafIndex);
+        _setRecoveryAddressAndBitmap(leafIndex, prev.prevRecoveryAgent, _getPubkeyBitmap(leafIndex));
+        delete _prevRecoveryAgentUpdates[leafIndex];
+
+        emit RecoveryAgentUpdateReverted(leafIndex, prev.prevRecoveryAgent, revertedAgent);
+    }
+
+    /// @inheritdoc IWorldIDRegistryV2
+    function getPreviousRecoveryAgentUpdate(uint64 leafIndex)
+        external
+        view
+        virtual
+        onlyProxy
+        onlyInitialized
+        returns (address prevRecoveryAgent, uint256 invalidAfter)
+    {
+        PreviousRecoveryAgentUpdate memory prev = _prevRecoveryAgentUpdates[leafIndex];
+        return (prev.prevRecoveryAgent, prev.invalidAfter);
+    }
+
+    /// @inheritdoc IWorldIDRegistry
+    /// @custom:override Overrides V1 (WIP-102) to return the effective Recovery Agent — the signer
+    ///     currently authorized to recover this account. During an active revert window the previous
+    ///     agent remains effective; after `invalidAfter` elapses the newly-set agent takes over.
+    ///     The scheduled new agent during a window is discoverable via the `RecoveryAgentUpdated` event.
+    function getRecoveryAgent(uint64 leafIndex)
+        external
+        view
+        virtual
+        override(IWorldIDRegistry, WorldIDRegistry)
+        onlyProxy
+        onlyInitialized
+        returns (address)
+    {
+        return _getEffectiveRecoveryAgent(leafIndex);
+    }
+
+    /// @dev Returns the effective Recovery Agent with WIP-102 revert-window semantics applied.
+    function _getEffectiveRecoveryAgent(uint64 leafIndex) internal view virtual returns (address) {
+        PreviousRecoveryAgentUpdate memory prev = _prevRecoveryAgentUpdates[leafIndex];
+        if (prev.invalidAfter != 0 && block.timestamp < prev.invalidAfter) {
+            return prev.prevRecoveryAgent;
+        }
+        return _getRecoveryAgent(leafIndex);
+    }
+
+    /// @inheritdoc IWorldIDRegistry
+    /// @custom:override Overrides V1 (WIP-102): during an active revert window, the valid recovery
+    ///     signer is the previous Recovery Agent, not the newly-set one. On success, clears any
+    ///     active update so that a malicious update by a compromised authenticator is undone when
+    ///     the true owner recovers the account.
+    function recoverAccount(
+        uint64 leafIndex,
+        address newAuthenticatorAddress,
+        uint256 newAuthenticatorPubkey,
+        uint256 oldOffchainSignerCommitment,
+        uint256 newOffchainSignerCommitment,
+        bytes memory signature,
+        uint256 nonce
+    ) external virtual override(IWorldIDRegistry, WorldIDRegistry) onlyProxy onlyInitialized {
+        if (leafIndex == 0 || _nextLeafIndex <= leafIndex) {
+            revert AccountDoesNotExist(leafIndex);
+        }
+
+        uint256 expectedNonce = _leafIndexToSignatureNonce[leafIndex];
+
+        if (nonce != expectedNonce) {
+            revert MismatchedSignatureNonce(leafIndex, expectedNonce, nonce);
+        }
+        _leafIndexToSignatureNonce[leafIndex]++;
+
+        bytes32 messageHash = _hashTypedDataV4(
+            keccak256(
+                abi.encode(
+                    RECOVER_ACCOUNT_TYPEHASH,
+                    leafIndex,
+                    newAuthenticatorAddress,
+                    newAuthenticatorPubkey,
+                    newOffchainSignerCommitment,
+                    nonce
+                )
+            )
+        );
+
+        // Effective signer applies WIP-102 window semantics: previous agent during an active window,
+        // newly-set agent once `invalidAfter` has elapsed.
+        address recoverySigner = _getEffectiveRecoveryAgent(leafIndex);
+        if (recoverySigner == address(0)) {
+            revert RecoveryNotEnabled();
+        }
+        if (!SignatureChecker.isValidSignatureNow(recoverySigner, messageHash, signature)) {
+            revert InvalidSignature();
+        }
+
+        _validateNewAuthenticatorAddress(newAuthenticatorAddress);
+
+        _leafIndexToRecoveryCounter[leafIndex]++;
+
+        if (_leafIndexToRecoveryCounter[leafIndex] > type(uint32).max) {
+            revert RecoveryCounterOverflow();
+        }
+        _authenticatorAddressToPackedAccountData[newAuthenticatorAddress] =
+            PackedAccountData.pack(leafIndex, uint32(_leafIndexToRecoveryCounter[leafIndex]), uint32(0));
+        _setPubkeyBitmap(leafIndex, 1); // Reset to only pubkeyId 0
+
+        // Clear any active Recovery Agent update so a malicious update by a compromised
+        // authenticator is undone as part of the true owner's recovery (WIP-102 attack mitigation).
+        delete _prevRecoveryAgentUpdates[leafIndex];
+
+        emit AccountRecovered(
+            leafIndex,
+            newAuthenticatorAddress,
+            newAuthenticatorPubkey,
+            oldOffchainSignerCommitment,
+            newOffchainSignerCommitment
+        );
+        _updateLeafAndRecord(leafIndex, oldOffchainSignerCommitment, newOffchainSignerCommitment);
+    }
+
+    /// @inheritdoc IWorldIDRegistry
+    /// @custom:override Overrides V1 to remove this functionality (WIP-102). Replaced by `updateRecoveryAgent`.
+    function initiateRecoveryAgentUpdate(uint64, address, bytes memory, uint256)
+        external
+        virtual
+        override(IWorldIDRegistry, WorldIDRegistry)
+        onlyProxy
+        onlyInitialized
+    {
+        revert MethodUnsupported();
+    }
+
+    /// @inheritdoc IWorldIDRegistry
+    /// @custom:override Overrides V1 to remove this functionality (WIP-102). Replaced by `revertRecoveryAgentUpdate`.
+    function cancelRecoveryAgentUpdate(uint64, bytes memory, uint256)
+        external
+        virtual
+        override(IWorldIDRegistry, WorldIDRegistry)
+        onlyProxy
+        onlyInitialized
+    {
+        revert MethodUnsupported();
+    }
+
+    /// @inheritdoc IWorldIDRegistry
+    /// @custom:override Overrides V1 to remove this functionality (WIP-102). No follow-up execute
+    ///     transaction is needed — `updateRecoveryAgent` applies the change immediately.
+    function executeRecoveryAgentUpdate(uint64)
+        external
+        virtual
+        override(IWorldIDRegistry, WorldIDRegistry)
+        onlyProxy
+        onlyInitialized
+    {
+        revert MethodUnsupported();
+    }
+
+    /// @inheritdoc IWorldIDRegistry
+    /// @custom:override Overrides V1 (WIP-102). The V1 "pending update" mapping is orphaned after
+    ///     upgrade and this view would only ever return `(address(0), 0)`, which could be mistaken
+    ///     for "no active update" when in fact the mechanism has been replaced. Consumers must
+    ///     migrate to `getPreviousRecoveryAgentUpdate`.
+    function getPendingRecoveryAgentUpdate(uint64)
+        external
+        view
+        virtual
+        override(IWorldIDRegistry, WorldIDRegistry)
+        onlyProxy
+        onlyInitialized
+        returns (address, uint256)
     {
         revert MethodUnsupported();
     }

--- a/contracts/src/core/WorldIDRegistryV2Unreleased.sol
+++ b/contracts/src/core/WorldIDRegistryV2Unreleased.sol
@@ -485,8 +485,18 @@ contract WorldIDRegistryV2 is IWorldIDRegistryV2, WorldIDRegistry {
             PackedAccountData.pack(leafIndex, uint32(_leafIndexToRecoveryCounter[leafIndex]), uint32(0));
         _setPubkeyBitmap(leafIndex, 1); // Reset to only pubkeyId 0
 
-        // Clear any active Recovery Agent update so a malicious update by a compromised
-        // authenticator is undone as part of the true owner's recovery (WIP-102 attack mitigation).
+        // WIP-102 attack mitigation. When recovery succeeds during an active revert
+        // window, the attacker's `newRecoveryAgent` is currently in the recovery slot
+        // but masked by `_getEffectiveRecoveryAgent`. Restoring `prev.prevRecoveryAgent`
+        // here — before clearing the window mapping prevents the attacker's address
+        // from becoming the effective recovery agent the moment the mask is removed.
+        // The condition mirrors `_getEffectiveRecoveryAgent`'s window-active check so we
+        // only restore when the recovery actually used the prev agent's authority
+        // (post-window recoveries leave the legitimate new agent in place).
+        PreviousRecoveryAgentUpdate memory prev = _prevRecoveryAgentUpdates[leafIndex];
+        if (prev.invalidAfter != 0 && block.timestamp < prev.invalidAfter) {
+            _setRecoveryAddressAndBitmap(leafIndex, prev.prevRecoveryAgent, _getPubkeyBitmap(leafIndex));
+        }
         delete _prevRecoveryAgentUpdates[leafIndex];
 
         emit AccountRecovered(

--- a/contracts/src/core/WorldIDRegistryV2Unreleased.sol
+++ b/contracts/src/core/WorldIDRegistryV2Unreleased.sol
@@ -397,6 +397,10 @@ contract WorldIDRegistryV2 is IWorldIDRegistryV2, WorldIDRegistry {
         returns (address prevRecoveryAgent, uint256 invalidAfter)
     {
         PreviousRecoveryAgentUpdate memory prev = _prevRecoveryAgentUpdates[leafIndex];
+        // if update passed, there is no updated in flight, so we return (0,0)
+        if (prev.invalidAfter == 0 || block.timestamp >= prev.invalidAfter) {
+            return (address(0), 0);
+        }
         return (prev.prevRecoveryAgent, prev.invalidAfter);
     }
 

--- a/contracts/src/core/WorldIDRegistryV2Unreleased.sol
+++ b/contracts/src/core/WorldIDRegistryV2Unreleased.sol
@@ -321,9 +321,8 @@ contract WorldIDRegistryV2 is IWorldIDRegistryV2, WorldIDRegistry {
             revert RecoveryAgentUpdateStillActive(leafIndex, prev.invalidAfter);
         }
 
-        bytes32 messageHash = _hashTypedDataV4(
-            keccak256(abi.encode(UPDATE_RECOVERY_AGENT_TYPEHASH, leafIndex, newRecoveryAgent, nonce))
-        );
+        bytes32 messageHash =
+            _hashTypedDataV4(keccak256(abi.encode(UPDATE_RECOVERY_AGENT_TYPEHASH, leafIndex, newRecoveryAgent, nonce)));
 
         (, uint256 packedAccountData) = _recoverAccountDataFromSignature(messageHash, signature);
         uint64 recoveredLeafIndex = PackedAccountData.leafIndex(packedAccountData);

--- a/contracts/src/core/WorldIDRegistryV2Unreleased.sol
+++ b/contracts/src/core/WorldIDRegistryV2Unreleased.sol
@@ -542,20 +542,30 @@ contract WorldIDRegistryV2 is IWorldIDRegistryV2, WorldIDRegistry {
     }
 
     /// @inheritdoc IWorldIDRegistry
-    /// @custom:override Overrides V1 (WIP-102). The V1 "pending update" mapping is orphaned after
-    ///     upgrade and this view would only ever return `(address(0), 0)`, which could be mistaken
-    ///     for "no active update" when in fact the mechanism has been replaced. Consumers must
-    ///     migrate to `getPreviousRecoveryAgentUpdate`.
-    function getPendingRecoveryAgentUpdate(uint64)
+    /// @custom:override Overrides V1 (WIP-102) to translate V2 active-update state into the
+    ///     legacy V1 shape. `newRecoveryAgent` is the scheduled agent sitting in the packed
+    ///     slot awaiting window elapse; the second return value is the timestamp at which
+    ///     that agent becomes the effective recovery signer (equal to V2's `invalidAfter`).
+    ///     Renamed from V1's `executeAfter` because WIP-102 removes the explicit execute
+    ///     step — the new agent becomes valid automatically once the timestamp elapses.
+    ///     Returns `(address(0), 0)` when no active update exists or when the window has
+    ///     already elapsed — matching V1's "no pending update" contract. Orphaned V1
+    ///     `_pendingRecoveryAgentUpdates` entries are correctly invisible (we read the V2
+    ///     mapping, not the V1 one); the indexer notifies affected users off-chain.
+    function getPendingRecoveryAgentUpdate(uint64 leafIndex)
         external
         view
         virtual
         override(IWorldIDRegistry, WorldIDRegistry)
         onlyProxy
         onlyInitialized
-        returns (address, uint256)
+        returns (address newRecoveryAgent, uint256 validAfter)
     {
-        revert MethodUnsupported();
+        PreviousRecoveryAgentUpdate memory prev = _prevRecoveryAgentUpdates[leafIndex];
+        if (prev.invalidAfter == 0 || block.timestamp >= prev.invalidAfter) {
+            return (address(0), 0);
+        }
+        return (_getRecoveryAgent(leafIndex), prev.invalidAfter);
     }
 
     ////////////////////////////////////////////////////////////

--- a/contracts/src/core/interfaces/IWorldIDRegistryV2.sol
+++ b/contracts/src/core/interfaces/IWorldIDRegistryV2.sol
@@ -88,9 +88,7 @@ interface IWorldIDRegistryV2 is IWorldIDRegistry {
      *      being displaced; `restoredRecoveryAgent` is the previous agent being restored.
      */
     event RecoveryAgentUpdateReverted(
-        uint64 indexed leafIndex,
-        address indexed restoredRecoveryAgent,
-        address indexed revertedRecoveryAgent
+        uint64 indexed leafIndex, address indexed restoredRecoveryAgent, address indexed revertedRecoveryAgent
     );
 
     ////////////////////////////////////////////////////////////
@@ -107,12 +105,8 @@ interface IWorldIDRegistryV2 is IWorldIDRegistry {
      * @param signature The EIP-712 signature from an existing authenticator authorizing the update.
      * @param nonce The signature nonce for replay protection.
      */
-    function updateRecoveryAgent(
-        uint64 leafIndex,
-        address newRecoveryAgent,
-        bytes memory signature,
-        uint256 nonce
-    ) external;
+    function updateRecoveryAgent(uint64 leafIndex, address newRecoveryAgent, bytes memory signature, uint256 nonce)
+        external;
 
     /**
      * @dev Reverts a pending Recovery Agent update, restoring the previous Recovery Agent (WIP-102).

--- a/contracts/src/core/interfaces/IWorldIDRegistryV2.sol
+++ b/contracts/src/core/interfaces/IWorldIDRegistryV2.sol
@@ -11,6 +11,19 @@ import {IWorldIDRegistry} from "./IWorldIDRegistry.sol";
  */
 interface IWorldIDRegistryV2 is IWorldIDRegistry {
     ////////////////////////////////////////////////////////////
+    //                        STRUCTS                         //
+    ////////////////////////////////////////////////////////////
+
+    /**
+     * @dev Previous Recovery Agent retained during the optimistic revert window after an
+     *      `updateRecoveryAgent` call (WIP-102). `invalidAfter == 0` means no active update.
+     */
+    struct PreviousRecoveryAgentUpdate {
+        address prevRecoveryAgent;
+        uint256 invalidAfter;
+    }
+
+    ////////////////////////////////////////////////////////////
     //                        ERRORS                          //
     ////////////////////////////////////////////////////////////
 
@@ -36,4 +49,91 @@ interface IWorldIDRegistryV2 is IWorldIDRegistry {
      * @dev Thrown when querying expiration for a root that was never recorded.
      */
     error UnknownRoot(uint256 root);
+
+    /**
+     * @dev Thrown when `updateRecoveryAgent` is called while a previous Recovery Agent update
+     *      is still within its revert window (WIP-102).
+     */
+    error RecoveryAgentUpdateStillActive(uint64 leafIndex, uint256 invalidAfter);
+
+    /**
+     * @dev Thrown when `revertRecoveryAgentUpdate` is called with no active update to revert (WIP-102).
+     */
+    error NoActiveRecoveryAgentUpdate(uint64 leafIndex);
+
+    /**
+     * @dev Thrown when `revertRecoveryAgentUpdate` is called after the revert window has elapsed (WIP-102).
+     */
+    error RecoveryAgentUpdateWindowExpired(uint64 leafIndex, uint256 invalidAfter);
+
+    ////////////////////////////////////////////////////////////
+    //                        EVENTS                          //
+    ////////////////////////////////////////////////////////////
+
+    /**
+     * @dev Emitted when a Recovery Agent is updated (WIP-102). The change takes effect
+     *      immediately on-chain but recovery operations continue to honor `prevRecoveryAgent`
+     *      until `invalidAfter` elapses.
+     */
+    event RecoveryAgentUpdated(
+        uint64 indexed leafIndex,
+        address indexed prevRecoveryAgent,
+        address indexed newRecoveryAgent,
+        uint256 invalidAfter
+    );
+
+    /**
+     * @dev Emitted when a Recovery Agent update is reverted within the revert window (WIP-102).
+     *      `revertedRecoveryAgent` is the Recovery Agent that was set by the update and is now
+     *      being displaced; `restoredRecoveryAgent` is the previous agent being restored.
+     */
+    event RecoveryAgentUpdateReverted(
+        uint64 indexed leafIndex,
+        address indexed restoredRecoveryAgent,
+        address indexed revertedRecoveryAgent
+    );
+
+    ////////////////////////////////////////////////////////////
+    //                   PUBLIC FUNCTIONS                     //
+    ////////////////////////////////////////////////////////////
+
+    /**
+     * @dev Updates the Recovery Agent for a World ID account (WIP-102). The change is applied
+     *      immediately, while the previous Recovery Agent remains valid for recovery until
+     *      `invalidAfter` (= now + `_recoveryAgentUpdateCooldown`) elapses. During that window
+     *      any authenticator can revert via `revertRecoveryAgentUpdate`.
+     * @param leafIndex The leaf index of the World ID account.
+     * @param newRecoveryAgent The new Recovery Agent address.
+     * @param signature The EIP-712 signature from an existing authenticator authorizing the update.
+     * @param nonce The signature nonce for replay protection.
+     */
+    function updateRecoveryAgent(
+        uint64 leafIndex,
+        address newRecoveryAgent,
+        bytes memory signature,
+        uint256 nonce
+    ) external;
+
+    /**
+     * @dev Reverts a pending Recovery Agent update, restoring the previous Recovery Agent (WIP-102).
+     *      Callable by any valid authenticator up until `invalidAfter`.
+     * @param leafIndex The leaf index of the World ID account.
+     * @param signature The EIP-712 signature from an existing authenticator authorizing the revert.
+     * @param nonce The signature nonce for replay protection.
+     */
+    function revertRecoveryAgentUpdate(uint64 leafIndex, bytes memory signature, uint256 nonce) external;
+
+    ////////////////////////////////////////////////////////////
+    //                    VIEW FUNCTIONS                      //
+    ////////////////////////////////////////////////////////////
+
+    /**
+     * @dev Returns the previous Recovery Agent retained during an active update's revert window (WIP-102).
+     *      Returns `(address(0), 0)` when no update is in flight.
+     * @param leafIndex The leaf index to query.
+     */
+    function getPreviousRecoveryAgentUpdate(uint64 leafIndex)
+        external
+        view
+        returns (address prevRecoveryAgent, uint256 invalidAfter);
 }

--- a/contracts/src/core/interfaces/IWorldIDRegistryV2.sol
+++ b/contracts/src/core/interfaces/IWorldIDRegistryV2.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.13;
 import {IWorldIDRegistry} from "./IWorldIDRegistry.sol";
 
 /**
- * @title IWorldIDRegistry
+ * @title IWorldIDRegistryV2
  * @author World Contributors
  * @notice Interface for the World ID Registry contract.
  * @dev Manages World IDs and the authenticators which are authorized to perform operations on behalf of them.

--- a/contracts/test/core/WorldIDRegistryV2.t.sol
+++ b/contracts/test/core/WorldIDRegistryV2.t.sol
@@ -686,10 +686,39 @@ contract WorldIDRegistryV2WIP102Test is WorldIDRegistryV2TestBase {
         registry.executeRecoveryAgentUpdate(leafIndex);
     }
 
-    function test_GetPendingRecoveryAgentUpdate_RevertsMethodUnsupported() public {
+    function test_GetPendingRecoveryAgentUpdate_NoActiveUpdate_ReturnsZero() public {
         uint64 leafIndex = _createAccount(auth1, recoveryOld);
-        vm.expectRevert(IWorldIDRegistryV2.MethodUnsupported.selector);
-        registry.getPendingRecoveryAgentUpdate(leafIndex);
+        (address pendingAgent, uint256 validAfter) = registry.getPendingRecoveryAgentUpdate(leafIndex);
+        assertEq(pendingAgent, address(0));
+        assertEq(validAfter, 0);
+    }
+
+    function test_GetPendingRecoveryAgentUpdate_DuringWindow_ReturnsTranslatedV2State() public {
+        uint64 leafIndex = _createAccount(auth1, recoveryOld);
+        uint256 cooldown = registry.getRecoveryAgentUpdateCooldown();
+        uint256 expectedValidAfter = block.timestamp + cooldown;
+
+        bytes memory sig = _updateRecoveryAgentSig(leafIndex, recoveryNew, 0, AUTH1_PRIVATE_KEY);
+        registry.updateRecoveryAgent(leafIndex, recoveryNew, sig, 0);
+
+        // V1 shape: `newRecoveryAgent` = the scheduled agent, `validAfter` = when it takes effect.
+        (address pendingAgent, uint256 validAfter) = registry.getPendingRecoveryAgentUpdate(leafIndex);
+        assertEq(pendingAgent, recoveryNew);
+        assertEq(validAfter, expectedValidAfter);
+    }
+
+    function test_GetPendingRecoveryAgentUpdate_AfterWindow_ReturnsZero() public {
+        uint64 leafIndex = _createAccount(auth1, recoveryOld);
+        uint256 cooldown = registry.getRecoveryAgentUpdateCooldown();
+
+        bytes memory sig = _updateRecoveryAgentSig(leafIndex, recoveryNew, 0, AUTH1_PRIVATE_KEY);
+        registry.updateRecoveryAgent(leafIndex, recoveryNew, sig, 0);
+        skip(cooldown + 1);
+
+        // Once the window elapses the update is no longer "pending" in V1 terms.
+        (address pendingAgent, uint256 validAfter) = registry.getPendingRecoveryAgentUpdate(leafIndex);
+        assertEq(pendingAgent, address(0));
+        assertEq(validAfter, 0);
     }
 }
 
@@ -736,10 +765,12 @@ contract WorldIDRegistryV2WIP102OrphanTest is Test {
         v1.upgradeToAndCall(address(implementationV2), "");
         WorldIDRegistryV2 v2 = WorldIDRegistryV2(address(proxy));
 
-        // V1 pending-update view is loudly deprecated — consumers must migrate to
-        // `getPreviousRecoveryAgentUpdate`. The underlying V1 storage slot is not cleared.
-        vm.expectRevert(IWorldIDRegistryV2.MethodUnsupported.selector);
-        v2.getPendingRecoveryAgentUpdate(leafIndex);
+        // V1 pending-update view now reports V2 active-update state in the legacy tuple shape.
+        // The orphaned V1 entry is correctly invisible: the view reads the V2 mapping and
+        // returns (0, 0), reflecting that no V2-side update is active.
+        (address orphanedPending, uint256 orphanedValidAfter) = v2.getPendingRecoveryAgentUpdate(leafIndex);
+        assertEq(orphanedPending, address(0));
+        assertEq(orphanedValidAfter, 0);
 
         // The new V2 flow works on the same leaf without tripping over the orphaned slot.
         // Nonce is now 1 (V1 initiate incremented it).

--- a/contracts/test/core/WorldIDRegistryV2.t.sol
+++ b/contracts/test/core/WorldIDRegistryV2.t.sol
@@ -323,8 +323,10 @@ contract WorldIDRegistryV2WIP102Test is WorldIDRegistryV2TestBase {
         view
         returns (bytes memory)
     {
-        return
-            _eip712Sign(registry.UPDATE_RECOVERY_AGENT_TYPEHASH(), abi.encode(leafIndex, newAgent, nonce), privateKey);
+        // WIP-102 reuses the `INITIATE_RECOVERY_AGENT_UPDATE_TYPEHASH` on `updateRecoveryAgent`
+        return _eip712Sign(
+            registry.INITIATE_RECOVERY_AGENT_UPDATE_TYPEHASH(), abi.encode(leafIndex, newAgent, nonce), privateKey
+        );
     }
 
     function _revertRecoveryAgentUpdateSig(uint64 leafIndex, uint256 nonce, uint256 privateKey)
@@ -332,7 +334,8 @@ contract WorldIDRegistryV2WIP102Test is WorldIDRegistryV2TestBase {
         view
         returns (bytes memory)
     {
-        return _eip712Sign(registry.REVERT_RECOVERY_AGENT_UPDATE_TYPEHASH(), abi.encode(leafIndex, nonce), privateKey);
+        // WIP-102 reuses the `CANCEL_RECOVERY_AGENT_UPDATE_TYPEHASH` on `revertRecoveryAgentUpdate`
+        return _eip712Sign(registry.CANCEL_RECOVERY_AGENT_UPDATE_TYPEHASH(), abi.encode(leafIndex, nonce), privateKey);
     }
 
     function _recoverAccountSig(
@@ -776,7 +779,8 @@ contract WorldIDRegistryV2WIP102OrphanTest is Test {
         // Nonce is now 1 (V1 initiate incremented it).
         bytes memory v2UpdateSig = _eip712SignV1(
             WorldIDRegistry(address(v2)),
-            v2.UPDATE_RECOVERY_AGENT_TYPEHASH(),
+            // WIP-102: `updateRecoveryAgent` verifies against V1's INITIATE typehash.
+            v2.INITIATE_RECOVERY_AGENT_UPDATE_TYPEHASH(),
             abi.encode(leafIndex, recoveryPostUpgrade, uint256(1)),
             WIP102_ORPHAN_AUTH1_PRIVATE_KEY
         );

--- a/contracts/test/core/WorldIDRegistryV2.t.sol
+++ b/contracts/test/core/WorldIDRegistryV2.t.sol
@@ -11,25 +11,14 @@ import {WorldIDBase} from "../../src/core/abstract/WorldIDBase.sol";
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import {ERC20Mock} from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
 
-contract WorldIDRegistryV2WIP104Test is Test {
+/// @dev Shared scaffolding for tests that exercise the upgraded V2 proxy:
+///     deploys V1 behind an ERC1967 proxy, upgrades to V2, and exposes an EIP-712 signing helper.
+abstract contract WorldIDRegistryV2TestBase is Test {
     WorldIDRegistryV2 public registry;
 
-    uint256 constant AUTH1_PRIVATE_KEY = 0x01;
-    uint256 constant AUTH2_PRIVATE_KEY = 0x02;
-    uint256 constant AUTH3_PRIVATE_KEY = 0x03;
-    uint256 constant OFFCHAIN_SIGNER_COMMITMENT = 0x1234567890;
+    uint256 internal constant OFFCHAIN_SIGNER_COMMITMENT = 0x1234567890;
 
-    address public auth1;
-    address public auth2;
-    address public auth3;
-    address public recoveryAddress;
-
-    function setUp() public {
-        auth1 = vm.addr(AUTH1_PRIVATE_KEY);
-        auth2 = vm.addr(AUTH2_PRIVATE_KEY);
-        auth3 = vm.addr(AUTH3_PRIVATE_KEY);
-        recoveryAddress = address(0xEC4);
-
+    function setUp() public virtual {
         WorldIDRegistry implementationV1 = new WorldIDRegistry();
         ERC20Mock feeToken = new ERC20Mock();
         bytes memory initData =
@@ -42,25 +31,48 @@ contract WorldIDRegistryV2WIP104Test is Test {
         registry = WorldIDRegistryV2(address(proxy));
     }
 
-    ////////////////////////////////////////////////////////////
-    //                        Helpers                         //
-    ////////////////////////////////////////////////////////////
-
-    function _eip712Sign(bytes32 typeHash, bytes memory data, uint256 privateKey) private view returns (bytes memory) {
+    function _eip712Sign(bytes32 typeHash, bytes memory data, uint256 privateKey)
+        internal
+        view
+        returns (bytes memory)
+    {
         bytes32 structHash = keccak256(abi.encodePacked(typeHash, data));
         bytes32 digest = keccak256(abi.encodePacked("\x19\x01", registry.domainSeparatorV4(), structHash));
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, digest);
         return abi.encodePacked(r, s, v);
     }
 
-    function _createAccount(address authenticator) private returns (uint64 leafIndex) {
-        leafIndex = uint64(registry.getNextLeafIndex());
+    function _createAccount(address authenticator, address recoveryAgent) internal returns (uint64 leafIndex) {
+        leafIndex = registry.getNextLeafIndex();
         address[] memory addrs = new address[](1);
         addrs[0] = authenticator;
         uint256[] memory pubkeys = new uint256[](1);
         pubkeys[0] = 0;
-        registry.createAccount(recoveryAddress, addrs, pubkeys, OFFCHAIN_SIGNER_COMMITMENT);
+        registry.createAccount(recoveryAgent, addrs, pubkeys, OFFCHAIN_SIGNER_COMMITMENT);
     }
+}
+
+contract WorldIDRegistryV2WIP104Test is WorldIDRegistryV2TestBase {
+    uint256 constant AUTH1_PRIVATE_KEY = 0x01;
+    uint256 constant AUTH2_PRIVATE_KEY = 0x02;
+    uint256 constant AUTH3_PRIVATE_KEY = 0x03;
+
+    address public auth1;
+    address public auth2;
+    address public auth3;
+    address public recoveryAddress;
+
+    function setUp() public override {
+        super.setUp();
+        auth1 = vm.addr(AUTH1_PRIVATE_KEY);
+        auth2 = vm.addr(AUTH2_PRIVATE_KEY);
+        auth3 = vm.addr(AUTH3_PRIVATE_KEY);
+        recoveryAddress = address(0xEC4);
+    }
+
+    ////////////////////////////////////////////////////////////
+    //                        Helpers                         //
+    ////////////////////////////////////////////////////////////
 
     function _insertAuthenticator(
         uint64 leafIndex,
@@ -126,7 +138,7 @@ contract WorldIDRegistryV2WIP104Test is Test {
     ////////////////////////////////////////////////////////////
 
     function test_InsertProvingAuthenticator() public {
-        uint64 leafIndex = _createAccount(auth1);
+        uint64 leafIndex = _createAccount(auth1, recoveryAddress);
         uint256 commitment = OFFCHAIN_SIGNER_COMMITMENT;
 
         commitment = _insertAuthenticator(leafIndex, address(0), 1, AUTH1_PRIVATE_KEY, commitment);
@@ -138,7 +150,7 @@ contract WorldIDRegistryV2WIP104Test is Test {
     }
 
     function test_InsertAdminAuthenticator() public {
-        uint64 leafIndex = _createAccount(auth1);
+        uint64 leafIndex = _createAccount(auth1, recoveryAddress);
         uint256 commitment = OFFCHAIN_SIGNER_COMMITMENT;
 
         commitment = _insertAuthenticator(leafIndex, auth2, 1, AUTH1_PRIVATE_KEY, commitment);
@@ -149,7 +161,7 @@ contract WorldIDRegistryV2WIP104Test is Test {
 
     function test_InsertProvingAuthenticator_SkipsAddressValidation() public {
         // Insert two proving authenticators with address(0) — should not conflict
-        uint64 leafIndex = _createAccount(auth1);
+        uint64 leafIndex = _createAccount(auth1, recoveryAddress);
         uint256 commitment = OFFCHAIN_SIGNER_COMMITMENT;
 
         commitment = _insertAuthenticator(leafIndex, address(0), 1, AUTH1_PRIVATE_KEY, commitment);
@@ -161,7 +173,7 @@ contract WorldIDRegistryV2WIP104Test is Test {
     ////////////////////////////////////////////////////////////
 
     function test_RemoveProvingAuthenticator() public {
-        uint64 leafIndex = _createAccount(auth1);
+        uint64 leafIndex = _createAccount(auth1, recoveryAddress);
         uint256 commitment = OFFCHAIN_SIGNER_COMMITMENT;
 
         commitment = _insertAuthenticator(leafIndex, address(0), 1, AUTH1_PRIVATE_KEY, commitment);
@@ -172,7 +184,7 @@ contract WorldIDRegistryV2WIP104Test is Test {
     }
 
     function test_RemoveAdminAuthenticator() public {
-        uint64 leafIndex = _createAccount(auth1);
+        uint64 leafIndex = _createAccount(auth1, recoveryAddress);
         uint256 commitment = OFFCHAIN_SIGNER_COMMITMENT;
 
         // Insert a second admin so we can remove the first
@@ -183,7 +195,7 @@ contract WorldIDRegistryV2WIP104Test is Test {
     }
 
     function test_RemoveProvingAuthenticator_RevertsWithNonZeroAddress() public {
-        uint64 leafIndex = _createAccount(auth1);
+        uint64 leafIndex = _createAccount(auth1, recoveryAddress);
         uint256 commitment = OFFCHAIN_SIGNER_COMMITMENT;
 
         commitment = _insertAuthenticator(leafIndex, address(0), 1, AUTH1_PRIVATE_KEY, commitment);
@@ -203,7 +215,7 @@ contract WorldIDRegistryV2WIP104Test is Test {
     }
 
     function test_RemoveAdminAuthenticator_RevertsWithZeroAddress() public {
-        uint64 leafIndex = _createAccount(auth1);
+        uint64 leafIndex = _createAccount(auth1, recoveryAddress);
         uint256 commitment = OFFCHAIN_SIGNER_COMMITMENT;
 
         commitment = _insertAuthenticator(leafIndex, auth2, 1, AUTH1_PRIVATE_KEY, commitment);
@@ -224,7 +236,7 @@ contract WorldIDRegistryV2WIP104Test is Test {
     }
 
     function test_RemoveLastAdmin_RevertsWhenOnlyProvingRemains() public {
-        uint64 leafIndex = _createAccount(auth1);
+        uint64 leafIndex = _createAccount(auth1, recoveryAddress);
         uint256 commitment = OFFCHAIN_SIGNER_COMMITMENT;
 
         // Insert a proving authenticator
@@ -246,7 +258,7 @@ contract WorldIDRegistryV2WIP104Test is Test {
 
     function test_RemoveLastAdmin_SucceedsWhenNoProvingRemains() public {
         // This is essentially removing the World ID as it won't be usable anymore
-        uint64 leafIndex = _createAccount(auth1);
+        uint64 leafIndex = _createAccount(auth1, recoveryAddress);
         uint256 commitment = OFFCHAIN_SIGNER_COMMITMENT;
 
         // Insert second admin, then remove first — leaves only one admin, no proving
@@ -261,7 +273,7 @@ contract WorldIDRegistryV2WIP104Test is Test {
     ////////////////////////////////////////////////////////////
 
     function test_UpdateAuthenticator_RevertsMethodUnsupported() public {
-        uint64 leafIndex = _createAccount(auth1);
+        uint64 leafIndex = _createAccount(auth1, recoveryAddress);
 
         vm.expectRevert(abi.encodeWithSelector(IWorldIDRegistryV2.MethodUnsupported.selector));
         registry.updateAuthenticator(
@@ -281,5 +293,478 @@ contract WorldIDRegistryV2WIP104Test is Test {
     function test_SetMaxAuthenticators_SucceedsAt48() public {
         registry.setMaxAuthenticators(48);
         assertEq(registry.getMaxAuthenticators(), 48);
+    }
+}
+
+/// @title WIP-102 tests for WorldIDRegistryV2
+/// @notice Exercises `updateRecoveryAgent`, `revertRecoveryAgentUpdate`, the new `recoverAccount`
+///     signer-selection semantics, and the deprecation of the three V1 recovery-agent-update methods.
+contract WorldIDRegistryV2WIP102Test is WorldIDRegistryV2TestBase {
+    uint256 constant AUTH1_PRIVATE_KEY = 0xA1;
+    uint256 constant RECOVERY_OLD_PRIVATE_KEY = 0xEC01;
+    uint256 constant RECOVERY_NEW_PRIVATE_KEY = 0xEC02;
+    uint256 constant RECOVERY_ATTACKER_PRIVATE_KEY = 0xBAD1;
+
+    address auth1;
+    address recoveryOld;
+    address recoveryNew;
+    address recoveryAttacker;
+
+    function setUp() public override {
+        super.setUp();
+        auth1 = vm.addr(AUTH1_PRIVATE_KEY);
+        recoveryOld = vm.addr(RECOVERY_OLD_PRIVATE_KEY);
+        recoveryNew = vm.addr(RECOVERY_NEW_PRIVATE_KEY);
+        recoveryAttacker = vm.addr(RECOVERY_ATTACKER_PRIVATE_KEY);
+    }
+
+    ////////////////////////////////////////////////////////////
+    //                        Helpers                         //
+    ////////////////////////////////////////////////////////////
+
+    function _updateRecoveryAgentSig(uint64 leafIndex, address newAgent, uint256 nonce, uint256 privateKey)
+        private
+        view
+        returns (bytes memory)
+    {
+        return
+            _eip712Sign(registry.UPDATE_RECOVERY_AGENT_TYPEHASH(), abi.encode(leafIndex, newAgent, nonce), privateKey);
+    }
+
+    function _revertRecoveryAgentUpdateSig(uint64 leafIndex, uint256 nonce, uint256 privateKey)
+        private
+        view
+        returns (bytes memory)
+    {
+        return _eip712Sign(
+            registry.REVERT_RECOVERY_AGENT_UPDATE_TYPEHASH(), abi.encode(leafIndex, nonce), privateKey
+        );
+    }
+
+    function _recoverAccountSig(
+        uint64 leafIndex,
+        address newAuth,
+        uint256 newCommitment,
+        uint256 nonce,
+        uint256 privateKey
+    ) private view returns (bytes memory) {
+        return _eip712Sign(
+            registry.RECOVER_ACCOUNT_TYPEHASH(),
+            abi.encode(leafIndex, newAuth, newCommitment, newCommitment, nonce),
+            privateKey
+        );
+    }
+
+    ////////////////////////////////////////////////////////////
+    //                  updateRecoveryAgent                   //
+    ////////////////////////////////////////////////////////////
+
+    function test_UpdateRecoveryAgent_Success() public {
+        uint64 leafIndex = _createAccount(auth1, recoveryOld);
+        uint256 cooldown = registry.getRecoveryAgentUpdateCooldown();
+        uint256 expectedInvalidAfter = block.timestamp + cooldown;
+
+        bytes memory sig = _updateRecoveryAgentSig(leafIndex, recoveryNew, 0, AUTH1_PRIVATE_KEY);
+
+        vm.expectEmit(true, true, true, true);
+        emit IWorldIDRegistryV2.RecoveryAgentUpdated(leafIndex, recoveryOld, recoveryNew, expectedInvalidAfter);
+        registry.updateRecoveryAgent(leafIndex, recoveryNew, sig, 0);
+
+        // Effective Recovery Agent remains the previous one during the revert window.
+        assertEq(registry.getRecoveryAgent(leafIndex), recoveryOld);
+
+        // Previous Recovery Agent captured in the revert window.
+        (address prev, uint256 invalidAfter) = registry.getPreviousRecoveryAgentUpdate(leafIndex);
+        assertEq(prev, recoveryOld);
+        assertEq(invalidAfter, expectedInvalidAfter);
+
+        // Nonce was incremented.
+        assertEq(registry.getSignatureNonce(leafIndex), 1);
+
+        // After the window elapses, the newly-set agent becomes the effective Recovery Agent.
+        skip(cooldown + 1);
+        assertEq(registry.getRecoveryAgent(leafIndex), recoveryNew);
+    }
+
+    function test_UpdateRecoveryAgent_RevertsWhenActiveUpdate() public {
+        uint64 leafIndex = _createAccount(auth1, recoveryOld);
+        uint256 cooldown = registry.getRecoveryAgentUpdateCooldown();
+
+        bytes memory sig1 = _updateRecoveryAgentSig(leafIndex, recoveryNew, 0, AUTH1_PRIVATE_KEY);
+        registry.updateRecoveryAgent(leafIndex, recoveryNew, sig1, 0);
+
+        // Still within the window → a second updateRecoveryAgent must revert.
+        address third = vm.addr(0xEC03);
+        bytes memory sig2 = _updateRecoveryAgentSig(leafIndex, third, 1, AUTH1_PRIVATE_KEY);
+        uint256 expectedInvalidAfter = block.timestamp + cooldown;
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IWorldIDRegistryV2.RecoveryAgentUpdateStillActive.selector, leafIndex, expectedInvalidAfter
+            )
+        );
+        registry.updateRecoveryAgent(leafIndex, third, sig2, 1);
+    }
+
+    function test_UpdateRecoveryAgent_SucceedsAfterWindowElapses() public {
+        uint64 leafIndex = _createAccount(auth1, recoveryOld);
+        uint256 cooldown = registry.getRecoveryAgentUpdateCooldown();
+
+        bytes memory sig1 = _updateRecoveryAgentSig(leafIndex, recoveryNew, 0, AUTH1_PRIVATE_KEY);
+        registry.updateRecoveryAgent(leafIndex, recoveryNew, sig1, 0);
+
+        // Window elapses → new agent becomes the sole valid Recovery Agent and a second update is allowed.
+        skip(cooldown + 1);
+
+        address third = vm.addr(0xEC03);
+        bytes memory sig2 = _updateRecoveryAgentSig(leafIndex, third, 1, AUTH1_PRIVATE_KEY);
+        uint256 expectedInvalidAfter = block.timestamp + cooldown;
+
+        vm.expectEmit(true, true, true, true);
+        emit IWorldIDRegistryV2.RecoveryAgentUpdated(leafIndex, recoveryNew, third, expectedInvalidAfter);
+        registry.updateRecoveryAgent(leafIndex, third, sig2, 1);
+
+        // A new revert window is open, so the effective agent is once again the previous one.
+        assertEq(registry.getRecoveryAgent(leafIndex), recoveryNew);
+        (address prev, uint256 invalidAfter) = registry.getPreviousRecoveryAgentUpdate(leafIndex);
+        assertEq(prev, recoveryNew);
+        assertEq(invalidAfter, expectedInvalidAfter);
+    }
+
+    function test_UpdateRecoveryAgent_InvalidSignature() public {
+        uint64 leafIndex = _createAccount(auth1, recoveryOld);
+
+        // Signed with a key whose recovered address has no packed account data.
+        uint256 strangerKey = 0xDEADBEEF;
+        bytes memory sig = _updateRecoveryAgentSig(leafIndex, recoveryNew, 0, strangerKey);
+
+        address stranger = vm.addr(strangerKey);
+        vm.expectRevert(abi.encodeWithSelector(IWorldIDRegistry.AuthenticatorDoesNotExist.selector, stranger));
+        registry.updateRecoveryAgent(leafIndex, recoveryNew, sig, 0);
+    }
+
+    function test_UpdateRecoveryAgent_InvalidNonce() public {
+        uint64 leafIndex = _createAccount(auth1, recoveryOld);
+
+        uint256 wrongNonce = 5;
+        bytes memory sig = _updateRecoveryAgentSig(leafIndex, recoveryNew, wrongNonce, AUTH1_PRIVATE_KEY);
+        vm.expectRevert(
+            abi.encodeWithSelector(IWorldIDRegistry.MismatchedSignatureNonce.selector, leafIndex, 0, wrongNonce)
+        );
+        registry.updateRecoveryAgent(leafIndex, recoveryNew, sig, wrongNonce);
+    }
+
+    function test_UpdateRecoveryAgent_AccountDoesNotExist() public {
+        uint64 leafIndex = 42; // never created
+        bytes memory sig = _updateRecoveryAgentSig(leafIndex, recoveryNew, 0, AUTH1_PRIVATE_KEY);
+        vm.expectRevert(abi.encodeWithSelector(IWorldIDRegistry.AccountDoesNotExist.selector, leafIndex));
+        registry.updateRecoveryAgent(leafIndex, recoveryNew, sig, 0);
+    }
+
+    ////////////////////////////////////////////////////////////
+    //               revertRecoveryAgentUpdate                //
+    ////////////////////////////////////////////////////////////
+
+    function test_RevertRecoveryAgentUpdate_Success() public {
+        uint64 leafIndex = _createAccount(auth1, recoveryOld);
+        bytes memory updateSig = _updateRecoveryAgentSig(leafIndex, recoveryNew, 0, AUTH1_PRIVATE_KEY);
+        registry.updateRecoveryAgent(leafIndex, recoveryNew, updateSig, 0);
+
+        bytes memory revertSig = _revertRecoveryAgentUpdateSig(leafIndex, 1, AUTH1_PRIVATE_KEY);
+
+        vm.expectEmit(true, true, true, true);
+        emit IWorldIDRegistryV2.RecoveryAgentUpdateReverted(leafIndex, recoveryOld, recoveryNew);
+        registry.revertRecoveryAgentUpdate(leafIndex, revertSig, 1);
+
+        assertEq(registry.getRecoveryAgent(leafIndex), recoveryOld);
+        (address prev, uint256 invalidAfter) = registry.getPreviousRecoveryAgentUpdate(leafIndex);
+        assertEq(prev, address(0));
+        assertEq(invalidAfter, 0);
+        assertEq(registry.getSignatureNonce(leafIndex), 2);
+    }
+
+    function test_RevertRecoveryAgentUpdate_RevertsWhenNoActiveUpdate() public {
+        uint64 leafIndex = _createAccount(auth1, recoveryOld);
+        bytes memory sig = _revertRecoveryAgentUpdateSig(leafIndex, 0, AUTH1_PRIVATE_KEY);
+        vm.expectRevert(abi.encodeWithSelector(IWorldIDRegistryV2.NoActiveRecoveryAgentUpdate.selector, leafIndex));
+        registry.revertRecoveryAgentUpdate(leafIndex, sig, 0);
+    }
+
+    function test_RevertRecoveryAgentUpdate_RevertsAfterWindowExpired() public {
+        uint64 leafIndex = _createAccount(auth1, recoveryOld);
+        uint256 cooldown = registry.getRecoveryAgentUpdateCooldown();
+
+        bytes memory updateSig = _updateRecoveryAgentSig(leafIndex, recoveryNew, 0, AUTH1_PRIVATE_KEY);
+        registry.updateRecoveryAgent(leafIndex, recoveryNew, updateSig, 0);
+        (, uint256 invalidAfter) = registry.getPreviousRecoveryAgentUpdate(leafIndex);
+
+        skip(cooldown + 1);
+
+        bytes memory revertSig = _revertRecoveryAgentUpdateSig(leafIndex, 1, AUTH1_PRIVATE_KEY);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IWorldIDRegistryV2.RecoveryAgentUpdateWindowExpired.selector, leafIndex, invalidAfter
+            )
+        );
+        registry.revertRecoveryAgentUpdate(leafIndex, revertSig, 1);
+    }
+
+    function test_RevertRecoveryAgentUpdate_InvalidSignature() public {
+        uint64 leafIndex = _createAccount(auth1, recoveryOld);
+        bytes memory updateSig = _updateRecoveryAgentSig(leafIndex, recoveryNew, 0, AUTH1_PRIVATE_KEY);
+        registry.updateRecoveryAgent(leafIndex, recoveryNew, updateSig, 0);
+
+        uint256 strangerKey = 0xCAFE;
+        address stranger = vm.addr(strangerKey);
+        bytes memory badRevertSig = _revertRecoveryAgentUpdateSig(leafIndex, 1, strangerKey);
+        vm.expectRevert(abi.encodeWithSelector(IWorldIDRegistry.AuthenticatorDoesNotExist.selector, stranger));
+        registry.revertRecoveryAgentUpdate(leafIndex, badRevertSig, 1);
+    }
+
+    function test_RevertRecoveryAgentUpdate_InvalidNonce() public {
+        uint64 leafIndex = _createAccount(auth1, recoveryOld);
+        bytes memory updateSig = _updateRecoveryAgentSig(leafIndex, recoveryNew, 0, AUTH1_PRIVATE_KEY);
+        registry.updateRecoveryAgent(leafIndex, recoveryNew, updateSig, 0);
+
+        uint256 wrongNonce = 99;
+        bytes memory revertSig = _revertRecoveryAgentUpdateSig(leafIndex, wrongNonce, AUTH1_PRIVATE_KEY);
+        vm.expectRevert(
+            abi.encodeWithSelector(IWorldIDRegistry.MismatchedSignatureNonce.selector, leafIndex, 1, wrongNonce)
+        );
+        registry.revertRecoveryAgentUpdate(leafIndex, revertSig, wrongNonce);
+    }
+
+    ////////////////////////////////////////////////////////////
+    //           recoverAccount with revert window            //
+    ////////////////////////////////////////////////////////////
+
+    function test_RecoverAccount_DuringWindow_UsesPreviousAgent() public {
+        uint64 leafIndex = _createAccount(auth1, recoveryOld);
+
+        // Kick off an update → revert window is open.
+        bytes memory updateSig = _updateRecoveryAgentSig(leafIndex, recoveryNew, 0, AUTH1_PRIVATE_KEY);
+        registry.updateRecoveryAgent(leafIndex, recoveryNew, updateSig, 0);
+
+        // Recovery signed by the PREVIOUS agent must succeed inside the window.
+        address newAuth = address(0xBEE1);
+        uint256 nonce = 1;
+        uint256 newCommitment = OFFCHAIN_SIGNER_COMMITMENT + 1;
+        bytes memory recoverySig = _recoverAccountSig(leafIndex, newAuth, newCommitment, nonce, RECOVERY_OLD_PRIVATE_KEY);
+        registry.recoverAccount(
+            leafIndex, newAuth, newCommitment, OFFCHAIN_SIGNER_COMMITMENT, newCommitment, recoverySig, nonce
+        );
+
+        // Prev-update mapping cleared.
+        (address prev, uint256 invalidAfter) = registry.getPreviousRecoveryAgentUpdate(leafIndex);
+        assertEq(prev, address(0));
+        assertEq(invalidAfter, 0);
+
+        // New authenticator installed with bumped recovery counter.
+        assertEq(PackedAccountData.leafIndex(registry.getPackedAccountData(newAuth)), leafIndex);
+        assertEq(PackedAccountData.recoveryCounter(registry.getPackedAccountData(newAuth)), 1);
+    }
+
+    function test_RecoverAccount_DuringWindow_NewAgentSignatureFails() public {
+        uint64 leafIndex = _createAccount(auth1, recoveryOld);
+        bytes memory updateSig = _updateRecoveryAgentSig(leafIndex, recoveryNew, 0, AUTH1_PRIVATE_KEY);
+        registry.updateRecoveryAgent(leafIndex, recoveryNew, updateSig, 0);
+
+        address newAuth = address(0xBEE1);
+        uint256 nonce = 1;
+        uint256 newCommitment = OFFCHAIN_SIGNER_COMMITMENT + 1;
+        bytes memory recoverySig = _recoverAccountSig(leafIndex, newAuth, newCommitment, nonce, RECOVERY_NEW_PRIVATE_KEY);
+
+        vm.expectRevert(IWorldIDRegistry.InvalidSignature.selector);
+        registry.recoverAccount(
+            leafIndex, newAuth, newCommitment, OFFCHAIN_SIGNER_COMMITMENT, newCommitment, recoverySig, nonce
+        );
+    }
+
+    function test_RecoverAccount_AfterWindow_UsesNewAgent() public {
+        uint64 leafIndex = _createAccount(auth1, recoveryOld);
+        uint256 cooldown = registry.getRecoveryAgentUpdateCooldown();
+
+        bytes memory updateSig = _updateRecoveryAgentSig(leafIndex, recoveryNew, 0, AUTH1_PRIVATE_KEY);
+        registry.updateRecoveryAgent(leafIndex, recoveryNew, updateSig, 0);
+
+        skip(cooldown + 1);
+
+        address newAuth = address(0xBEE1);
+        uint256 nonce = 1;
+        uint256 newCommitment = OFFCHAIN_SIGNER_COMMITMENT + 1;
+        bytes memory recoverySig = _recoverAccountSig(leafIndex, newAuth, newCommitment, nonce, RECOVERY_NEW_PRIVATE_KEY);
+
+        registry.recoverAccount(
+            leafIndex, newAuth, newCommitment, OFFCHAIN_SIGNER_COMMITMENT, newCommitment, recoverySig, nonce
+        );
+
+        assertEq(PackedAccountData.leafIndex(registry.getPackedAccountData(newAuth)), leafIndex);
+    }
+
+    function test_RecoverAccount_AfterWindow_PrevAgentFails() public {
+        uint64 leafIndex = _createAccount(auth1, recoveryOld);
+        uint256 cooldown = registry.getRecoveryAgentUpdateCooldown();
+
+        bytes memory updateSig = _updateRecoveryAgentSig(leafIndex, recoveryNew, 0, AUTH1_PRIVATE_KEY);
+        registry.updateRecoveryAgent(leafIndex, recoveryNew, updateSig, 0);
+        skip(cooldown + 1);
+
+        address newAuth = address(0xBEE1);
+        uint256 nonce = 1;
+        uint256 newCommitment = OFFCHAIN_SIGNER_COMMITMENT + 1;
+        bytes memory recoverySig = _recoverAccountSig(leafIndex, newAuth, newCommitment, nonce, RECOVERY_OLD_PRIVATE_KEY);
+
+        vm.expectRevert(IWorldIDRegistry.InvalidSignature.selector);
+        registry.recoverAccount(
+            leafIndex, newAuth, newCommitment, OFFCHAIN_SIGNER_COMMITMENT, newCommitment, recoverySig, nonce
+        );
+    }
+
+    function test_RecoverAccount_NoPendingUpdate_UsesCurrentAgent() public {
+        uint64 leafIndex = _createAccount(auth1, recoveryOld);
+
+        address newAuth = address(0xBEE1);
+        uint256 nonce = 0;
+        uint256 newCommitment = OFFCHAIN_SIGNER_COMMITMENT + 1;
+        bytes memory recoverySig = _recoverAccountSig(leafIndex, newAuth, newCommitment, nonce, RECOVERY_OLD_PRIVATE_KEY);
+
+        registry.recoverAccount(
+            leafIndex, newAuth, newCommitment, OFFCHAIN_SIGNER_COMMITMENT, newCommitment, recoverySig, nonce
+        );
+
+        assertEq(PackedAccountData.leafIndex(registry.getPackedAccountData(newAuth)), leafIndex);
+        assertEq(registry.getRecoveryCounter(leafIndex), 1);
+    }
+
+    ////////////////////////////////////////////////////////////
+    //                   Attack mitigation                    //
+    ////////////////////////////////////////////////////////////
+
+    function test_AttackMitigation_MaliciousUpdateClearedByRecovery() public {
+        // Compromised authenticator `auth1` initiates a Recovery Agent swap to `recoveryAttacker`.
+        uint64 leafIndex = _createAccount(auth1, recoveryOld);
+        bytes memory attackerSig = _updateRecoveryAgentSig(leafIndex, recoveryAttacker, 0, AUTH1_PRIVATE_KEY);
+        registry.updateRecoveryAgent(leafIndex, recoveryAttacker, attackerSig, 0);
+
+        // On-chain agent is now the attacker, but the revert window keeps the legitimate agent as the
+        // only valid recovery signer. True owner recovers the account via the previous (legitimate) agent.
+        address newAuth = address(0xBEE1);
+        uint256 nonce = 1;
+        uint256 newCommitment = OFFCHAIN_SIGNER_COMMITMENT + 1;
+        bytes memory recoverySig = _recoverAccountSig(leafIndex, newAuth, newCommitment, nonce, RECOVERY_OLD_PRIVATE_KEY);
+
+        registry.recoverAccount(
+            leafIndex, newAuth, newCommitment, OFFCHAIN_SIGNER_COMMITMENT, newCommitment, recoverySig, nonce
+        );
+
+        // Attacker's mapping entry is cleared. Note the on-chain recovery agent is still `recoveryAttacker`
+        // at this point — the user must issue a fresh `updateRecoveryAgent` to restore their own agent.
+        // The critical property is that the attacker's update is no longer "protected" by a revert window.
+        (address prev, uint256 invalidAfter) = registry.getPreviousRecoveryAgentUpdate(leafIndex);
+        assertEq(prev, address(0));
+        assertEq(invalidAfter, 0);
+    }
+
+    ////////////////////////////////////////////////////////////
+    //                 Deprecated V1 methods                  //
+    ////////////////////////////////////////////////////////////
+
+    function test_InitiateRecoveryAgentUpdate_RevertsMethodUnsupported() public {
+        uint64 leafIndex = _createAccount(auth1, recoveryOld);
+        vm.expectRevert(IWorldIDRegistryV2.MethodUnsupported.selector);
+        registry.initiateRecoveryAgentUpdate(leafIndex, recoveryNew, bytes(""), 0);
+    }
+
+    function test_CancelRecoveryAgentUpdate_RevertsMethodUnsupported() public {
+        uint64 leafIndex = _createAccount(auth1, recoveryOld);
+        vm.expectRevert(IWorldIDRegistryV2.MethodUnsupported.selector);
+        registry.cancelRecoveryAgentUpdate(leafIndex, bytes(""), 0);
+    }
+
+    function test_ExecuteRecoveryAgentUpdate_RevertsMethodUnsupported() public {
+        uint64 leafIndex = _createAccount(auth1, recoveryOld);
+        vm.expectRevert(IWorldIDRegistryV2.MethodUnsupported.selector);
+        registry.executeRecoveryAgentUpdate(leafIndex);
+    }
+
+    function test_GetPendingRecoveryAgentUpdate_RevertsMethodUnsupported() public {
+        uint64 leafIndex = _createAccount(auth1, recoveryOld);
+        vm.expectRevert(IWorldIDRegistryV2.MethodUnsupported.selector);
+        registry.getPendingRecoveryAgentUpdate(leafIndex);
+    }
+}
+
+/// @title Cross-version sanity: a V1 pending update is orphaned (but harmless) after upgrade to V2.
+contract WorldIDRegistryV2WIP102OrphanTest is Test {
+    uint256 constant WIP102_ORPHAN_AUTH1_PRIVATE_KEY = 0xA1;
+    uint256 constant WIP102_ORPHAN_OFFCHAIN_SIGNER_COMMITMENT = 0x1234567890;
+
+    function test_V1PendingUpdateOrphanedAfterUpgrade() public {
+        address auth1 = vm.addr(WIP102_ORPHAN_AUTH1_PRIVATE_KEY);
+        address recoveryOld = address(0xEC01);
+        address recoveryLegacyPending = address(0xEC0F);
+        address recoveryPostUpgrade = address(0xEC02);
+
+        // Deploy V1 and create a pending update under the V1 three-tx flow.
+        WorldIDRegistry implementationV1 = new WorldIDRegistry();
+        ERC20Mock feeToken = new ERC20Mock();
+        bytes memory initData =
+            abi.encodeWithSelector(WorldIDRegistry.initialize.selector, 30, address(this), feeToken, 0);
+        ERC1967Proxy proxy = new ERC1967Proxy(address(implementationV1), initData);
+        WorldIDRegistry v1 = WorldIDRegistry(address(proxy));
+
+        address[] memory addrs = new address[](1);
+        addrs[0] = auth1;
+        uint256[] memory pubkeys = new uint256[](1);
+        pubkeys[0] = 0;
+        v1.createAccount(recoveryOld, addrs, pubkeys, WIP102_ORPHAN_OFFCHAIN_SIGNER_COMMITMENT);
+        uint64 leafIndex = 1;
+
+        bytes memory v1InitiateSig = _eip712SignV1(
+            v1,
+            v1.INITIATE_RECOVERY_AGENT_UPDATE_TYPEHASH(),
+            abi.encode(leafIndex, recoveryLegacyPending, uint256(0)),
+            WIP102_ORPHAN_AUTH1_PRIVATE_KEY
+        );
+        v1.initiateRecoveryAgentUpdate(leafIndex, recoveryLegacyPending, v1InitiateSig, 0);
+
+        (address legacyPending, uint256 legacyExecuteAfter) = v1.getPendingRecoveryAgentUpdate(leafIndex);
+        assertEq(legacyPending, recoveryLegacyPending);
+        assertTrue(legacyExecuteAfter > 0);
+
+        // Upgrade to V2.
+        WorldIDRegistryV2 implementationV2 = new WorldIDRegistryV2();
+        v1.upgradeToAndCall(address(implementationV2), "");
+        WorldIDRegistryV2 v2 = WorldIDRegistryV2(address(proxy));
+
+        // V1 pending-update view is loudly deprecated — consumers must migrate to
+        // `getPreviousRecoveryAgentUpdate`. The underlying V1 storage slot is not cleared.
+        vm.expectRevert(IWorldIDRegistryV2.MethodUnsupported.selector);
+        v2.getPendingRecoveryAgentUpdate(leafIndex);
+
+        // The new V2 flow works on the same leaf without tripping over the orphaned slot.
+        // Nonce is now 1 (V1 initiate incremented it).
+        bytes memory v2UpdateSig = _eip712SignV1(
+            WorldIDRegistry(address(v2)),
+            v2.UPDATE_RECOVERY_AGENT_TYPEHASH(),
+            abi.encode(leafIndex, recoveryPostUpgrade, uint256(1)),
+            WIP102_ORPHAN_AUTH1_PRIVATE_KEY
+        );
+        v2.updateRecoveryAgent(leafIndex, recoveryPostUpgrade, v2UpdateSig, 1);
+
+        // Effective agent during the fresh revert window is still the original recoveryOld.
+        assertEq(v2.getRecoveryAgent(leafIndex), recoveryOld);
+        (address prev,) = v2.getPreviousRecoveryAgentUpdate(leafIndex);
+        assertEq(prev, recoveryOld);
+    }
+
+    function _eip712SignV1(WorldIDRegistry reg, bytes32 typeHash, bytes memory data, uint256 privateKey)
+        private
+        view
+        returns (bytes memory)
+    {
+        bytes32 structHash = keccak256(abi.encodePacked(typeHash, data));
+        bytes32 digest = keccak256(abi.encodePacked("\x19\x01", reg.domainSeparatorV4(), structHash));
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, digest);
+        return abi.encodePacked(r, s, v);
     }
 }

--- a/contracts/test/core/WorldIDRegistryV2.t.sol
+++ b/contracts/test/core/WorldIDRegistryV2.t.sol
@@ -31,11 +31,7 @@ abstract contract WorldIDRegistryV2TestBase is Test {
         registry = WorldIDRegistryV2(address(proxy));
     }
 
-    function _eip712Sign(bytes32 typeHash, bytes memory data, uint256 privateKey)
-        internal
-        view
-        returns (bytes memory)
-    {
+    function _eip712Sign(bytes32 typeHash, bytes memory data, uint256 privateKey) internal view returns (bytes memory) {
         bytes32 structHash = keccak256(abi.encodePacked(typeHash, data));
         bytes32 digest = keccak256(abi.encodePacked("\x19\x01", registry.domainSeparatorV4(), structHash));
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, digest);
@@ -336,9 +332,7 @@ contract WorldIDRegistryV2WIP102Test is WorldIDRegistryV2TestBase {
         view
         returns (bytes memory)
     {
-        return _eip712Sign(
-            registry.REVERT_RECOVERY_AGENT_UPDATE_TYPEHASH(), abi.encode(leafIndex, nonce), privateKey
-        );
+        return _eip712Sign(registry.REVERT_RECOVERY_AGENT_UPDATE_TYPEHASH(), abi.encode(leafIndex, nonce), privateKey);
     }
 
     function _recoverAccountSig(
@@ -548,7 +542,8 @@ contract WorldIDRegistryV2WIP102Test is WorldIDRegistryV2TestBase {
         address newAuth = address(0xBEE1);
         uint256 nonce = 1;
         uint256 newCommitment = OFFCHAIN_SIGNER_COMMITMENT + 1;
-        bytes memory recoverySig = _recoverAccountSig(leafIndex, newAuth, newCommitment, nonce, RECOVERY_OLD_PRIVATE_KEY);
+        bytes memory recoverySig =
+            _recoverAccountSig(leafIndex, newAuth, newCommitment, nonce, RECOVERY_OLD_PRIVATE_KEY);
         registry.recoverAccount(
             leafIndex, newAuth, newCommitment, OFFCHAIN_SIGNER_COMMITMENT, newCommitment, recoverySig, nonce
         );
@@ -571,7 +566,8 @@ contract WorldIDRegistryV2WIP102Test is WorldIDRegistryV2TestBase {
         address newAuth = address(0xBEE1);
         uint256 nonce = 1;
         uint256 newCommitment = OFFCHAIN_SIGNER_COMMITMENT + 1;
-        bytes memory recoverySig = _recoverAccountSig(leafIndex, newAuth, newCommitment, nonce, RECOVERY_NEW_PRIVATE_KEY);
+        bytes memory recoverySig =
+            _recoverAccountSig(leafIndex, newAuth, newCommitment, nonce, RECOVERY_NEW_PRIVATE_KEY);
 
         vm.expectRevert(IWorldIDRegistry.InvalidSignature.selector);
         registry.recoverAccount(
@@ -591,7 +587,8 @@ contract WorldIDRegistryV2WIP102Test is WorldIDRegistryV2TestBase {
         address newAuth = address(0xBEE1);
         uint256 nonce = 1;
         uint256 newCommitment = OFFCHAIN_SIGNER_COMMITMENT + 1;
-        bytes memory recoverySig = _recoverAccountSig(leafIndex, newAuth, newCommitment, nonce, RECOVERY_NEW_PRIVATE_KEY);
+        bytes memory recoverySig =
+            _recoverAccountSig(leafIndex, newAuth, newCommitment, nonce, RECOVERY_NEW_PRIVATE_KEY);
 
         registry.recoverAccount(
             leafIndex, newAuth, newCommitment, OFFCHAIN_SIGNER_COMMITMENT, newCommitment, recoverySig, nonce
@@ -611,7 +608,8 @@ contract WorldIDRegistryV2WIP102Test is WorldIDRegistryV2TestBase {
         address newAuth = address(0xBEE1);
         uint256 nonce = 1;
         uint256 newCommitment = OFFCHAIN_SIGNER_COMMITMENT + 1;
-        bytes memory recoverySig = _recoverAccountSig(leafIndex, newAuth, newCommitment, nonce, RECOVERY_OLD_PRIVATE_KEY);
+        bytes memory recoverySig =
+            _recoverAccountSig(leafIndex, newAuth, newCommitment, nonce, RECOVERY_OLD_PRIVATE_KEY);
 
         vm.expectRevert(IWorldIDRegistry.InvalidSignature.selector);
         registry.recoverAccount(
@@ -625,7 +623,8 @@ contract WorldIDRegistryV2WIP102Test is WorldIDRegistryV2TestBase {
         address newAuth = address(0xBEE1);
         uint256 nonce = 0;
         uint256 newCommitment = OFFCHAIN_SIGNER_COMMITMENT + 1;
-        bytes memory recoverySig = _recoverAccountSig(leafIndex, newAuth, newCommitment, nonce, RECOVERY_OLD_PRIVATE_KEY);
+        bytes memory recoverySig =
+            _recoverAccountSig(leafIndex, newAuth, newCommitment, nonce, RECOVERY_OLD_PRIVATE_KEY);
 
         registry.recoverAccount(
             leafIndex, newAuth, newCommitment, OFFCHAIN_SIGNER_COMMITMENT, newCommitment, recoverySig, nonce
@@ -650,7 +649,8 @@ contract WorldIDRegistryV2WIP102Test is WorldIDRegistryV2TestBase {
         address newAuth = address(0xBEE1);
         uint256 nonce = 1;
         uint256 newCommitment = OFFCHAIN_SIGNER_COMMITMENT + 1;
-        bytes memory recoverySig = _recoverAccountSig(leafIndex, newAuth, newCommitment, nonce, RECOVERY_OLD_PRIVATE_KEY);
+        bytes memory recoverySig =
+            _recoverAccountSig(leafIndex, newAuth, newCommitment, nonce, RECOVERY_OLD_PRIVATE_KEY);
 
         registry.recoverAccount(
             leafIndex, newAuth, newCommitment, OFFCHAIN_SIGNER_COMMITMENT, newCommitment, recoverySig, nonce

--- a/contracts/test/core/WorldIDRegistryV2.t.sol
+++ b/contracts/test/core/WorldIDRegistryV2.t.sol
@@ -689,7 +689,7 @@ contract WorldIDRegistryV2WIP102Test is WorldIDRegistryV2TestBase {
             victimNonce
         );
 
-        // Attacker still controls `recoveryAttacker`'s ECDSA key. 
+        // Attacker still controls `recoveryAttacker`'s ECDSA key.
         // Effective recovery agent is `recoveryOld` again, so the attacker's signature no longer
         // matches the expected signer and the call reverts.
         address attackerNewAuth = address(0xBAD2);

--- a/contracts/test/core/WorldIDRegistryV2.t.sol
+++ b/contracts/test/core/WorldIDRegistryV2.t.sol
@@ -659,9 +659,78 @@ contract WorldIDRegistryV2WIP102Test is WorldIDRegistryV2TestBase {
             leafIndex, newAuth, newCommitment, OFFCHAIN_SIGNER_COMMITMENT, newCommitment, recoverySig, nonce
         );
 
-        // Attacker's mapping entry is cleared. Note the on-chain recovery agent is still `recoveryAttacker`
-        // at this point — the user must issue a fresh `updateRecoveryAgent` to restore their own agent.
-        // The critical property is that the attacker's update is no longer "protected" by a revert window.
+        // Mapping entry cleared and the legitimate recovery agent is restored to the slot. Without the
+        // restore, deleting the mapping would unmask the attacker's address as the effective agent and
+        // let them re-recover the account immediately afterwards.
+        (address prev, uint256 invalidAfter) = registry.getPreviousRecoveryAgentUpdate(leafIndex);
+        assertEq(prev, address(0));
+        assertEq(invalidAfter, 0);
+        assertEq(registry.getRecoveryAgent(leafIndex), recoveryOld);
+    }
+
+    function test_AttackMitigation_AttackerCannotReRecoverAfterVictimRecovery() public {
+        // Setup mirrors the mitigation test: attacker swaps the agent, victim recovers via the prev agent.
+        uint64 leafIndex = _createAccount(auth1, recoveryOld);
+        bytes memory attackerSig = _updateRecoveryAgentSig(leafIndex, recoveryAttacker, 0, AUTH1_PRIVATE_KEY);
+        registry.updateRecoveryAgent(leafIndex, recoveryAttacker, attackerSig, 0);
+
+        address victimNewAuth = address(0xBEE1);
+        uint256 victimNonce = 1;
+        uint256 victimCommitment = OFFCHAIN_SIGNER_COMMITMENT + 1;
+        bytes memory victimSig =
+            _recoverAccountSig(leafIndex, victimNewAuth, victimCommitment, victimNonce, RECOVERY_OLD_PRIVATE_KEY);
+        registry.recoverAccount(
+            leafIndex,
+            victimNewAuth,
+            victimCommitment,
+            OFFCHAIN_SIGNER_COMMITMENT,
+            victimCommitment,
+            victimSig,
+            victimNonce
+        );
+
+        // Attacker still controls `recoveryAttacker`'s ECDSA key. 
+        // Effective recovery agent is `recoveryOld` again, so the attacker's signature no longer
+        // matches the expected signer and the call reverts.
+        address attackerNewAuth = address(0xBAD2);
+        uint256 attackerNonce = 2;
+        uint256 attackerCommitment = victimCommitment + 1;
+        bytes memory attackerRecoverySig = _recoverAccountSig(
+            leafIndex, attackerNewAuth, attackerCommitment, attackerNonce, RECOVERY_ATTACKER_PRIVATE_KEY
+        );
+        vm.expectRevert(IWorldIDRegistry.InvalidSignature.selector);
+        registry.recoverAccount(
+            leafIndex,
+            attackerNewAuth,
+            attackerCommitment,
+            victimCommitment,
+            attackerCommitment,
+            attackerRecoverySig,
+            attackerNonce
+        );
+    }
+
+    function test_RecoverAccount_AfterWindow_DoesNotRestorePrev() public {
+        // Legitimate user rotates the recovery agent and lets the window elapse — `recoveryNew` is
+        // now fully effective. A subsequent recovery signed by the new agent must NOT restore the
+        // old agent into the slot.
+        uint64 leafIndex = _createAccount(auth1, recoveryOld);
+        bytes memory updateSig = _updateRecoveryAgentSig(leafIndex, recoveryNew, 0, AUTH1_PRIVATE_KEY);
+        registry.updateRecoveryAgent(leafIndex, recoveryNew, updateSig, 0);
+
+        skip(registry.getRecoveryAgentUpdateCooldown() + 1);
+
+        address newAuth = address(0xBEE2);
+        uint256 nonce = 1;
+        uint256 newCommitment = OFFCHAIN_SIGNER_COMMITMENT + 1;
+        bytes memory recoverySig =
+            _recoverAccountSig(leafIndex, newAuth, newCommitment, nonce, RECOVERY_NEW_PRIVATE_KEY);
+        registry.recoverAccount(
+            leafIndex, newAuth, newCommitment, OFFCHAIN_SIGNER_COMMITMENT, newCommitment, recoverySig, nonce
+        );
+
+        // Legitimate post-window state is preserved: the new agent stays in place, stale mapping cleared.
+        assertEq(registry.getRecoveryAgent(leafIndex), recoveryNew);
         (address prev, uint256 invalidAfter) = registry.getPreviousRecoveryAgentUpdate(leafIndex);
         assertEq(prev, address(0));
         assertEq(invalidAfter, 0);

--- a/contracts/test/core/WorldIDRegistryV2.t.sol
+++ b/contracts/test/core/WorldIDRegistryV2.t.sol
@@ -792,6 +792,22 @@ contract WorldIDRegistryV2WIP102Test is WorldIDRegistryV2TestBase {
         assertEq(pendingAgent, address(0));
         assertEq(validAfter, 0);
     }
+
+    function test_GetPreviousRecoveryAgentUpdate_AfterWindow_ReturnsZero() public {
+        // The mapping entry isn't auto-cleaned when `invalidAfter` elapses; the view must apply
+        // the timestamp guard so callers see `(0, 0)` consistently with the interface contract
+        // and don't offer doomed `revertRecoveryAgentUpdate` calls (would revert WindowExpired).
+        uint64 leafIndex = _createAccount(auth1, recoveryOld);
+        uint256 cooldown = registry.getRecoveryAgentUpdateCooldown();
+
+        bytes memory sig = _updateRecoveryAgentSig(leafIndex, recoveryNew, 0, AUTH1_PRIVATE_KEY);
+        registry.updateRecoveryAgent(leafIndex, recoveryNew, sig, 0);
+        skip(cooldown + 1);
+
+        (address prev, uint256 invalidAfter) = registry.getPreviousRecoveryAgentUpdate(leafIndex);
+        assertEq(prev, address(0));
+        assertEq(invalidAfter, 0);
+    }
 }
 
 /// @title Cross-version sanity: a V1 pending update is orphaned (but harmless) after upgrade to V2.

--- a/contracts/test/core/WorldIDRegistryV2.t.sol
+++ b/contracts/test/core/WorldIDRegistryV2.t.sol
@@ -547,6 +547,9 @@ contract WorldIDRegistryV2WIP102Test is WorldIDRegistryV2TestBase {
         uint256 newCommitment = OFFCHAIN_SIGNER_COMMITMENT + 1;
         bytes memory recoverySig =
             _recoverAccountSig(leafIndex, newAuth, newCommitment, nonce, RECOVERY_OLD_PRIVATE_KEY);
+
+        vm.expectEmit(true, true, true, true);
+        emit IWorldIDRegistryV2.RecoveryAgentUpdateReverted(leafIndex, recoveryOld, recoveryNew);
         registry.recoverAccount(
             leafIndex, newAuth, newCommitment, OFFCHAIN_SIGNER_COMMITMENT, newCommitment, recoverySig, nonce
         );

--- a/crates/authenticator/src/recovery.rs
+++ b/crates/authenticator/src/recovery.rs
@@ -23,7 +23,7 @@ impl Authenticator {
     /// # Errors
     /// Returns an error if the gateway rejects the request or a network error occurs.
     #[deprecated(
-        note = "WIP-102: use `update_recovery_agent`. The legacy URL still works against a V2-upgraded gateway, but the V2 contract changes the agent immediately with a revert window instead of starting a cooldown."
+        note = "WIP-102: use `update_recovery_agent`. The legacy URL still works against a V2-upgraded gateway, but the V2 contract changes the agent immediately (with a revert window) instead of starting a cooldown."
     )]
     pub async fn initiate_recovery_agent_update(
         &self,
@@ -93,13 +93,14 @@ impl Authenticator {
         Ok((signature, nonce))
     }
 
-    /// Updates the holder's recovery agent.
+    /// Updates the holder's recovery agent (WIP-102).
     ///
     /// On a V2 registry the new agent becomes effective immediately, but for a
     /// revert window (`getRecoveryAgentUpdateCooldown` seconds) any
     /// authenticator can call [`Self::revert_recovery_agent_update`] to roll
-    /// back. During that window the previous agent remains the valid signer for
-    /// `recoverAccount`.
+    /// back. During that window the *previous* agent remains the only valid
+    /// signer for `recoverAccount`, which mitigates a compromised authenticator
+    /// silently swapping in an attacker-controlled recovery address.
     ///
     /// # Errors
     /// Returns an error if the gateway rejects the request or a network error occurs.
@@ -134,7 +135,7 @@ impl Authenticator {
     /// # Errors
     /// Returns an error if the gateway rejects the request or a network error occurs.
     #[deprecated(
-        note = "WIP-102: this operation no longer exists. On a V2-upgraded gateway the call is a no-op and returns Queued without touching chain. Remove the call from your flow."
+        note = "WIP-102: this operation no longer exists. On a V2-upgraded gateway the call is a no-op (returns Queued without touching chain). Remove the call from your flow."
     )]
     pub async fn execute_recovery_agent_update(
         &self,
@@ -159,7 +160,7 @@ impl Authenticator {
     /// # Errors
     /// Returns an error if the gateway rejects the request or a network error occurs.
     #[deprecated(
-        note = "WIP-102: use `revert_recovery_agent_update`. The legacy URL still works against a V2-upgraded gateway, but the new method name reflects WIP-102 revert-window semantics."
+        note = "WIP-102: use `revert_recovery_agent_update`. The legacy URL still works against a V2-upgraded gateway, but the new method name reflects WIP-102 semantics: the operation can only succeed within the revert window after `update_recovery_agent`."
     )]
     pub async fn cancel_recovery_agent_update(
         &self,
@@ -195,7 +196,7 @@ impl Authenticator {
         Ok(gateway_resp.request_id)
     }
 
-    /// Reverts an in-flight recovery agent update during the revert window.
+    /// Reverts an in-flight recovery agent update during the revert window (WIP-102).
     ///
     /// # Errors
     /// Returns an error if the gateway rejects the request or a network error occurs.

--- a/crates/authenticator/src/recovery.rs
+++ b/crates/authenticator/src/recovery.rs
@@ -101,10 +101,6 @@ impl Authenticator {
     /// back. During that window the previous agent remains the valid signer for
     /// `recoverAccount`.
     ///
-    /// Internally signs with the same EIP-712 typehash as the legacy
-    /// `initiate_recovery_agent_update`, so existing keys and signing helpers
-    /// transfer over unchanged.
-    ///
     /// # Errors
     /// Returns an error if the gateway rejects the request or a network error occurs.
     pub async fn update_recovery_agent(
@@ -200,11 +196,6 @@ impl Authenticator {
     }
 
     /// Reverts an in-flight recovery agent update during the revert window.
-    ///
-    /// Only succeeds while `getPreviousRecoveryAgentUpdate` reports an active
-    /// window for this leaf. Once the window has elapsed, the new agent is
-    /// permanent and this call reverts on-chain. Internally signs with the same
-    /// EIP-712 typehash as the legacy `cancel_recovery_agent_update`.
     ///
     /// # Errors
     /// Returns an error if the gateway rejects the request or a network error occurs.

--- a/crates/authenticator/src/recovery.rs
+++ b/crates/authenticator/src/recovery.rs
@@ -135,7 +135,7 @@ impl Authenticator {
     /// # Errors
     /// Returns an error if the gateway rejects the request or a network error occurs.
     #[deprecated(
-        note = "WIP-102: this operation no longer exists. On a V2-upgraded gateway the call is a no-op (returns Queued without touching chain). Remove the call from your flow."
+        note = "WIP-102: this operation no longer exists. On a V2-upgraded gateway the call is a no-op (returns Finalized without touching chain). Remove the call from your flow."
     )]
     pub async fn execute_recovery_agent_update(
         &self,

--- a/crates/authenticator/src/recovery.rs
+++ b/crates/authenticator/src/recovery.rs
@@ -22,6 +22,9 @@ impl Authenticator {
     ///
     /// # Errors
     /// Returns an error if the gateway rejects the request or a network error occurs.
+    #[deprecated(
+        note = "WIP-102: use `update_recovery_agent`. The legacy URL still works against a V2-upgraded gateway, but the V2 contract changes the agent immediately with a revert window instead of starting a cooldown."
+    )]
     pub async fn initiate_recovery_agent_update(
         &self,
         new_recovery_agent: Address,
@@ -90,6 +93,43 @@ impl Authenticator {
         Ok((signature, nonce))
     }
 
+    /// Updates the holder's recovery agent.
+    ///
+    /// On a V2 registry the new agent becomes effective immediately, but for a
+    /// revert window (`getRecoveryAgentUpdateCooldown` seconds) any
+    /// authenticator can call [`Self::revert_recovery_agent_update`] to roll
+    /// back. During that window the previous agent remains the valid signer for
+    /// `recoverAccount`.
+    ///
+    /// Internally signs with the same EIP-712 typehash as the legacy
+    /// `initiate_recovery_agent_update`, so existing keys and signing helpers
+    /// transfer over unchanged.
+    ///
+    /// # Errors
+    /// Returns an error if the gateway rejects the request or a network error occurs.
+    pub async fn update_recovery_agent(
+        &self,
+        new_recovery_agent: Address,
+    ) -> Result<GatewayRequestId, AuthenticatorError> {
+        let leaf_index = self.leaf_index();
+        let (sig, nonce) = self
+            .danger_sign_initiate_recovery_agent_update(new_recovery_agent)
+            .await?;
+
+        let req = UpdateRecoveryAgentRequest {
+            leaf_index,
+            new_recovery_agent,
+            signature: sig,
+            nonce,
+        };
+
+        let gateway_resp: GatewayStatusResponse = self
+            .gateway_client
+            .post_json(self.config.gateway_url(), "/update-recovery-agent", &req)
+            .await?;
+        Ok(gateway_resp.request_id)
+    }
+
     /// Executes a pending recovery agent update for the holder's World ID.
     ///
     /// This is a permissionless operation that can be called by anyone after the cooldown
@@ -97,6 +137,9 @@ impl Authenticator {
     ///
     /// # Errors
     /// Returns an error if the gateway rejects the request or a network error occurs.
+    #[deprecated(
+        note = "WIP-102: this operation no longer exists. On a V2-upgraded gateway the call is a no-op and returns Queued without touching chain. Remove the call from your flow."
+    )]
     pub async fn execute_recovery_agent_update(
         &self,
     ) -> Result<GatewayRequestId, AuthenticatorError> {
@@ -119,6 +162,9 @@ impl Authenticator {
     ///
     /// # Errors
     /// Returns an error if the gateway rejects the request or a network error occurs.
+    #[deprecated(
+        note = "WIP-102: use `revert_recovery_agent_update`. The legacy URL still works against a V2-upgraded gateway, but the new method name reflects WIP-102 revert-window semantics."
+    )]
     pub async fn cancel_recovery_agent_update(
         &self,
     ) -> Result<GatewayRequestId, AuthenticatorError> {
@@ -147,6 +193,49 @@ impl Authenticator {
             .post_json(
                 self.config.gateway_url(),
                 "/cancel-recovery-agent-update",
+                &req,
+            )
+            .await?;
+        Ok(gateway_resp.request_id)
+    }
+
+    /// Reverts an in-flight recovery agent update during the revert window.
+    ///
+    /// Only succeeds while `getPreviousRecoveryAgentUpdate` reports an active
+    /// window for this leaf. Once the window has elapsed, the new agent is
+    /// permanent and this call reverts on-chain. Internally signs with the same
+    /// EIP-712 typehash as the legacy `cancel_recovery_agent_update`.
+    ///
+    /// # Errors
+    /// Returns an error if the gateway rejects the request or a network error occurs.
+    pub async fn revert_recovery_agent_update(
+        &self,
+    ) -> Result<GatewayRequestId, AuthenticatorError> {
+        let leaf_index = self.leaf_index();
+        let nonce = self.signing_nonce().await?;
+        let eip712_domain = domain(self.config.chain_id(), *self.config.registry_address());
+
+        let sig = sign_cancel_recovery_agent_update(
+            &self.signer.onchain_signer(),
+            leaf_index,
+            nonce,
+            &eip712_domain,
+        )
+        .map_err(|e| {
+            AuthenticatorError::Generic(format!("Failed to sign revert recovery agent update: {e}"))
+        })?;
+
+        let req = CancelRecoveryAgentUpdateRequest {
+            leaf_index,
+            signature: sig,
+            nonce,
+        };
+
+        let gateway_resp: GatewayStatusResponse = self
+            .gateway_client
+            .post_json(
+                self.config.gateway_url(),
+                "/revert-recovery-agent-update",
                 &req,
             )
             .await?;

--- a/crates/primitives/src/api_types.rs
+++ b/crates/primitives/src/api_types.rs
@@ -190,6 +190,9 @@ pub struct UpdateRecoveryAgentRequest {
 /// `RecoveryAgentUpdateStillInCooldown` if called too early.
 ///
 /// Numeric string fields in this request accept decimal or `0x`/`0X`-prefixed hex.
+// TODO(WIP-102): delete this type once V1 callers have migrated. WIP-102
+// removes the explicit execute step — the new agent activates automatically
+// when the revert window elapses.
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ExecuteRecoveryAgentUpdateRequest {
@@ -202,6 +205,9 @@ pub struct ExecuteRecoveryAgentUpdateRequest {
 /// The request to cancel a pending recovery agent update.
 ///
 /// Numeric string fields in this request accept decimal or `0x`/`0X`-prefixed hex.
+// TODO(WIP-102): rename to `RevertRecoveryAgentUpdateRequest` once V1 callers
+// have migrated. The struct shape is identical; only the name needs to change
+// to reflect WIP-102's revert-window semantics.
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 #[derive(Debug, Serialize, Deserialize)]
 pub struct CancelRecoveryAgentUpdateRequest {
@@ -324,8 +330,12 @@ pub enum GatewayRequestKind {
     /// Recovery agent update initiation request.
     UpdateRecoveryAgent,
     /// Recovery agent update cancellation request.
+    // TODO(WIP-102): rename to `RevertRecoveryAgentUpdate` once V1 callers
+    // have migrated.
     CancelRecoveryAgentUpdate,
     /// Recovery agent update execution request.
+    // TODO(WIP-102): delete this variant once V1 callers have migrated — the
+    // execute step no longer exists in WIP-102.
     ExecuteRecoveryAgentUpdate,
     /// Account recovery request.
     RecoverAccount,
@@ -440,6 +450,13 @@ pub struct IndexerRecoveryAgentResponse {
 }
 
 /// Response containing the pending recovery agent from the indexer.
+// TODO(WIP-102): post-V1-sunset, rename this type and its `execute_after`
+// field to reflect WIP-102 semantics — the timestamp is no longer when the
+// update may be *executed* but when the new agent becomes the only valid
+// recovery signer (`validAfter` / `invalidAfter` for the previous agent).
+// The wire shape is preserved on V2 via a contract-side override of
+// `getPendingRecoveryAgentUpdate`, so no breaking change is required until
+// callers migrate to a new indexer route.
 #[derive(Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 pub struct IndexerPendingRecoveryAgentResponse {

--- a/crates/primitives/src/api_types.rs
+++ b/crates/primitives/src/api_types.rs
@@ -577,6 +577,10 @@ pub enum GatewayErrorCode {
     RateLimitExceeded,
     /// The request timed out.
     RequestTimeout,
+    /// Endpoint exists but is not available against the currently-deployed
+    /// registry version (e.g. a WIP-102 V2-only route hit while the registry
+    /// is still on V1). Mirrors the contract-level `MethodUnsupported()` revert.
+    MethodNotAvailable,
 }
 
 /// Error object returned by the services APIs (indexer, gateway).

--- a/crates/registries/abi/WorldIDRegistryV2Abi.json
+++ b/crates/registries/abi/WorldIDRegistryV2Abi.json
@@ -1,0 +1,2165 @@
+[
+  {
+    "type": "function",
+    "name": "CANCEL_RECOVERY_AGENT_UPDATE_TYPEHASH",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "EIP712_NAME",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "EIP712_VERSION",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "INITIATE_RECOVERY_AGENT_UPDATE_TYPEHASH",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "INSERT_AUTHENTICATOR_TYPEHASH",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "MAX_AUTHENTICATORS_HARD_LIMIT",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "MAX_AUTHENTICATORS_V2_HARD_LIMIT",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "RECOVER_ACCOUNT_TYPEHASH",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "REMOVE_AUTHENTICATOR_TYPEHASH",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "REVERT_RECOVERY_AGENT_UPDATE_TYPEHASH",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "UPDATE_AUTHENTICATOR_TYPEHASH",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "UPDATE_RECOVERY_AGENT_TYPEHASH",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "UPGRADE_INTERFACE_VERSION",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "acceptOwnership",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "cancelRecoveryAgentUpdate",
+    "inputs": [
+      {
+        "name": "",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "",
+        "type": "bytes",
+        "internalType": "bytes"
+      },
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "createAccount",
+    "inputs": [
+      {
+        "name": "recoveryAddress",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "authenticatorAddresses",
+        "type": "address[]",
+        "internalType": "address[]"
+      },
+      {
+        "name": "authenticatorPubkeys",
+        "type": "uint256[]",
+        "internalType": "uint256[]"
+      },
+      {
+        "name": "offchainSignerCommitment",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "createManyAccounts",
+    "inputs": [
+      {
+        "name": "recoveryAddresses",
+        "type": "address[]",
+        "internalType": "address[]"
+      },
+      {
+        "name": "authenticatorAddresses",
+        "type": "address[][]",
+        "internalType": "address[][]"
+      },
+      {
+        "name": "authenticatorPubkeys",
+        "type": "uint256[][]",
+        "internalType": "uint256[][]"
+      },
+      {
+        "name": "offchainSignerCommitments",
+        "type": "uint256[]",
+        "internalType": "uint256[]"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "currentRoot",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "domainSeparatorV4",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "eip712Domain",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "fields",
+        "type": "bytes1",
+        "internalType": "bytes1"
+      },
+      {
+        "name": "name",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "version",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "chainId",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "verifyingContract",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "salt",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "extensions",
+        "type": "uint256[]",
+        "internalType": "uint256[]"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "executeRecoveryAgentUpdate",
+    "inputs": [
+      {
+        "name": "",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "getFeeRecipient",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getFeeToken",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getLatestRoot",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getMaxAuthenticators",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getNextLeafIndex",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getPackedAccountData",
+    "inputs": [
+      {
+        "name": "authenticatorAddress",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getPendingRecoveryAgentUpdate",
+    "inputs": [
+      {
+        "name": "",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getPreviousRecoveryAgentUpdate",
+    "inputs": [
+      {
+        "name": "leafIndex",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "prevRecoveryAgent",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "invalidAfter",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getProof",
+    "inputs": [
+      {
+        "name": "leafIndex",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256[]",
+        "internalType": "uint256[]"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getRecoveryAgent",
+    "inputs": [
+      {
+        "name": "leafIndex",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getRecoveryAgentUpdateCooldown",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getRecoveryCounter",
+    "inputs": [
+      {
+        "name": "leafIndex",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getRegistrationFee",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getRootExpiration",
+    "inputs": [
+      {
+        "name": "root",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getRootTimestamp",
+    "inputs": [
+      {
+        "name": "root",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getRootValidityWindow",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getSignatureNonce",
+    "inputs": [
+      {
+        "name": "leafIndex",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getTreeDepth",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "initialize",
+    "inputs": [
+      {
+        "name": "initialTreeDepth",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "feeRecipient",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "feeToken",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "registrationFee",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "initiateRecoveryAgentUpdate",
+    "inputs": [
+      {
+        "name": "",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "",
+        "type": "bytes",
+        "internalType": "bytes"
+      },
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "insertAuthenticator",
+    "inputs": [
+      {
+        "name": "leafIndex",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "newAuthenticatorAddress",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "pubkeyId",
+        "type": "uint32",
+        "internalType": "uint32"
+      },
+      {
+        "name": "newAuthenticatorPubkey",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "oldOffchainSignerCommitment",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "newOffchainSignerCommitment",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "signature",
+        "type": "bytes",
+        "internalType": "bytes"
+      },
+      {
+        "name": "nonce",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "isValidRoot",
+    "inputs": [
+      {
+        "name": "root",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "owner",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "pendingOwner",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "proxiableUUID",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "recoverAccount",
+    "inputs": [
+      {
+        "name": "leafIndex",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "newAuthenticatorAddress",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "newAuthenticatorPubkey",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "oldOffchainSignerCommitment",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "newOffchainSignerCommitment",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "signature",
+        "type": "bytes",
+        "internalType": "bytes"
+      },
+      {
+        "name": "nonce",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "removeAuthenticator",
+    "inputs": [
+      {
+        "name": "leafIndex",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "authenticatorAddress",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "pubkeyId",
+        "type": "uint32",
+        "internalType": "uint32"
+      },
+      {
+        "name": "authenticatorPubkey",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "oldOffchainSignerCommitment",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "newOffchainSignerCommitment",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "signature",
+        "type": "bytes",
+        "internalType": "bytes"
+      },
+      {
+        "name": "nonce",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "renounceOwnership",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "revertRecoveryAgentUpdate",
+    "inputs": [
+      {
+        "name": "leafIndex",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "signature",
+        "type": "bytes",
+        "internalType": "bytes"
+      },
+      {
+        "name": "nonce",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setFeeRecipient",
+    "inputs": [
+      {
+        "name": "newFeeRecipient",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setFeeToken",
+    "inputs": [
+      {
+        "name": "newFeeToken",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setMaxAuthenticators",
+    "inputs": [
+      {
+        "name": "newMaxAuthenticators",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setRecoveryAgentUpdateCooldown",
+    "inputs": [
+      {
+        "name": "newCooldown",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setRegistrationFee",
+    "inputs": [
+      {
+        "name": "newFee",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setRootValidityWindow",
+    "inputs": [
+      {
+        "name": "newWindow",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "transferOwnership",
+    "inputs": [
+      {
+        "name": "newOwner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "updateAuthenticator",
+    "inputs": [
+      {
+        "name": "",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "",
+        "type": "uint32",
+        "internalType": "uint32"
+      },
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "",
+        "type": "bytes",
+        "internalType": "bytes"
+      },
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "updateRecoveryAgent",
+    "inputs": [
+      {
+        "name": "leafIndex",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "newRecoveryAgent",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "signature",
+        "type": "bytes",
+        "internalType": "bytes"
+      },
+      {
+        "name": "nonce",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "upgradeToAndCall",
+    "inputs": [
+      {
+        "name": "newImplementation",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "data",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "event",
+    "name": "AccountCreated",
+    "inputs": [
+      {
+        "name": "leafIndex",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
+      },
+      {
+        "name": "recoveryAddress",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "authenticatorAddresses",
+        "type": "address[]",
+        "indexed": false,
+        "internalType": "address[]"
+      },
+      {
+        "name": "authenticatorPubkeys",
+        "type": "uint256[]",
+        "indexed": false,
+        "internalType": "uint256[]"
+      },
+      {
+        "name": "offchainSignerCommitment",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "AccountRecovered",
+    "inputs": [
+      {
+        "name": "leafIndex",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
+      },
+      {
+        "name": "newAuthenticatorAddress",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "newAuthenticatorPubkey",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "oldOffchainSignerCommitment",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "newOffchainSignerCommitment",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "AccountUpdated",
+    "inputs": [
+      {
+        "name": "leafIndex",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
+      },
+      {
+        "name": "pubkeyId",
+        "type": "uint32",
+        "indexed": false,
+        "internalType": "uint32"
+      },
+      {
+        "name": "newAuthenticatorPubkey",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "oldAuthenticatorAddress",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "newAuthenticatorAddress",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "oldOffchainSignerCommitment",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "newOffchainSignerCommitment",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "AuthenticatorInserted",
+    "inputs": [
+      {
+        "name": "leafIndex",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
+      },
+      {
+        "name": "pubkeyId",
+        "type": "uint32",
+        "indexed": false,
+        "internalType": "uint32"
+      },
+      {
+        "name": "authenticatorAddress",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "newAuthenticatorPubkey",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "oldOffchainSignerCommitment",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "newOffchainSignerCommitment",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "AuthenticatorRemoved",
+    "inputs": [
+      {
+        "name": "leafIndex",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
+      },
+      {
+        "name": "pubkeyId",
+        "type": "uint32",
+        "indexed": false,
+        "internalType": "uint32"
+      },
+      {
+        "name": "authenticatorAddress",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "authenticatorPubkey",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "oldOffchainSignerCommitment",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "newOffchainSignerCommitment",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "EIP712DomainChanged",
+    "inputs": [],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "FeeRecipientUpdated",
+    "inputs": [
+      {
+        "name": "oldRecipient",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "newRecipient",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "FeeTokenUpdated",
+    "inputs": [
+      {
+        "name": "oldToken",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "newToken",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Initialized",
+    "inputs": [
+      {
+        "name": "version",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "MaxAuthenticatorsUpdated",
+    "inputs": [
+      {
+        "name": "oldMax",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "newMax",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "OwnershipTransferStarted",
+    "inputs": [
+      {
+        "name": "previousOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "newOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "OwnershipTransferred",
+    "inputs": [
+      {
+        "name": "previousOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "newOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "RecoveryAgentUpdateCancelled",
+    "inputs": [
+      {
+        "name": "leafIndex",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
+      },
+      {
+        "name": "cancelledRecoveryAgent",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "RecoveryAgentUpdateCooldownUpdated",
+    "inputs": [
+      {
+        "name": "oldCooldown",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "newCooldown",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "RecoveryAgentUpdateExecuted",
+    "inputs": [
+      {
+        "name": "leafIndex",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
+      },
+      {
+        "name": "oldRecoveryAgent",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "newRecoveryAgent",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "RecoveryAgentUpdateInitiated",
+    "inputs": [
+      {
+        "name": "leafIndex",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
+      },
+      {
+        "name": "oldRecoveryAgent",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "newRecoveryAgent",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "executeAfter",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "RecoveryAgentUpdateReverted",
+    "inputs": [
+      {
+        "name": "leafIndex",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
+      },
+      {
+        "name": "restoredRecoveryAgent",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "revertedRecoveryAgent",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "RecoveryAgentUpdated",
+    "inputs": [
+      {
+        "name": "leafIndex",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
+      },
+      {
+        "name": "prevRecoveryAgent",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "newRecoveryAgent",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "invalidAfter",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "RegistrationFeeUpdated",
+    "inputs": [
+      {
+        "name": "oldFee",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "newFee",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "RootRecorded",
+    "inputs": [
+      {
+        "name": "root",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "timestamp",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "RootValidityWindowUpdated",
+    "inputs": [
+      {
+        "name": "oldWindow",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "newWindow",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Upgraded",
+    "inputs": [
+      {
+        "name": "implementation",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "error",
+    "name": "AccountDoesNotExist",
+    "inputs": [
+      {
+        "name": "leafIndex",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "AddressEmptyCode",
+    "inputs": [
+      {
+        "name": "target",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "AlreadyInitialized",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "AuthenticatorAddressAlreadyInUse",
+    "inputs": [
+      {
+        "name": "authenticatorAddress",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "AuthenticatorAlreadyExists",
+    "inputs": [
+      {
+        "name": "authenticatorAddress",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "AuthenticatorClassMismatch",
+    "inputs": [
+      {
+        "name": "pubkeyId",
+        "type": "uint32",
+        "internalType": "uint32"
+      },
+      {
+        "name": "isProvingAuthenticator",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "AuthenticatorDoesNotBelongToAccount",
+    "inputs": [
+      {
+        "name": "expectedLeafIndex",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "actualLeafIndex",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "AuthenticatorDoesNotExist",
+    "inputs": [
+      {
+        "name": "authenticatorAddress",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "BitmapOverflow",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "DepthNotSupported",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ECDSAInvalidSignature",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ECDSAInvalidSignatureLength",
+    "inputs": [
+      {
+        "name": "length",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ECDSAInvalidSignatureS",
+    "inputs": [
+      {
+        "name": "s",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ERC1967InvalidImplementation",
+    "inputs": [
+      {
+        "name": "implementation",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ERC1967NonPayable",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "EmptyAddressArray",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "FailedCall",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ImplementationNotInitialized",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InsufficientFunds",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidInitialization",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidSignature",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "LeafDoesNotExist",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "LeafIndexOutOfRange",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "MethodUnsupported",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "MismatchedAuthenticatorSigner",
+    "inputs": [
+      {
+        "name": "expectedAuthenticatorAddress",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "actualAuthenticatorAddress",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "MismatchedLeafIndex",
+    "inputs": [
+      {
+        "name": "expectedLeafIndex",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "actualLeafIndex",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "MismatchedPubkeyId",
+    "inputs": [
+      {
+        "name": "expectedPubkeyId",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "actualPubkeyId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "MismatchedRecoveryCounter",
+    "inputs": [
+      {
+        "name": "leafIndex",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "expectedRecoveryCounter",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "actualRecoveryCounter",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "MismatchedSignatureNonce",
+    "inputs": [
+      {
+        "name": "leafIndex",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "expectedNonce",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "actualNonce",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "MismatchingArrayLengths",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NewLeafCannotEqualOldLeaf",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NoActiveRecoveryAgentUpdate",
+    "inputs": [
+      {
+        "name": "leafIndex",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "NoPendingRecoveryAgentUpdate",
+    "inputs": [
+      {
+        "name": "leafIndex",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "NotInitializing",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "OwnableInvalidOwner",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "OwnableUnauthorizedAccount",
+    "inputs": [
+      {
+        "name": "account",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "OwnerMaxAuthenticatorsOutOfBounds",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "PubkeyIdDoesNotExist",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "PubkeyIdInUse",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "PubkeyIdOutOfBounds",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "PubkeyIdOverflow",
+    "inputs": [
+      {
+        "name": "pubkeyId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "RecoveryAddressNotSet",
+    "inputs": [
+      {
+        "name": "leafIndex",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "RecoveryAgentUpdateStillActive",
+    "inputs": [
+      {
+        "name": "leafIndex",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "invalidAfter",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "RecoveryAgentUpdateStillInCooldown",
+    "inputs": [
+      {
+        "name": "leafIndex",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "executeAfter",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "RecoveryAgentUpdateWindowExpired",
+    "inputs": [
+      {
+        "name": "leafIndex",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "invalidAfter",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "RecoveryCounterOverflow",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "RecoveryNotEnabled",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ReusedAuthenticatorAddress",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "SafeERC20FailedOperation",
+    "inputs": [
+      {
+        "name": "token",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "TreeIsFull",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "UUPSUnauthorizedCallContext",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "UUPSUnsupportedProxiableUUID",
+    "inputs": [
+      {
+        "name": "slot",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "UnknownRoot",
+    "inputs": [
+      {
+        "name": "root",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "UnmanageableNotAllowed",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ValueGreaterThanSnarkScalarField",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "WrongDefaultZeroIndex",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroAddress",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroRecoveredSignatureAddress",
+    "inputs": []
+  }
+]

--- a/crates/registries/abi/WorldIDRegistryV2Abi.json
+++ b/crates/registries/abi/WorldIDRegistryV2Abi.json
@@ -425,19 +425,19 @@
     "name": "getPendingRecoveryAgentUpdate",
     "inputs": [
       {
-        "name": "",
+        "name": "leafIndex",
         "type": "uint64",
         "internalType": "uint64"
       }
     ],
     "outputs": [
       {
-        "name": "",
+        "name": "newRecoveryAgent",
         "type": "address",
         "internalType": "address"
       },
       {
-        "name": "",
+        "name": "validAfter",
         "type": "uint256",
         "internalType": "uint256"
       }

--- a/crates/registries/abi/WorldIDRegistryV2Abi.json
+++ b/crates/registries/abi/WorldIDRegistryV2Abi.json
@@ -118,33 +118,7 @@
   },
   {
     "type": "function",
-    "name": "REVERT_RECOVERY_AGENT_UPDATE_TYPEHASH",
-    "inputs": [],
-    "outputs": [
-      {
-        "name": "",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
     "name": "UPDATE_AUTHENTICATOR_TYPEHASH",
-    "inputs": [],
-    "outputs": [
-      {
-        "name": "",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
-    "name": "UPDATE_RECOVERY_AGENT_TYPEHASH",
     "inputs": [],
     "outputs": [
       {

--- a/crates/registries/src/world_id.rs
+++ b/crates/registries/src/world_id.rs
@@ -95,7 +95,9 @@ mod sol_types {
         /// EIP-712 typed-data payload for `cancelRecoveryAgentUpdate`.
         ///
         /// Matches `CANCEL_RECOVERY_AGENT_UPDATE_TYPEHASH` on the contract:
-        /// `CancelRecoveryAgentUpdate(uint64 leafIndex,uint256 nonce)`
+        /// `CancelRecoveryAgentUpdate(uint64 leafIndex,uint256 nonce)`.
+        /// WIP-102 reuses this same typehash on `revertRecoveryAgentUpdate`
+        /// entry point so pre-upgrade signatures remain valid post-upgrade.
         struct CancelRecoveryAgentUpdate {
             uint64 leafIndex;
             uint256 nonce;
@@ -112,8 +114,10 @@ pub type RemoveAuthenticatorTypedData = sol_types::RemoveAuthenticator;
 /// EIP-712 typed-data signature payload for `recoverAccount`.
 pub type RecoverAccountTypedData = sol_types::RecoverAccount;
 /// EIP-712 typed-data signature payload for `initiateRecoveryAgentUpdate`.
+/// Also used by V2 `updateRecoveryAgent` (WIP-102 — reuses the V1 typehash).
 pub type InitiateRecoveryAgentUpdateTypedData = sol_types::InitiateRecoveryAgentUpdate;
 /// EIP-712 typed-data signature payload for `cancelRecoveryAgentUpdate`.
+/// Also used by V2 `revertRecoveryAgentUpdate` (WIP-102 — reuses the V1 typehash).
 pub type CancelRecoveryAgentUpdateTypedData = sol_types::CancelRecoveryAgentUpdate;
 
 /// Returns the EIP-712 domain used by the `[WorldIdRegistry]` contract
@@ -277,8 +281,8 @@ pub fn sign_cancel_recovery_agent_update<S: SignerSync + Sync>(
     let digest = payload.eip712_signing_hash(domain);
     Ok(signer.sign_hash_sync(&digest)?)
 }
-
 #[cfg(test)]
+
 mod tests {
     use super::*;
     use alloy::{

--- a/crates/registries/src/world_id.rs
+++ b/crates/registries/src/world_id.rs
@@ -18,9 +18,7 @@ sol!(
 );
 
 sol!(
-    /// V2 of the World ID registry: bundles the root-validity race-condition fix, WIP-104
-    /// Proving Authenticators, and WIP-102 simplified optimistic Recovery Agent update
-    /// (`updateRecoveryAgent` / `revertRecoveryAgentUpdate`). ABI is a superset of V1.
+    /// V2 of the World ID registry
     #[allow(clippy::too_many_arguments)]
     #[sol(rpc, ignore_unlinked)]
     WorldIdRegistryV2,
@@ -95,9 +93,6 @@ mod sol_types {
         /// EIP-712 typed-data payload for `cancelRecoveryAgentUpdate`.
         ///
         /// Matches `CANCEL_RECOVERY_AGENT_UPDATE_TYPEHASH` on the contract:
-        /// `CancelRecoveryAgentUpdate(uint64 leafIndex,uint256 nonce)`.
-        /// WIP-102 reuses this same typehash on `revertRecoveryAgentUpdate`
-        /// entry point so pre-upgrade signatures remain valid post-upgrade.
         struct CancelRecoveryAgentUpdate {
             uint64 leafIndex;
             uint256 nonce;

--- a/crates/registries/src/world_id.rs
+++ b/crates/registries/src/world_id.rs
@@ -282,7 +282,6 @@ pub fn sign_cancel_recovery_agent_update<S: SignerSync + Sync>(
     Ok(signer.sign_hash_sync(&digest)?)
 }
 #[cfg(test)]
-
 mod tests {
     use super::*;
     use alloy::{

--- a/crates/registries/src/world_id.rs
+++ b/crates/registries/src/world_id.rs
@@ -17,6 +17,16 @@ sol!(
     "abi/WorldIDRegistryAbi.json"
 );
 
+sol!(
+    /// V2 of the World ID registry: bundles the root-validity race-condition fix, WIP-104
+    /// Proving Authenticators, and WIP-102 simplified optimistic Recovery Agent update
+    /// (`updateRecoveryAgent` / `revertRecoveryAgentUpdate`). ABI is a superset of V1.
+    #[allow(clippy::too_many_arguments)]
+    #[sol(rpc, ignore_unlinked)]
+    WorldIdRegistryV2,
+    "abi/WorldIDRegistryV2Abi.json"
+);
+
 /// These structs are created in a private module to avoid confusion with their exports.
 ///
 /// They are only used to compute the EIP-712 typed data for signature.

--- a/crates/test-utils/src/anvil.rs
+++ b/crates/test-utils/src/anvil.rs
@@ -85,6 +85,16 @@ sol!(
 );
 
 sol!(
+    #[allow(clippy::too_many_arguments)]
+    #[sol(rpc, ignore_unlinked)]
+    WorldIDRegistryV2,
+    concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../contracts/out/WorldIDRegistryV2Unreleased.sol/WorldIDRegistryV2.json"
+    )
+);
+
+sol!(
     #[sol(rpc)]
     ERC1967Proxy,
     concat!(
@@ -405,57 +415,25 @@ impl TestAnvil {
             .wallet(EthereumWallet::from(signer.clone()))
             .connect_http(self.rpc_url.parse().context("invalid anvil endpoint URL")?);
 
-        // Step 1: Deploy Poseidon2T2 library (no dependencies)
         let poseidon = Poseidon2T2::deploy(provider.clone())
             .await
             .context("failed to deploy Poseidon2T2 library")?;
-
-        // Step 2: Deploy PackedAccountData library (no dependencies)
         let packed_account_data = PackedAccountData::deploy(provider.clone())
             .await
             .context("failed to deploy PackedAccountData library")?;
 
-        // Step 3: Link Poseidon2T2 and PackedAccountData to WorldIDRegistry
-        // (FullStorageBinaryIMT is an internal library inlined into WorldIDRegistry,
-        // but it uses Poseidon2T2 which is a public library requiring linking.)
-        let world_id_registry_json = include_str!(concat!(
+        let v1_json = include_str!(concat!(
             env!("CARGO_MANIFEST_DIR"),
             "/../../contracts/out/WorldIDRegistry.sol/WorldIDRegistry.json"
         ));
-
-        let json_value: serde_json::Value = serde_json::from_str(world_id_registry_json)?;
-        let mut bytecode_str = json_value["bytecode"]["object"]
-            .as_str()
-            .context("bytecode not found in JSON")?
-            .strip_prefix("0x")
-            .unwrap_or_else(|| {
-                json_value["bytecode"]["object"]
-                    .as_str()
-                    .expect("bytecode should be a string")
-            })
-            .to_string();
-
-        bytecode_str = Self::link_bytecode_hex(
-            world_id_registry_json,
-            &bytecode_str,
-            "src/core/hash/Poseidon2.sol:Poseidon2T2",
+        let implementation_address = Self::deploy_linked_registry_impl(
+            provider.clone(),
+            v1_json,
             *poseidon.address(),
-        )?;
-
-        bytecode_str = Self::link_bytecode_hex(
-            world_id_registry_json,
-            &bytecode_str,
-            "src/core/libraries/PackedAccountData.sol:PackedAccountData",
             *packed_account_data.address(),
-        )?;
-
-        // Decode the fully-linked bytecode
-        let world_id_registry_bytecode = Bytes::from(hex::decode(bytecode_str)?);
-
-        let implementation_address =
-            Self::deploy_contract(provider.clone(), world_id_registry_bytecode, Bytes::new())
-                .await
-                .context("failed to deploy WorldIDRegistry implementation")?;
+        )
+        .await
+        .context("failed to deploy WorldIDRegistry implementation")?;
 
         let init_data = Bytes::from(
             WorldIDRegistry::initializeCall {
@@ -479,6 +457,127 @@ impl TestAnvil {
     pub async fn deploy_world_id_registry(&self, signer: PrivateKeySigner) -> Result<Address> {
         self.deploy_world_id_registry_with_depth(signer, TREE_DEPTH as u64)
             .await
+    }
+
+    /// Deploys the `WorldIDRegistry` behind an ERC1967 proxy (initialized as V1)
+    /// and then upgrades the proxy to the V2 implementation. Returns the proxy
+    /// address. Mirrors the on-chain contract upgrade flow used in production.
+    #[allow(dead_code)]
+    pub async fn deploy_world_id_registry_v2_with_depth(
+        &self,
+        signer: PrivateKeySigner,
+        tree_depth: u64,
+    ) -> Result<Address> {
+        let provider = ProviderBuilder::new()
+            .wallet(EthereumWallet::from(signer.clone()))
+            .connect_http(self.rpc_url.parse().context("invalid anvil endpoint URL")?);
+
+        // 1. Deploy the libraries shared by both V1 and V2 bytecode.
+        let poseidon = Poseidon2T2::deploy(provider.clone())
+            .await
+            .context("failed to deploy Poseidon2T2 library")?;
+        let packed_account_data = PackedAccountData::deploy(provider.clone())
+            .await
+            .context("failed to deploy PackedAccountData library")?;
+
+        // 2. Deploy V1 implementation, link, and stand up the proxy.
+        let v1_json = include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../contracts/out/WorldIDRegistry.sol/WorldIDRegistry.json"
+        ));
+        let v1_impl = Self::deploy_linked_registry_impl(
+            provider.clone(),
+            v1_json,
+            *poseidon.address(),
+            *packed_account_data.address(),
+        )
+        .await
+        .context("failed to deploy WorldIDRegistry V1 implementation")?;
+
+        let init_data = Bytes::from(
+            WorldIDRegistry::initializeCall {
+                initialTreeDepth: U256::from(tree_depth),
+                feeRecipient: address!("0x2cFc85d8E48F8EAB294be644d9E25C3030863003"),
+                feeToken: address!("0x2cFc85d8E48F8EAB294be644d9E25C3030863003"),
+                registrationFee: U256::from(0),
+            }
+            .abi_encode(),
+        );
+        let proxy = ERC1967Proxy::deploy(provider.clone(), v1_impl, init_data)
+            .await
+            .context("failed to deploy WorldIDRegistry proxy")?;
+        let proxy_address = *proxy.address();
+
+        // 3. Deploy V2 implementation linked against the same libraries.
+        let v2_json = include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../contracts/out/WorldIDRegistryV2Unreleased.sol/WorldIDRegistryV2.json"
+        ));
+        let v2_impl = Self::deploy_linked_registry_impl(
+            provider.clone(),
+            v2_json,
+            *poseidon.address(),
+            *packed_account_data.address(),
+        )
+        .await
+        .context("failed to deploy WorldIDRegistry V2 implementation")?;
+
+        // 4. Upgrade the proxy to V2.
+        let proxy_v1 = WorldIDRegistry::new(proxy_address, provider);
+        proxy_v1
+            .upgradeToAndCall(v2_impl, Bytes::new())
+            .send()
+            .await
+            .context("failed to send upgradeToAndCall(V2)")?
+            .watch()
+            .await
+            .context("upgradeToAndCall(V2) transaction not mined")?;
+
+        Ok(proxy_address)
+    }
+
+    /// Deploys the V2 `WorldIDRegistry` (V1 → V2 upgrade) with default tree depth.
+    #[allow(dead_code)]
+    pub async fn deploy_world_id_registry_v2(&self, signer: PrivateKeySigner) -> Result<Address> {
+        self.deploy_world_id_registry_v2_with_depth(signer, TREE_DEPTH as u64)
+            .await
+    }
+
+    /// Links Poseidon2T2 + PackedAccountData into a registry implementation
+    /// bytecode (`WorldIDRegistry` or `WorldIDRegistryV2`) and deploys it.
+    async fn deploy_linked_registry_impl<P: Provider>(
+        provider: P,
+        impl_json: &str,
+        poseidon_addr: Address,
+        packed_account_data_addr: Address,
+    ) -> Result<Address> {
+        let json_value: serde_json::Value = serde_json::from_str(impl_json)?;
+        let mut bytecode_str = json_value["bytecode"]["object"]
+            .as_str()
+            .context("bytecode not found in JSON")?
+            .strip_prefix("0x")
+            .unwrap_or_else(|| {
+                json_value["bytecode"]["object"]
+                    .as_str()
+                    .expect("bytecode should be a string")
+            })
+            .to_string();
+
+        bytecode_str = Self::link_bytecode_hex(
+            impl_json,
+            &bytecode_str,
+            "src/core/hash/Poseidon2.sol:Poseidon2T2",
+            poseidon_addr,
+        )?;
+        bytecode_str = Self::link_bytecode_hex(
+            impl_json,
+            &bytecode_str,
+            "src/core/libraries/PackedAccountData.sol:PackedAccountData",
+            packed_account_data_addr,
+        )?;
+
+        let bytecode = Bytes::from(hex::decode(bytecode_str)?);
+        Self::deploy_contract(provider, bytecode, Bytes::new()).await
     }
 
     /// Deploys the `RpRegistry` contract using the supplied signer.

--- a/crates/test-utils/src/anvil.rs
+++ b/crates/test-utils/src/anvil.rs
@@ -527,10 +527,6 @@ impl TestAnvil {
             .await
     }
 
-    /// Encodes the `initialize(...)` calldata used when deploying the
-    /// `WorldIDRegistry` proxy. Both V1 and V2 deploy paths use the same
-    /// initializer (V2 is upgraded into post-deploy without re-init), so this
-    /// is shared between them.
     fn world_id_registry_init_data(tree_depth: u64) -> Bytes {
         Bytes::from(
             WorldIDRegistry::initializeCall {

--- a/crates/test-utils/src/anvil.rs
+++ b/crates/test-utils/src/anvil.rs
@@ -435,15 +435,7 @@ impl TestAnvil {
         .await
         .context("failed to deploy WorldIDRegistry implementation")?;
 
-        let init_data = Bytes::from(
-            WorldIDRegistry::initializeCall {
-                initialTreeDepth: U256::from(tree_depth),
-                feeRecipient: address!("0x2cFc85d8E48F8EAB294be644d9E25C3030863003"),
-                feeToken: address!("0x2cFc85d8E48F8EAB294be644d9E25C3030863003"),
-                registrationFee: U256::from(0),
-            }
-            .abi_encode(),
-        );
+        let init_data = Self::world_id_registry_init_data(tree_depth);
 
         let proxy = ERC1967Proxy::deploy(provider, implementation_address, init_data)
             .await
@@ -494,15 +486,7 @@ impl TestAnvil {
         .await
         .context("failed to deploy WorldIDRegistry V1 implementation")?;
 
-        let init_data = Bytes::from(
-            WorldIDRegistry::initializeCall {
-                initialTreeDepth: U256::from(tree_depth),
-                feeRecipient: address!("0x2cFc85d8E48F8EAB294be644d9E25C3030863003"),
-                feeToken: address!("0x2cFc85d8E48F8EAB294be644d9E25C3030863003"),
-                registrationFee: U256::from(0),
-            }
-            .abi_encode(),
-        );
+        let init_data = Self::world_id_registry_init_data(tree_depth);
         let proxy = ERC1967Proxy::deploy(provider.clone(), v1_impl, init_data)
             .await
             .context("failed to deploy WorldIDRegistry proxy")?;
@@ -541,6 +525,22 @@ impl TestAnvil {
     pub async fn deploy_world_id_registry_v2(&self, signer: PrivateKeySigner) -> Result<Address> {
         self.deploy_world_id_registry_v2_with_depth(signer, TREE_DEPTH as u64)
             .await
+    }
+
+    /// Encodes the `initialize(...)` calldata used when deploying the
+    /// `WorldIDRegistry` proxy. Both V1 and V2 deploy paths use the same
+    /// initializer (V2 is upgraded into post-deploy without re-init), so this
+    /// is shared between them.
+    fn world_id_registry_init_data(tree_depth: u64) -> Bytes {
+        Bytes::from(
+            WorldIDRegistry::initializeCall {
+                initialTreeDepth: U256::from(tree_depth),
+                feeRecipient: address!("0x2cFc85d8E48F8EAB294be644d9E25C3030863003"),
+                feeToken: address!("0x2cFc85d8E48F8EAB294be644d9E25C3030863003"),
+                registrationFee: U256::from(0),
+            }
+            .abi_encode(),
+        )
     }
 
     /// Links Poseidon2T2 + PackedAccountData into a registry implementation

--- a/services/gateway/src/lib.rs
+++ b/services/gateway/src/lib.rs
@@ -57,7 +57,9 @@ pub async fn spawn_gateway_for_tests(cfg: GatewayConfig) -> GatewayResult<Gatewa
         cfg.registry_addr,
         provider.clone(),
     ));
-    let registry_version = probe(provider.clone(), cfg.registry_addr).await;
+    let registry_version = probe(provider.clone(), cfg.registry_addr)
+        .await
+        .map_err(GatewayError::Config)?;
     tracing::info!(version = ?registry_version, "registry version detected");
     let app = build_app(
         registry,
@@ -114,7 +116,9 @@ pub async fn run() -> GatewayResult<()> {
         cfg.registry_addr,
         provider.clone(),
     ));
-    let registry_version = probe(provider.clone(), cfg.registry_addr).await;
+    let registry_version = probe(provider.clone(), cfg.registry_addr)
+        .await
+        .map_err(GatewayError::Config)?;
     tracing::info!(version = ?registry_version, "registry version detected");
 
     tracing::info!("Config is ready. Building app...");

--- a/services/gateway/src/lib.rs
+++ b/services/gateway/src/lib.rs
@@ -57,7 +57,7 @@ pub async fn spawn_gateway_for_tests(cfg: GatewayConfig) -> GatewayResult<Gatewa
         cfg.registry_addr,
         provider.clone(),
     ));
-    let registry_version = probe(provider.clone(), cfg.registry_addr).await;
+    let registry_version = probe(provider.clone(), cfg.registry_addr).await?;
     let app = build_app(
         registry,
         registry_version,
@@ -113,7 +113,7 @@ pub async fn run() -> GatewayResult<()> {
         cfg.registry_addr,
         provider.clone(),
     ));
-    let registry_version = probe(provider.clone(), cfg.registry_addr).await;
+    let registry_version = probe(provider.clone(), cfg.registry_addr).await?;
 
     tracing::info!("Config is ready. Building app...");
     let app = build_app(

--- a/services/gateway/src/lib.rs
+++ b/services/gateway/src/lib.rs
@@ -4,9 +4,10 @@ pub use crate::{
         defaults,
     },
     orphan_sweeper::sweep_once,
+    registry_version::RegistryVersion,
     request_tracker::{RequestRecord, RequestTracker, now_unix_secs},
 };
-use crate::{routes::build_app, types::AppState};
+use crate::{registry_version::probe, routes::build_app, types::AppState};
 use std::{backtrace::Backtrace, net::SocketAddr, sync::Arc};
 use tokio::sync::oneshot;
 use world_id_registries::world_id::WorldIdRegistry::WorldIdRegistryInstance;
@@ -17,6 +18,7 @@ mod config;
 mod error;
 pub mod metrics;
 pub mod orphan_sweeper;
+mod registry_version;
 mod request;
 pub mod request_tracker;
 mod routes;
@@ -55,8 +57,11 @@ pub async fn spawn_gateway_for_tests(cfg: GatewayConfig) -> GatewayResult<Gatewa
         cfg.registry_addr,
         provider.clone(),
     ));
+    let registry_version = probe(provider.clone(), cfg.registry_addr).await;
+    tracing::info!(version = ?registry_version, "registry version detected");
     let app = build_app(
         registry,
+        registry_version,
         batcher_config,
         cfg.redis_url,
         rate_limit,
@@ -105,11 +110,17 @@ pub async fn run() -> GatewayResult<()> {
     let sweeper_config = cfg.sweeper();
 
     let provider = Arc::new(cfg.provider.http().await?);
-    let registry = Arc::new(WorldIdRegistryInstance::new(cfg.registry_addr, provider));
+    let registry = Arc::new(WorldIdRegistryInstance::new(
+        cfg.registry_addr,
+        provider.clone(),
+    ));
+    let registry_version = probe(provider.clone(), cfg.registry_addr).await;
+    tracing::info!(version = ?registry_version, "registry version detected");
 
     tracing::info!("Config is ready. Building app...");
     let app = build_app(
         registry,
+        registry_version,
         batcher_config,
         cfg.redis_url,
         rate_limit,

--- a/services/gateway/src/lib.rs
+++ b/services/gateway/src/lib.rs
@@ -116,9 +116,16 @@ pub async fn run() -> GatewayResult<()> {
         cfg.registry_addr,
         provider.clone(),
     ));
-    let registry_version = probe(provider.clone(), cfg.registry_addr)
-        .await
-        .map_err(GatewayError::Config)?;
+    let registry_version = match probe(provider.clone(), cfg.registry_addr).await {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::warn!(
+                error = %e,
+                "registry version probe failed at startup; defaulting to V1. Version-switching handlers will use V1 selectors until the next gateway restart."
+            );
+            RegistryVersion::V1
+        }
+    };
     tracing::info!(version = ?registry_version, "registry version detected");
 
     tracing::info!("Config is ready. Building app...");

--- a/services/gateway/src/lib.rs
+++ b/services/gateway/src/lib.rs
@@ -57,10 +57,7 @@ pub async fn spawn_gateway_for_tests(cfg: GatewayConfig) -> GatewayResult<Gatewa
         cfg.registry_addr,
         provider.clone(),
     ));
-    let registry_version = probe(provider.clone(), cfg.registry_addr)
-        .await
-        .map_err(GatewayError::Config)?;
-    tracing::info!(version = ?registry_version, "registry version detected");
+    let registry_version = probe(provider.clone(), cfg.registry_addr).await;
     let app = build_app(
         registry,
         registry_version,
@@ -116,17 +113,7 @@ pub async fn run() -> GatewayResult<()> {
         cfg.registry_addr,
         provider.clone(),
     ));
-    let registry_version = match probe(provider.clone(), cfg.registry_addr).await {
-        Ok(v) => v,
-        Err(e) => {
-            tracing::warn!(
-                error = %e,
-                "registry version probe failed at startup; defaulting to V1. Version-switching handlers will use V1 selectors until the next gateway restart."
-            );
-            RegistryVersion::V1
-        }
-    };
-    tracing::info!(version = ?registry_version, "registry version detected");
+    let registry_version = probe(provider.clone(), cfg.registry_addr).await;
 
     tracing::info!("Config is ready. Building app...");
     let app = build_app(

--- a/services/gateway/src/registry_version.rs
+++ b/services/gateway/src/registry_version.rs
@@ -5,10 +5,8 @@
 use std::sync::Arc;
 
 use alloy::{primitives::Address, providers::DynProvider};
-use tracing::debug;
-use world_id_registries::world_id::{
-    WorldIdRegistry::WorldIdRegistryInstance, WorldIdRegistryV2::WorldIdRegistryV2Instance,
-};
+use tracing::{info, warn};
+use world_id_registries::world_id::WorldIdRegistryV2::WorldIdRegistryV2Instance;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum RegistryVersion {
@@ -17,42 +15,20 @@ pub enum RegistryVersion {
 }
 
 /// Probes `MAX_AUTHENTICATORS_V2_HARD_LIMIT()` — a V2-only public constant (WIP-104).
-/// Success → V2. V2 selector failure → confirm the proxy is reachable through a
-/// V1 view, retry the V2 selector once, then fall back to V1.
+/// Success → V2. Any error (unknown selector, revert, transport failure) → V1.
 ///
-/// This avoids permanently selecting V1 at startup when the initial V2 probe
-/// failed due to a transient RPC/transport issue rather than an unknown selector.
-pub async fn probe(
-    provider: Arc<DynProvider>,
-    proxy_addr: Address,
-) -> Result<RegistryVersion, String> {
-    let v2 = WorldIdRegistryV2Instance::new(proxy_addr, provider.clone());
+/// Owns its own outcome logging so callers don't double-log: info on V2 detection,
+/// warn on V1 fallback (which surfaces a misconfigured RPC in production).
+pub async fn probe(provider: Arc<DynProvider>, proxy_addr: Address) -> RegistryVersion {
+    let v2 = WorldIdRegistryV2Instance::new(proxy_addr, provider);
     match v2.MAX_AUTHENTICATORS_V2_HARD_LIMIT().call().await {
-        Ok(_) => Ok(RegistryVersion::V2),
-        Err(first_v2_err) => {
-            debug!(error = ?first_v2_err, "initial V2 selector probe failed");
-
-            let v1 = WorldIdRegistryInstance::new(proxy_addr, provider);
-            v1.getMaxAuthenticators()
-                .call()
-                .await
-                .map_err(|v1_err| {
-                    format!(
-                        "registry version probe failed: V2 selector error: {first_v2_err}; V1 reachability error: {v1_err}"
-                    )
-                })?;
-
-            match v2.MAX_AUTHENTICATORS_V2_HARD_LIMIT().call().await {
-                Ok(_) => Ok(RegistryVersion::V2),
-                Err(second_v2_err) => {
-                    debug!(
-                        first_error = ?first_v2_err,
-                        second_error = ?second_v2_err,
-                        "V2 selector probe failed twice while V1 view succeeded; treating proxy as V1"
-                    );
-                    Ok(RegistryVersion::V1)
-                }
-            }
+        Ok(_) => {
+            info!("registry version detected: V2");
+            RegistryVersion::V2
+        }
+        Err(err) => {
+            warn!(error = ?err, "V2 selector probe failed; defaulting to V1");
+            RegistryVersion::V1
         }
     }
 }

--- a/services/gateway/src/registry_version.rs
+++ b/services/gateway/src/registry_version.rs
@@ -1,0 +1,28 @@
+//! Whether the WorldIDRegistry proxy is pointing at V1 or V2. Probed once at
+//! startup; not updated at runtime. The gateway is rolling-restarted after a
+//! contract upgrade so pods re-probe.
+
+use std::sync::Arc;
+
+use alloy::{primitives::Address, providers::DynProvider};
+use tracing::debug;
+use world_id_registries::world_id::WorldIdRegistryV2::WorldIdRegistryV2Instance;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RegistryVersion {
+    V1,
+    V2,
+}
+
+/// Probes `MAX_AUTHENTICATORS_V2_HARD_LIMIT()` — a V2-only public constant (WIP-104).
+/// Success → V2. Any error (revert, unknown selector, transport failure) → V1.
+pub async fn probe(provider: Arc<DynProvider>, proxy_addr: Address) -> RegistryVersion {
+    let v2 = WorldIdRegistryV2Instance::new(proxy_addr, provider);
+    match v2.MAX_AUTHENTICATORS_V2_HARD_LIMIT().call().await {
+        Ok(_) => RegistryVersion::V2,
+        Err(err) => {
+            debug!(error = ?err, "V2 selector probe failed; treating proxy as V1");
+            RegistryVersion::V1
+        }
+    }
+}

--- a/services/gateway/src/registry_version.rs
+++ b/services/gateway/src/registry_version.rs
@@ -10,6 +10,11 @@ use world_id_registries::world_id::WorldIdRegistryV2::WorldIdRegistryV2Instance;
 
 use crate::error::{GatewayError, GatewayResult};
 
+fn http_only_run_mode() -> bool {
+    std::env::var("RUN_MODE")
+        .is_ok_and(|value| matches!(value.to_ascii_lowercase().as_str(), "http" | "http-only"))
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum RegistryVersion {
     V1,
@@ -33,10 +38,18 @@ pub async fn probe(
             Ok(RegistryVersion::V1)
         }
         Err(err) => {
-            warn!(error = ?err, "registry version probe failed");
-            Err(GatewayError::Config(format!(
-                "failed to probe registry version: {err}"
-            )))
+            if http_only_run_mode() {
+                warn!(
+                    error = ?err,
+                    "registry version probe failed in http-only mode; defaulting to V1"
+                );
+                Ok(RegistryVersion::V1)
+            } else {
+                warn!(error = ?err, "registry version probe failed");
+                Err(GatewayError::Config(format!(
+                    "failed to probe registry version: {err}"
+                )))
+            }
         }
     }
 }

--- a/services/gateway/src/registry_version.rs
+++ b/services/gateway/src/registry_version.rs
@@ -4,9 +4,11 @@
 
 use std::sync::Arc;
 
-use alloy::{primitives::Address, providers::DynProvider};
+use alloy::{contract::Error as ContractError, primitives::Address, providers::DynProvider};
 use tracing::{info, warn};
 use world_id_registries::world_id::WorldIdRegistryV2::WorldIdRegistryV2Instance;
+
+use crate::error::{GatewayError, GatewayResult};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum RegistryVersion {
@@ -15,17 +17,30 @@ pub enum RegistryVersion {
 }
 
 /// Probes `MAX_AUTHENTICATORS_V2_HARD_LIMIT()` — a V2-only public constant (WIP-104).
-/// Success → V2.
-pub async fn probe(provider: Arc<DynProvider>, proxy_addr: Address) -> RegistryVersion {
+/// Success means V2.
+pub async fn probe(
+    provider: Arc<DynProvider>,
+    proxy_addr: Address,
+) -> GatewayResult<RegistryVersion> {
     let v2 = WorldIdRegistryV2Instance::new(proxy_addr, provider);
     match v2.MAX_AUTHENTICATORS_V2_HARD_LIMIT().call().await {
         Ok(_) => {
             info!("registry version detected: V2");
-            RegistryVersion::V2
+            Ok(RegistryVersion::V2)
+        }
+        Err(err) if is_v2_selector_unavailable(&err) => {
+            warn!(error = ?err, "V2 selector unavailable; defaulting to V1");
+            Ok(RegistryVersion::V1)
         }
         Err(err) => {
-            warn!(error = ?err, "V2 selector probe failed; defaulting to V1");
-            RegistryVersion::V1
+            warn!(error = ?err, "registry version probe failed");
+            Err(GatewayError::Config(format!(
+                "failed to probe registry version: {err}"
+            )))
         }
     }
+}
+
+fn is_v2_selector_unavailable(err: &ContractError) -> bool {
+    matches!(err, ContractError::ZeroData(_, _)) || err.as_revert_data().is_some()
 }

--- a/services/gateway/src/registry_version.rs
+++ b/services/gateway/src/registry_version.rs
@@ -15,10 +15,7 @@ pub enum RegistryVersion {
 }
 
 /// Probes `MAX_AUTHENTICATORS_V2_HARD_LIMIT()` — a V2-only public constant (WIP-104).
-/// Success → V2. Any error (unknown selector, revert, transport failure) → V1.
-///
-/// Owns its own outcome logging so callers don't double-log: info on V2 detection,
-/// warn on V1 fallback (which surfaces a misconfigured RPC in production).
+/// Success → V2.
 pub async fn probe(provider: Arc<DynProvider>, proxy_addr: Address) -> RegistryVersion {
     let v2 = WorldIdRegistryV2Instance::new(proxy_addr, provider);
     match v2.MAX_AUTHENTICATORS_V2_HARD_LIMIT().call().await {

--- a/services/gateway/src/registry_version.rs
+++ b/services/gateway/src/registry_version.rs
@@ -6,7 +6,9 @@ use std::sync::Arc;
 
 use alloy::{primitives::Address, providers::DynProvider};
 use tracing::debug;
-use world_id_registries::world_id::WorldIdRegistryV2::WorldIdRegistryV2Instance;
+use world_id_registries::world_id::{
+    WorldIdRegistry::WorldIdRegistryInstance, WorldIdRegistryV2::WorldIdRegistryV2Instance,
+};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum RegistryVersion {
@@ -15,14 +17,42 @@ pub enum RegistryVersion {
 }
 
 /// Probes `MAX_AUTHENTICATORS_V2_HARD_LIMIT()` — a V2-only public constant (WIP-104).
-/// Success → V2. Any error (revert, unknown selector, transport failure) → V1.
-pub async fn probe(provider: Arc<DynProvider>, proxy_addr: Address) -> RegistryVersion {
-    let v2 = WorldIdRegistryV2Instance::new(proxy_addr, provider);
+/// Success → V2. V2 selector failure → confirm the proxy is reachable through a
+/// V1 view, retry the V2 selector once, then fall back to V1.
+///
+/// This avoids permanently selecting V1 at startup when the initial V2 probe
+/// failed due to a transient RPC/transport issue rather than an unknown selector.
+pub async fn probe(
+    provider: Arc<DynProvider>,
+    proxy_addr: Address,
+) -> Result<RegistryVersion, String> {
+    let v2 = WorldIdRegistryV2Instance::new(proxy_addr, provider.clone());
     match v2.MAX_AUTHENTICATORS_V2_HARD_LIMIT().call().await {
-        Ok(_) => RegistryVersion::V2,
-        Err(err) => {
-            debug!(error = ?err, "V2 selector probe failed; treating proxy as V1");
-            RegistryVersion::V1
+        Ok(_) => Ok(RegistryVersion::V2),
+        Err(first_v2_err) => {
+            debug!(error = ?first_v2_err, "initial V2 selector probe failed");
+
+            let v1 = WorldIdRegistryInstance::new(proxy_addr, provider);
+            v1.getMaxAuthenticators()
+                .call()
+                .await
+                .map_err(|v1_err| {
+                    format!(
+                        "registry version probe failed: V2 selector error: {first_v2_err}; V1 reachability error: {v1_err}"
+                    )
+                })?;
+
+            match v2.MAX_AUTHENTICATORS_V2_HARD_LIMIT().call().await {
+                Ok(_) => Ok(RegistryVersion::V2),
+                Err(second_v2_err) => {
+                    debug!(
+                        first_error = ?first_v2_err,
+                        second_error = ?second_v2_err,
+                        "V2 selector probe failed twice while V1 view succeeded; treating proxy as V1"
+                    );
+                    Ok(RegistryVersion::V1)
+                }
+            }
         }
     }
 }

--- a/services/gateway/src/request.rs
+++ b/services/gateway/src/request.rs
@@ -20,6 +20,8 @@ use world_id_primitives::api_types::{
 };
 use world_id_registries::world_id::WorldIdRegistry::WorldIdRegistryInstance;
 
+use crate::registry_version::RegistryVersion;
+
 /// Type alias for the registry instance.
 pub type Registry = WorldIdRegistryInstance<Arc<DynProvider>>;
 
@@ -27,6 +29,10 @@ pub type Registry = WorldIdRegistryInstance<Arc<DynProvider>>;
 #[derive(Clone)]
 pub struct GatewayContext {
     pub registry: Arc<Registry>,
+    /// Detected registry implementation version at gateway startup. Does not
+    /// change at runtime — the gateway is rolling-restarted after a contract
+    /// upgrade so the new fleet re-probes.
+    pub registry_version: RegistryVersion,
     pub tracker: RequestTracker,
     pub batcher: BatcherHandle,
     pub root_cache: Cache<U256, U256>,
@@ -338,6 +344,71 @@ impl IntoCommand for ExecuteRecoveryAgentUpdateRequest {
 impl IntoRequestWithRateLimit for ExecuteRecoveryAgentUpdateRequest {}
 
 impl Request<ExecuteRecoveryAgentUpdateRequest> {
+    pub async fn submit(
+        self,
+        ctx: &GatewayContext,
+    ) -> Result<SubmittedRequest, GatewayErrorResponse> {
+        submit_request(self, ctx).await
+    }
+}
+
+// =============================================================================
+// V2 Recovery Agent flow (WIP-102)
+// =============================================================================
+// Same wire shape as the V1 request types; calldata targets the V2 selector.
+
+/// Marks the gateway flow as WIP-102 `updateRecoveryAgent`.
+pub struct UpdateRecoveryAgentV2Request(pub UpdateRecoveryAgentRequest);
+
+impl HasLeafIndex for UpdateRecoveryAgentV2Request {
+    fn leaf_index(&self) -> u64 {
+        self.0.leaf_index
+    }
+}
+
+impl IntoRequest for UpdateRecoveryAgentV2Request {
+    const KIND: GatewayRequestKind = GatewayRequestKind::UpdateRecoveryAgent;
+}
+
+impl IntoCommand for UpdateRecoveryAgentV2Request {
+    fn into_command(id: Uuid, _payload: Self, calldata: Bytes) -> Command {
+        Command::operation(id, calldata, DEFAULT_INITIATE_RECOVERY_AGENT_UPDATE_GAS)
+    }
+}
+
+impl IntoRequestWithRateLimit for UpdateRecoveryAgentV2Request {}
+
+impl Request<UpdateRecoveryAgentV2Request> {
+    pub async fn submit(
+        self,
+        ctx: &GatewayContext,
+    ) -> Result<SubmittedRequest, GatewayErrorResponse> {
+        submit_request(self, ctx).await
+    }
+}
+
+/// Marks the gateway flow as WIP-102 `revertRecoveryAgentUpdate`.
+pub struct RevertRecoveryAgentUpdateRequest(pub CancelRecoveryAgentUpdateRequest);
+
+impl HasLeafIndex for RevertRecoveryAgentUpdateRequest {
+    fn leaf_index(&self) -> u64 {
+        self.0.leaf_index
+    }
+}
+
+impl IntoRequest for RevertRecoveryAgentUpdateRequest {
+    const KIND: GatewayRequestKind = GatewayRequestKind::CancelRecoveryAgentUpdate;
+}
+
+impl IntoCommand for RevertRecoveryAgentUpdateRequest {
+    fn into_command(id: Uuid, _payload: Self, calldata: Bytes) -> Command {
+        Command::operation(id, calldata, DEFAULT_CANCEL_RECOVERY_AGENT_UPDATE_GAS)
+    }
+}
+
+impl IntoRequestWithRateLimit for RevertRecoveryAgentUpdateRequest {}
+
+impl Request<RevertRecoveryAgentUpdateRequest> {
     pub async fn submit(
         self,
         ctx: &GatewayContext,

--- a/services/gateway/src/request.rs
+++ b/services/gateway/src/request.rs
@@ -29,9 +29,6 @@ pub type Registry = WorldIdRegistryInstance<Arc<DynProvider>>;
 #[derive(Clone)]
 pub struct GatewayContext {
     pub registry: Arc<Registry>,
-    /// Detected registry implementation version at gateway startup. Does not
-    /// change at runtime — the gateway is rolling-restarted after a contract
-    /// upgrade so the new fleet re-probes.
     pub registry_version: RegistryVersion,
     pub tracker: RequestTracker,
     pub batcher: BatcherHandle,

--- a/services/gateway/src/request.rs
+++ b/services/gateway/src/request.rs
@@ -369,7 +369,7 @@ impl IntoRequest for UpdateRecoveryAgentV2Request {
 
 impl IntoCommand for UpdateRecoveryAgentV2Request {
     fn into_command(id: Uuid, _payload: Self, calldata: Bytes) -> Command {
-        Command::operation(id, calldata, DEFAULT_INITIATE_RECOVERY_AGENT_UPDATE_GAS)
+        Command::operation(id, calldata)
     }
 }
 
@@ -399,7 +399,7 @@ impl IntoRequest for RevertRecoveryAgentUpdateRequest {
 
 impl IntoCommand for RevertRecoveryAgentUpdateRequest {
     fn into_command(id: Uuid, _payload: Self, calldata: Bytes) -> Command {
-        Command::operation(id, calldata, DEFAULT_CANCEL_RECOVERY_AGENT_UPDATE_GAS)
+        Command::operation(id, calldata)
     }
 }
 

--- a/services/gateway/src/request.rs
+++ b/services/gateway/src/request.rs
@@ -352,7 +352,7 @@ impl Request<ExecuteRecoveryAgentUpdateRequest> {
 // =============================================================================
 // V2 Recovery Agent flow (WIP-102)
 // =============================================================================
-// Same wire shape as the V1 request types; calldata targets the V2 selector.
+// Same shape as the V1 request types; calldata targets the V2 selector.
 
 /// Marks the gateway flow as WIP-102 `updateRecoveryAgent`.
 pub struct UpdateRecoveryAgentV2Request(pub UpdateRecoveryAgentRequest);

--- a/services/gateway/src/request_tracker.rs
+++ b/services/gateway/src/request_tracker.rs
@@ -100,6 +100,57 @@ impl RequestTracker {
         format!("gateway:inflight:{tag}:{raw}")
     }
 
+    /// Records a terminal request with a specific ID without adding it to the
+    /// pending set or acquiring in-flight locks.
+    ///
+    /// This is intended for compatibility no-op endpoints that should be
+    /// visible through `/status/{request_id}` even though there is no batcher or
+    /// on-chain transaction to track.
+    pub async fn new_terminal_request_with_id(
+        &self,
+        id: String,
+        kind: GatewayRequestKind,
+        status: GatewayRequestState,
+    ) -> Result<(), GatewayErrorResponse> {
+        debug_assert!(
+            matches!(
+                &status,
+                GatewayRequestState::Finalized { .. } | GatewayRequestState::Failed { .. }
+            ),
+            "new_terminal_request_with_id should only be used with terminal states"
+        );
+
+        let record = RequestRecord {
+            kind,
+            status,
+            updated_at: now_unix_secs(),
+            inflight_keys: Vec::new(),
+        };
+
+        let mut manager = self.redis_manager.clone();
+        let key = Self::request_key(&id);
+        let json_str = serde_json::to_string(&record).map_err(|e| {
+            tracing::error!("FATAL: unable to serialize a RequestRecord: {e}");
+            GatewayErrorResponse::internal_server_error()
+        })?;
+
+        let result: Result<(), redis::RedisError> = redis::cmd("SET")
+            .arg(&key)
+            .arg(&json_str)
+            .arg("NX")
+            .arg("EX")
+            .arg(REQUESTS_TTL.as_secs())
+            .query_async(&mut manager)
+            .await;
+
+        if let Err(e) = result {
+            tracing::error!("Error creating terminal request {id}: {e}");
+            return Err(GatewayErrorResponse::internal_server_error());
+        }
+
+        Ok(())
+    }
+
     /// Creates a new request with a specific ID, atomically acquiring in-flight
     /// lock keys via `SET NX`.
     ///

--- a/services/gateway/src/routes.rs
+++ b/services/gateway/src/routes.rs
@@ -9,6 +9,7 @@ use crate::{
     config::{BatchPolicyConfig, BatcherConfig, OrphanSweeperConfig, RateLimitConfig},
     error::{GatewayErrorBody, GatewayErrorResponse, GatewayResult},
     orphan_sweeper::run_orphan_sweeper,
+    registry_version::RegistryVersion,
     request::GatewayContext,
     request_tracker::RequestTracker,
     routes::{
@@ -22,7 +23,9 @@ use crate::{
         recover_account::recover_account,
         remove_authenticator::remove_authenticator,
         request_status::request_status,
+        revert_recovery_agent_update::revert_recovery_agent_update,
         update_authenticator::update_authenticator,
+        update_recovery_agent::update_recovery_agent,
     },
     types::RootExpiry,
 };
@@ -63,6 +66,8 @@ mod update_authenticator;
 mod cancel_recovery_agent_update;
 mod execute_recovery_agent_update;
 mod initiate_recovery_agent_update;
+mod revert_recovery_agent_update;
+mod update_recovery_agent;
 
 // Admin / utility routes
 mod is_valid_root;
@@ -77,6 +82,7 @@ const OPS_BATCHER_CHANNEL_CAPACITY: usize = 2048;
 
 pub(crate) async fn build_app(
     registry: Arc<WorldIdRegistryInstance<Arc<DynProvider>>>,
+    registry_version: RegistryVersion,
     batcher_config: BatcherConfig,
     redis_url: String,
     rate_limit: Option<RateLimitConfig>,
@@ -148,6 +154,7 @@ pub(crate) async fn build_app(
     };
     let ctx = GatewayContext {
         registry: registry.clone(),
+        registry_version,
         tracker,
         batcher: batcher_handle,
         root_cache,
@@ -176,6 +183,12 @@ pub(crate) async fn build_app(
         .route(
             "/execute-recovery-agent-update",
             post(execute_recovery_agent_update),
+        )
+        // WIP-102 optimistic recovery agent update (gated on V2 contract)
+        .route("/update-recovery-agent", post(update_recovery_agent))
+        .route(
+            "/revert-recovery-agent-update",
+            post(revert_recovery_agent_update),
         )
         // admin / utility
         .route("/is-valid-root", get(is_valid_root))

--- a/services/gateway/src/routes.rs
+++ b/services/gateway/src/routes.rs
@@ -80,6 +80,7 @@ const ROOT_CACHE_SIZE: u64 = 1024;
 const CREATE_BATCHER_CHANNEL_CAPACITY: usize = 1024;
 const OPS_BATCHER_CHANNEL_CAPACITY: usize = 2048;
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) async fn build_app(
     registry: Arc<WorldIdRegistryInstance<Arc<DynProvider>>>,
     registry_version: RegistryVersion,

--- a/services/gateway/src/routes.rs
+++ b/services/gateway/src/routes.rs
@@ -80,7 +80,7 @@ const ROOT_CACHE_SIZE: u64 = 1024;
 const CREATE_BATCHER_CHANNEL_CAPACITY: usize = 1024;
 const OPS_BATCHER_CHANNEL_CAPACITY: usize = 2048;
 
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 pub(crate) async fn build_app(
     registry: Arc<WorldIdRegistryInstance<Arc<DynProvider>>>,
     registry_version: RegistryVersion,

--- a/services/gateway/src/routes/cancel_recovery_agent_update.rs
+++ b/services/gateway/src/routes/cancel_recovery_agent_update.rs
@@ -15,6 +15,9 @@ use world_id_primitives::api_types::{CancelRecoveryAgentUpdateRequest, GatewaySt
 ///
 /// Legacy URL. Pre-V2: cancels a pending recovery agent update. Post-V2:
 /// translates into a WIP-102 `revertRecoveryAgentUpdate`.
+///
+/// TODO(WIP-102): remove this handler and its route once all clients have
+/// migrated to `POST /revert-recovery-agent-update`.
 #[instrument(name = "cancel_recovery_agent_update", skip(state, payload), fields(request_id = %id))]
 pub(crate) async fn cancel_recovery_agent_update(
     State(state): State<AppState>,

--- a/services/gateway/src/routes/cancel_recovery_agent_update.rs
+++ b/services/gateway/src/routes/cancel_recovery_agent_update.rs
@@ -1,7 +1,10 @@
 //! Cancel recovery agent update handler.
 
 use crate::{
-    error::GatewayErrorResponse, request::IntoRequestWithRateLimit, routes::middleware::RequestId,
+    RegistryVersion,
+    error::GatewayErrorResponse,
+    request::{IntoRequestWithRateLimit, RevertRecoveryAgentUpdateRequest},
+    routes::middleware::RequestId,
     types::AppState,
 };
 use axum::{Extension, Json, extract::State};
@@ -10,17 +13,26 @@ use world_id_primitives::api_types::{CancelRecoveryAgentUpdateRequest, GatewaySt
 
 /// POST /cancel-recovery-agent-update
 ///
-/// Cancels a pending recovery agent update.
+/// Legacy URL. Pre-V2: cancels a pending recovery agent update. Post-V2:
+/// translates into a WIP-102 `revertRecoveryAgentUpdate`.
 #[instrument(name = "cancel_recovery_agent_update", skip(state, payload), fields(request_id = %id))]
 pub(crate) async fn cancel_recovery_agent_update(
     State(state): State<AppState>,
     Extension(RequestId(id)): Extension<RequestId>,
     Json(payload): Json<CancelRecoveryAgentUpdateRequest>,
 ) -> Result<Json<GatewayStatusResponse>, GatewayErrorResponse> {
-    payload
-        .into_request_with_rate_limit(id, &state.ctx)
-        .await?
-        .submit(&state.ctx)
-        .await
-        .map(|r| Json(r.into_response()))
+    match state.ctx.registry_version {
+        RegistryVersion::V1 => payload
+            .into_request_with_rate_limit(id, &state.ctx)
+            .await?
+            .submit(&state.ctx)
+            .await
+            .map(|r| Json(r.into_response())),
+        RegistryVersion::V2 => RevertRecoveryAgentUpdateRequest(payload)
+            .into_request_with_rate_limit(id, &state.ctx)
+            .await?
+            .submit(&state.ctx)
+            .await
+            .map(|r| Json(r.into_response())),
+    }
 }

--- a/services/gateway/src/routes/execute_recovery_agent_update.rs
+++ b/services/gateway/src/routes/execute_recovery_agent_update.rs
@@ -16,6 +16,9 @@ use world_id_primitives::api_types::{
 /// Legacy URL. Pre-V2: executes a pending recovery agent update (permissionless;
 /// the contract enforces the 14-day cooldown). Post-V2: no-op — WIP-102 applies
 /// updates immediately, nothing to execute.
+///
+/// TODO(WIP-102): remove this handler and its route once all clients have
+/// stopped calling it (no V2 replacement — the operation no longer exists).
 #[instrument(name = "execute_recovery_agent_update", skip(state, payload), fields(request_id = %id))]
 pub(crate) async fn execute_recovery_agent_update(
     State(state): State<AppState>,

--- a/services/gateway/src/routes/execute_recovery_agent_update.rs
+++ b/services/gateway/src/routes/execute_recovery_agent_update.rs
@@ -1,31 +1,41 @@
 //! Execute recovery agent update handler.
 
 use crate::{
-    error::GatewayErrorResponse, request::IntoRequestWithRateLimit, routes::middleware::RequestId,
-    types::AppState,
+    RegistryVersion, error::GatewayErrorResponse, request::IntoRequestWithRateLimit,
+    routes::middleware::RequestId, types::AppState,
 };
 use axum::{Extension, Json, extract::State};
 use tracing::instrument;
-use world_id_primitives::api_types::{ExecuteRecoveryAgentUpdateRequest, GatewayStatusResponse};
+use world_id_primitives::api_types::{
+    ExecuteRecoveryAgentUpdateRequest, GatewayRequestId, GatewayRequestKind, GatewayRequestState,
+    GatewayStatusResponse,
+};
 
 /// POST /execute-recovery-agent-update
 ///
-/// Executes a pending recovery agent update once the 14-day cooldown has elapsed.
-///
-/// This call is **permissionless** — no signature or nonce is required. The
-/// contract enforces the cooldown and will revert with
-/// `RecoveryAgentUpdateStillInCooldown` if called too early; that revert is
-/// surfaced to the caller via the pre-flight `eth_call` simulation.
+/// Legacy URL. Pre-V2: executes a pending recovery agent update (permissionless;
+/// the contract enforces the 14-day cooldown). Post-V2: no-op — WIP-102 applies
+/// updates immediately, nothing to execute.
 #[instrument(name = "execute_recovery_agent_update", skip(state, payload), fields(request_id = %id))]
 pub(crate) async fn execute_recovery_agent_update(
     State(state): State<AppState>,
     Extension(RequestId(id)): Extension<RequestId>,
     Json(payload): Json<ExecuteRecoveryAgentUpdateRequest>,
 ) -> Result<Json<GatewayStatusResponse>, GatewayErrorResponse> {
-    payload
-        .into_request_with_rate_limit(id, &state.ctx)
-        .await?
-        .submit(&state.ctx)
-        .await
-        .map(|r| Json(r.into_response()))
+    match state.ctx.registry_version {
+        RegistryVersion::V1 => payload
+            .into_request_with_rate_limit(id, &state.ctx)
+            .await?
+            .submit(&state.ctx)
+            .await
+            .map(|r| Json(r.into_response())),
+        RegistryVersion::V2 => {
+            let _ = payload;
+            Ok(Json(GatewayStatusResponse {
+                request_id: GatewayRequestId::new(id.to_string()),
+                kind: GatewayRequestKind::ExecuteRecoveryAgentUpdate,
+                status: GatewayRequestState::Queued,
+            }))
+        }
+    }
 }

--- a/services/gateway/src/routes/execute_recovery_agent_update.rs
+++ b/services/gateway/src/routes/execute_recovery_agent_update.rs
@@ -33,11 +33,15 @@ pub(crate) async fn execute_recovery_agent_update(
             .await
             .map(|r| Json(r.into_response())),
         RegistryVersion::V2 => {
+            // WIP-102 removes the explicit execute step
+            // Return a terminal `Finalized`
             let _ = payload;
             Ok(Json(GatewayStatusResponse {
                 request_id: GatewayRequestId::new(id.to_string()),
                 kind: GatewayRequestKind::ExecuteRecoveryAgentUpdate,
-                status: GatewayRequestState::Queued,
+                status: GatewayRequestState::Finalized {
+                    tx_hash: String::new(),
+                },
             }))
         }
     }

--- a/services/gateway/src/routes/execute_recovery_agent_update.rs
+++ b/services/gateway/src/routes/execute_recovery_agent_update.rs
@@ -33,15 +33,25 @@ pub(crate) async fn execute_recovery_agent_update(
             .await
             .map(|r| Json(r.into_response())),
         RegistryVersion::V2 => {
-            // WIP-102 removes the explicit execute step
-            // Return a terminal `Finalized`
+            // WIP-102 removes the explicit execute step. Record the terminal
+            // no-op result so clients polling `/status/{request_id}` do not get
+            // a 404 even though no transaction was needed.
             let _ = payload;
+            let kind = GatewayRequestKind::ExecuteRecoveryAgentUpdate;
+            let status = GatewayRequestState::Finalized {
+                tx_hash: String::new(),
+            };
+
+            state
+                .ctx
+                .tracker
+                .new_terminal_request_with_id(id.to_string(), kind, status.clone())
+                .await?;
+
             Ok(Json(GatewayStatusResponse {
                 request_id: GatewayRequestId::new(id.to_string()),
-                kind: GatewayRequestKind::ExecuteRecoveryAgentUpdate,
-                status: GatewayRequestState::Finalized {
-                    tx_hash: String::new(),
-                },
+                kind,
+                status,
             }))
         }
     }

--- a/services/gateway/src/routes/initiate_recovery_agent_update.rs
+++ b/services/gateway/src/routes/initiate_recovery_agent_update.rs
@@ -1,7 +1,10 @@
 //! Initiate recovery agent update handler.
 
 use crate::{
-    error::GatewayErrorResponse, request::IntoRequestWithRateLimit, routes::middleware::RequestId,
+    RegistryVersion,
+    error::GatewayErrorResponse,
+    request::{IntoRequestWithRateLimit, UpdateRecoveryAgentV2Request},
+    routes::middleware::RequestId,
     types::AppState,
 };
 use axum::{Extension, Json, extract::State};
@@ -10,17 +13,26 @@ use world_id_primitives::api_types::{GatewayStatusResponse, UpdateRecoveryAgentR
 
 /// POST /initiate-recovery-agent-update
 ///
-/// Initiates a time-locked recovery agent update (14-day cooldown).
+/// Legacy URL. Pre-V2: initiates a time-locked recovery agent update (14-day
+/// cooldown flow). Post-V2: translates into a WIP-102 `updateRecoveryAgent`.
 #[instrument(name = "initiate_recovery_agent_update", skip(state, payload), fields(request_id = %id))]
 pub(crate) async fn initiate_recovery_agent_update(
     State(state): State<AppState>,
     Extension(RequestId(id)): Extension<RequestId>,
     Json(payload): Json<UpdateRecoveryAgentRequest>,
 ) -> Result<Json<GatewayStatusResponse>, GatewayErrorResponse> {
-    payload
-        .into_request_with_rate_limit(id, &state.ctx)
-        .await?
-        .submit(&state.ctx)
-        .await
-        .map(|r| Json(r.into_response()))
+    match state.ctx.registry_version {
+        RegistryVersion::V1 => payload
+            .into_request_with_rate_limit(id, &state.ctx)
+            .await?
+            .submit(&state.ctx)
+            .await
+            .map(|r| Json(r.into_response())),
+        RegistryVersion::V2 => UpdateRecoveryAgentV2Request(payload)
+            .into_request_with_rate_limit(id, &state.ctx)
+            .await?
+            .submit(&state.ctx)
+            .await
+            .map(|r| Json(r.into_response())),
+    }
 }

--- a/services/gateway/src/routes/initiate_recovery_agent_update.rs
+++ b/services/gateway/src/routes/initiate_recovery_agent_update.rs
@@ -15,6 +15,9 @@ use world_id_primitives::api_types::{GatewayStatusResponse, UpdateRecoveryAgentR
 ///
 /// Legacy URL. Pre-V2: initiates a time-locked recovery agent update (14-day
 /// cooldown flow). Post-V2: translates into a WIP-102 `updateRecoveryAgent`.
+///
+/// TODO(WIP-102): remove this handler and its route once all clients have
+/// migrated to `POST /update-recovery-agent`.
 #[instrument(name = "initiate_recovery_agent_update", skip(state, payload), fields(request_id = %id))]
 pub(crate) async fn initiate_recovery_agent_update(
     State(state): State<AppState>,

--- a/services/gateway/src/routes/revert_recovery_agent_update.rs
+++ b/services/gateway/src/routes/revert_recovery_agent_update.rs
@@ -1,25 +1,38 @@
 //! Revert recovery agent update handler.
 
 use crate::{
+    RegistryVersion,
     error::GatewayErrorResponse,
     request::{IntoRequestWithRateLimit, RevertRecoveryAgentUpdateRequest},
     routes::middleware::RequestId,
     types::AppState,
 };
-use axum::{Extension, Json, extract::State};
+use axum::{Extension, Json, extract::State, http::StatusCode};
 use tracing::instrument;
-use world_id_primitives::api_types::{CancelRecoveryAgentUpdateRequest, GatewayStatusResponse};
+use world_id_primitives::api_types::{
+    CancelRecoveryAgentUpdateRequest, GatewayErrorCode, GatewayStatusResponse,
+};
 
 /// POST /revert-recovery-agent-update
 ///
 /// Revert an in-flight WIP-102 Recovery Agent update within the revert window.
-/// Requires the registry proxy to be on the V2 implementation.
+/// Requires the registry proxy to be on the V2 implementation; against V1
+/// returns 501 Not Implemented.
 #[instrument(name = "revert_recovery_agent_update", skip(state, payload), fields(request_id = %id))]
 pub(crate) async fn revert_recovery_agent_update(
     State(state): State<AppState>,
     Extension(RequestId(id)): Extension<RequestId>,
     Json(payload): Json<CancelRecoveryAgentUpdateRequest>,
 ) -> Result<Json<GatewayStatusResponse>, GatewayErrorResponse> {
+    if state.ctx.registry_version == RegistryVersion::V1 {
+        return Err(GatewayErrorResponse::new(
+            GatewayErrorCode::MethodNotAvailable,
+            "POST /revert-recovery-agent-update requires the registry to be on V2 (WIP-102). \
+             The current registry is V1; use POST /cancel-recovery-agent-update instead."
+                .to_string(),
+            StatusCode::NOT_IMPLEMENTED,
+        ));
+    }
     RevertRecoveryAgentUpdateRequest(payload)
         .into_request_with_rate_limit(id, &state.ctx)
         .await?

--- a/services/gateway/src/routes/revert_recovery_agent_update.rs
+++ b/services/gateway/src/routes/revert_recovery_agent_update.rs
@@ -1,0 +1,29 @@
+//! Revert recovery agent update handler.
+
+use crate::{
+    error::GatewayErrorResponse,
+    request::{IntoRequestWithRateLimit, RevertRecoveryAgentUpdateRequest},
+    routes::middleware::RequestId,
+    types::AppState,
+};
+use axum::{Extension, Json, extract::State};
+use tracing::instrument;
+use world_id_primitives::api_types::{CancelRecoveryAgentUpdateRequest, GatewayStatusResponse};
+
+/// POST /revert-recovery-agent-update
+///
+/// Revert an in-flight WIP-102 Recovery Agent update within the revert window.
+/// Requires the registry proxy to be on the V2 implementation.
+#[instrument(name = "revert_recovery_agent_update", skip(state, payload), fields(request_id = %id))]
+pub(crate) async fn revert_recovery_agent_update(
+    State(state): State<AppState>,
+    Extension(RequestId(id)): Extension<RequestId>,
+    Json(payload): Json<CancelRecoveryAgentUpdateRequest>,
+) -> Result<Json<GatewayStatusResponse>, GatewayErrorResponse> {
+    RevertRecoveryAgentUpdateRequest(payload)
+        .into_request_with_rate_limit(id, &state.ctx)
+        .await?
+        .submit(&state.ctx)
+        .await
+        .map(|r| Json(r.into_response()))
+}

--- a/services/gateway/src/routes/update_recovery_agent.rs
+++ b/services/gateway/src/routes/update_recovery_agent.rs
@@ -1,0 +1,29 @@
+//! Update recovery agent handler.
+
+use crate::{
+    error::GatewayErrorResponse,
+    request::{IntoRequestWithRateLimit, UpdateRecoveryAgentV2Request},
+    routes::middleware::RequestId,
+    types::AppState,
+};
+use axum::{Extension, Json, extract::State};
+use tracing::instrument;
+use world_id_primitives::api_types::{GatewayStatusResponse, UpdateRecoveryAgentRequest};
+
+/// POST /update-recovery-agent
+///
+/// Apply a WIP-102 optimistic Recovery Agent update. Requires the registry
+/// proxy to be on the V2 implementation.
+#[instrument(name = "update_recovery_agent", skip(state, payload), fields(request_id = %id))]
+pub(crate) async fn update_recovery_agent(
+    State(state): State<AppState>,
+    Extension(RequestId(id)): Extension<RequestId>,
+    Json(payload): Json<UpdateRecoveryAgentRequest>,
+) -> Result<Json<GatewayStatusResponse>, GatewayErrorResponse> {
+    UpdateRecoveryAgentV2Request(payload)
+        .into_request_with_rate_limit(id, &state.ctx)
+        .await?
+        .submit(&state.ctx)
+        .await
+        .map(|r| Json(r.into_response()))
+}

--- a/services/gateway/src/routes/update_recovery_agent.rs
+++ b/services/gateway/src/routes/update_recovery_agent.rs
@@ -1,25 +1,37 @@
 //! Update recovery agent handler.
 
 use crate::{
+    RegistryVersion,
     error::GatewayErrorResponse,
     request::{IntoRequestWithRateLimit, UpdateRecoveryAgentV2Request},
     routes::middleware::RequestId,
     types::AppState,
 };
-use axum::{Extension, Json, extract::State};
+use axum::{Extension, Json, extract::State, http::StatusCode};
 use tracing::instrument;
-use world_id_primitives::api_types::{GatewayStatusResponse, UpdateRecoveryAgentRequest};
+use world_id_primitives::api_types::{
+    GatewayErrorCode, GatewayStatusResponse, UpdateRecoveryAgentRequest,
+};
 
 /// POST /update-recovery-agent
 ///
 /// Apply a WIP-102 optimistic Recovery Agent update. Requires the registry
-/// proxy to be on the V2 implementation.
+/// proxy to be on the V2 implementation; against V1 returns 501 Not Implemented.
 #[instrument(name = "update_recovery_agent", skip(state, payload), fields(request_id = %id))]
 pub(crate) async fn update_recovery_agent(
     State(state): State<AppState>,
     Extension(RequestId(id)): Extension<RequestId>,
     Json(payload): Json<UpdateRecoveryAgentRequest>,
 ) -> Result<Json<GatewayStatusResponse>, GatewayErrorResponse> {
+    if state.ctx.registry_version == RegistryVersion::V1 {
+        return Err(GatewayErrorResponse::new(
+            GatewayErrorCode::MethodNotAvailable,
+            "POST /update-recovery-agent requires the registry to be on V2 (WIP-102). \
+             The current registry is V1; use POST /initiate-recovery-agent-update instead."
+                .to_string(),
+            StatusCode::NOT_IMPLEMENTED,
+        ));
+    }
     UpdateRecoveryAgentV2Request(payload)
         .into_request_with_rate_limit(id, &state.ctx)
         .await?

--- a/services/gateway/src/routes/validation.rs
+++ b/services/gateway/src/routes/validation.rs
@@ -15,10 +15,13 @@ use world_id_primitives::api_types::{
 use world_id_registries::world_id::{
     CancelRecoveryAgentUpdateTypedData, InitiateRecoveryAgentUpdateTypedData,
     InsertAuthenticatorTypedData, RecoverAccountTypedData, RemoveAuthenticatorTypedData,
-    UpdateAuthenticatorTypedData,
+    UpdateAuthenticatorTypedData, WorldIdRegistryV2::WorldIdRegistryV2Instance,
 };
 
-use crate::{request::Registry, types::MAX_AUTHENTICATORS};
+use crate::{
+    request::{Registry, RevertRecoveryAgentUpdateRequest, UpdateRecoveryAgentV2Request},
+    types::MAX_AUTHENTICATORS,
+};
 
 /// Global OnceCell to store the chain ID.
 pub static CHAIN_ID: OnceCell<u64> = OnceCell::const_new();
@@ -494,6 +497,56 @@ impl RequestValidation for ExecuteRecoveryAgentUpdateRequest {
             .executeRecoveryAgentUpdate(self.leaf_index)
             .calldata()
             .clone()
+    }
+}
+
+// =============================================================================
+// V2 Recovery Agent flow (WIP-102): reuses V1 typehashes; targets V2 selectors.
+// `pre_flight` delegates to the inner V1 request since the field checks and
+// EIP-712 digest are identical — only the contract selector differs.
+// =============================================================================
+impl RequestValidation for UpdateRecoveryAgentV2Request {
+    fn pre_flight(
+        &self,
+        chain_id: u64,
+        verifying_contract: Address,
+    ) -> Result<(), GatewayErrorResponse> {
+        self.0.pre_flight(chain_id, verifying_contract)
+    }
+
+    fn calldata(&self, registry: &Registry) -> Bytes {
+        let v2 = WorldIdRegistryV2Instance::new(*registry.address(), registry.provider().clone());
+        let inner = &self.0;
+        v2.updateRecoveryAgent(
+            inner.leaf_index,
+            inner.new_recovery_agent,
+            Bytes::copy_from_slice(&inner.signature.as_bytes()),
+            inner.nonce,
+        )
+        .calldata()
+        .clone()
+    }
+}
+
+impl RequestValidation for RevertRecoveryAgentUpdateRequest {
+    fn pre_flight(
+        &self,
+        chain_id: u64,
+        verifying_contract: Address,
+    ) -> Result<(), GatewayErrorResponse> {
+        self.0.pre_flight(chain_id, verifying_contract)
+    }
+
+    fn calldata(&self, registry: &Registry) -> Bytes {
+        let v2 = WorldIdRegistryV2Instance::new(*registry.address(), registry.provider().clone());
+        let inner = &self.0;
+        v2.revertRecoveryAgentUpdate(
+            inner.leaf_index,
+            Bytes::copy_from_slice(&inner.signature.as_bytes()),
+            inner.nonce,
+        )
+        .calldata()
+        .clone()
     }
 }
 

--- a/services/gateway/tests/common.rs
+++ b/services/gateway/tests/common.rs
@@ -37,6 +37,14 @@ pub(crate) struct TestGateway {
     pub(crate) _redis: ContainerAsync<Redis>,
 }
 
+fn spawn_test_anvil() -> TestAnvil {
+    let mut fork_url = std::env::var("TESTS_RPC_FORK_URL").unwrap_or_default();
+    if fork_url.is_empty() {
+        fork_url = RPC_FORK_URL.to_string();
+    }
+    TestAnvil::spawn_fork(&fork_url).expect("failed to spawn forked anvil")
+}
+
 /// Spawn a test gateway backed by a forked anvil chain and a Redis container.
 ///
 /// * `batch_ms` – when `None` the gateway uses `BatchPolicyConfig::default()`
@@ -44,16 +52,35 @@ pub(crate) struct TestGateway {
 ///   a custom batch window (used by `test_inflight.rs`).
 #[allow(dead_code)]
 pub(crate) async fn spawn_test_gateway(batch_ms: Option<u64>) -> TestGateway {
-    let mut fork_url = std::env::var("TESTS_RPC_FORK_URL").unwrap_or_default();
-    if fork_url.is_empty() {
-        fork_url = RPC_FORK_URL.to_string();
-    }
-    let anvil = TestAnvil::spawn_fork(&fork_url).expect("failed to spawn forked anvil");
+    let anvil = spawn_test_anvil();
     let deployer = anvil.signer(0).expect("failed to fetch deployer signer");
     let registry_addr = anvil
         .deploy_world_id_registry(deployer)
         .await
         .expect("failed to deploy WorldIDRegistry");
+    spawn_test_gateway_for_registry(anvil, registry_addr, batch_ms).await
+}
+
+/// Same as [`spawn_test_gateway`] but deploys the V2 (WIP-102) registry —
+/// the V1 implementation behind an ERC1967 proxy upgraded to V2.
+#[allow(dead_code)]
+pub(crate) async fn spawn_test_gateway_v2(batch_ms: Option<u64>) -> TestGateway {
+    let anvil = spawn_test_anvil();
+    let deployer = anvil.signer(0).expect("failed to fetch deployer signer");
+    let registry_addr = anvil
+        .deploy_world_id_registry_v2(deployer)
+        .await
+        .expect("failed to deploy WorldIDRegistry V2");
+    spawn_test_gateway_for_registry(anvil, registry_addr, batch_ms).await
+}
+
+/// Spawn the gateway/Redis half of the stack against an already-deployed
+/// registry. Shared by [`spawn_test_gateway`] and [`spawn_test_gateway_v2`].
+async fn spawn_test_gateway_for_registry(
+    anvil: TestAnvil,
+    registry_addr: Address,
+    batch_ms: Option<u64>,
+) -> TestGateway {
     let rpc_url = anvil.endpoint().to_string();
     let chain_id = anvil.instance.chain_id();
 

--- a/services/gateway/tests/test_recovery_agent_update.rs
+++ b/services/gateway/tests/test_recovery_agent_update.rs
@@ -2,6 +2,10 @@
 //!
 //! Exercises `initiate-recovery-agent-update`, `cancel-recovery-agent-update`,
 //! and `execute-recovery-agent-update` through a real gateway ↔ anvil stack.
+//!
+//! TODO(WIP-102): delete this file together with the V1 legacy handlers once
+//! all clients have migrated to the V2 routes (covered by
+//! `test_recovery_agent_update_v2.rs`).
 
 use std::{future::Future, time::Duration};
 

--- a/services/gateway/tests/test_recovery_agent_update.rs
+++ b/services/gateway/tests/test_recovery_agent_update.rs
@@ -4,16 +4,7 @@
 //! and `execute-recovery-agent-update` against both a V1 registry and a
 //! V2-upgraded one (which translates legacy URLs into WIP-102 selectors), plus
 //! the new V2-native `update-recovery-agent` / `revert-recovery-agent-update`
-//! URLs. Helpers are shared across V1 and V2 tests since the V2 contract
-//! preserves the V1 ABI shape for `getPendingRecoveryAgentUpdate`.
-//!
-//! TODO(WIP-102): once all clients have migrated to the V2 URLs, delete the V1
-//! legacy handlers and the corresponding tests in this file
-//! (`e2e_initiate_and_cancel_recovery_agent_update`,
-//! `e2e_initiate_and_execute_recovery_agent_update`,
-//! `e2e_initiate_and_cancel_recovery_agent_update_v2`,
-//! `e2e_initiate_then_window_elapse_and_execute_noop_v2`). Only the V2-native
-//! `e2e_update_and_revert_via_v2_urls` test needs to survive.
+//! URLs.
 
 use std::{future::Future, time::Duration};
 

--- a/services/gateway/tests/test_recovery_agent_update.rs
+++ b/services/gateway/tests/test_recovery_agent_update.rs
@@ -1,11 +1,19 @@
 //! E2E tests for recovery-agent-update gateway routes.
 //!
 //! Exercises `initiate-recovery-agent-update`, `cancel-recovery-agent-update`,
-//! and `execute-recovery-agent-update` through a real gateway ↔ anvil stack.
+//! and `execute-recovery-agent-update` against both a V1 registry and a
+//! V2-upgraded one (which translates legacy URLs into WIP-102 selectors), plus
+//! the new V2-native `update-recovery-agent` / `revert-recovery-agent-update`
+//! URLs. Helpers are shared across V1 and V2 tests since the V2 contract
+//! preserves the V1 ABI shape for `getPendingRecoveryAgentUpdate`.
 //!
-//! TODO(WIP-102): delete this file together with the V1 legacy handlers once
-//! all clients have migrated to the V2 routes (covered by
-//! `test_recovery_agent_update_v2.rs`).
+//! TODO(WIP-102): once all clients have migrated to the V2 URLs, delete the V1
+//! legacy handlers and the corresponding tests in this file
+//! (`e2e_initiate_and_cancel_recovery_agent_update`,
+//! `e2e_initiate_and_execute_recovery_agent_update`,
+//! `e2e_initiate_and_cancel_recovery_agent_update_v2`,
+//! `e2e_initiate_then_window_elapse_and_execute_noop_v2`). Only the V2-native
+//! `e2e_update_and_revert_via_v2_urls` test needs to survive.
 
 use std::{future::Future, time::Duration};
 
@@ -16,15 +24,15 @@ use alloy::{
 };
 use reqwest::StatusCode;
 use world_id_primitives::api_types::{
-    CancelRecoveryAgentUpdateRequest, ExecuteRecoveryAgentUpdateRequest, GatewayStatusResponse,
-    UpdateRecoveryAgentRequest,
+    CancelRecoveryAgentUpdateRequest, ExecuteRecoveryAgentUpdateRequest, GatewayRequestState,
+    GatewayStatusResponse, UpdateRecoveryAgentRequest,
 };
 use world_id_registries::world_id::{
     WorldIdRegistry, domain as ag_domain, sign_cancel_recovery_agent_update,
     sign_initiate_recovery_agent_update,
 };
 
-use crate::common::{TestGateway, spawn_test_gateway, wait_for_finalized};
+use crate::common::{TestGateway, spawn_test_gateway, spawn_test_gateway_v2, wait_for_finalized};
 
 mod common;
 
@@ -80,7 +88,7 @@ async fn wait_for_pending_recovery_agent_update<F, Fut>(
                 if pending_recovery_agent == expected_recovery_agent {
                     assert!(
                         execute_after > U256::ZERO,
-                        "executeAfter should be set after initiation"
+                        "executeAfter timestamp should be set on-chain"
                     );
                     true
                 } else {
@@ -99,7 +107,7 @@ async fn wait_for_pending_recovery_agent_update_to_clear<F, Fut>(
     Fut: Future<Output = (Address, U256)>,
 {
     wait_for_condition(
-        "timeout waiting for pending recovery agent update to clear after cancel",
+        "timeout waiting for pending recovery agent update to clear",
         move || {
             let pending_recovery_agent_update = get_pending_recovery_agent_update();
             async move {
@@ -175,6 +183,31 @@ async fn create_account(gw: &TestGateway) -> (PrivateKeySigner, Address) {
     .await;
 
     (signer, wallet_addr)
+}
+
+/// Advance anvil's clock past the V1 cooldown / V2 revert window so the
+/// pending update either becomes executable (V1) or self-activates (V2).
+async fn advance_past_revert_window<P: Provider>(provider: &P, contract_addr: Address) {
+    // V2 reuses the existing `_recoveryAgentUpdateCooldown` storage as the
+    // revert-window length, so the V1 ABI's `getRecoveryAgentUpdateCooldown`
+    // returns the right value for both.
+    let contract = WorldIdRegistry::new(contract_addr, provider);
+    let cooldown = contract
+        .getRecoveryAgentUpdateCooldown()
+        .call()
+        .await
+        .unwrap();
+    let jump_secs: u64 = cooldown.to::<u64>() + 60;
+    let _: u64 = provider
+        .client()
+        .request("evm_increaseTime", (jump_secs,))
+        .await
+        .expect("evm_increaseTime failed");
+    let _: serde_json::Value = provider
+        .client()
+        .request("evm_mine", ())
+        .await
+        .expect("evm_mine failed");
 }
 
 // ---------------------------------------------------------------------------
@@ -369,24 +402,7 @@ async fn e2e_initiate_and_execute_recovery_agent_update() {
     .await;
 
     // ── 2. Fast-forward anvil past the 14-day cooldown ────────────────
-    let cooldown = contract
-        .getRecoveryAgentUpdateCooldown()
-        .call()
-        .await
-        .unwrap();
-    // Add an extra 60 s buffer to comfortably clear the cooldown.
-    let jump_secs: u64 = cooldown.to::<u64>() + 60;
-    let _: u64 = provider
-        .client()
-        .request("evm_increaseTime", (jump_secs,))
-        .await
-        .expect("evm_increaseTime failed");
-    // Mine a block so the new timestamp takes effect.
-    let _: serde_json::Value = provider
-        .client()
-        .request("evm_mine", ())
-        .await
-        .expect("evm_mine failed");
+    advance_past_revert_window(&provider, gw.registry_addr).await;
 
     // ── 3. Execute the pending update ─────────────────────────────────
     let body_exec = ExecuteRecoveryAgentUpdateRequest { leaf_index };
@@ -423,5 +439,321 @@ async fn e2e_initiate_and_execute_recovery_agent_update() {
         pending.newRecoveryAgent,
         Address::ZERO,
         "pending update should be cleared after execution"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// V2 (WIP-102) tests — gateway against a V2-upgraded registry
+// ---------------------------------------------------------------------------
+
+/// Backwards-compat scenario: client calls the legacy `/initiate-` and
+/// `/cancel-` URLs against a V2 registry, signing with the V1 typehash. The
+/// gateway translates each to the V2 selector internally and the contract
+/// accepts the V1-typehash signatures (typehash reuse).
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn e2e_initiate_and_cancel_recovery_agent_update_v2() {
+    let gw = spawn_test_gateway_v2(None).await;
+    let (signer, wallet_addr) = create_account(&gw).await;
+
+    let provider = alloy::providers::ProviderBuilder::new()
+        .wallet(alloy::network::EthereumWallet::from(signer.clone()))
+        .connect_http(gw.rpc_url.parse().expect("invalid anvil endpoint url"));
+    let contract = WorldIdRegistry::new(gw.registry_addr, provider.clone());
+    let chain_id = provider.get_chain_id().await.unwrap();
+    let domain = ag_domain(chain_id, gw.registry_addr);
+
+    let leaf_index: u64 = 1;
+    let nonce = U256::from(0);
+    let new_recovery_agent: Address = "0x000000000000000000000000000000000000beef"
+        .parse()
+        .unwrap();
+
+    // 1. Legacy URL → V2 `updateRecoveryAgent`.
+    let sig_init = sign_initiate_recovery_agent_update(
+        &signer,
+        leaf_index,
+        new_recovery_agent,
+        nonce,
+        &domain,
+    )
+    .unwrap();
+    let body_init = UpdateRecoveryAgentRequest {
+        leaf_index,
+        new_recovery_agent,
+        signature: sig_init,
+        nonce,
+    };
+    let resp = gw
+        .client
+        .post(format!("{}/initiate-recovery-agent-update", gw.base_url))
+        .json(&body_init)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK, "initiate failed: {:?}", resp);
+    let accepted: GatewayStatusResponse = resp.json().await.unwrap();
+    let _ = wait_for_finalized(&gw.client, &gw.base_url, &accepted.request_id).await;
+
+    // V2-translated `getPendingRecoveryAgentUpdate` returns the scheduled new
+    // agent and the `invalidAfter` timestamp.
+    wait_for_pending_recovery_agent_update(
+        || async {
+            let pending = contract
+                .getPendingRecoveryAgentUpdate(leaf_index)
+                .call()
+                .await
+                .unwrap();
+            (pending.newRecoveryAgent, pending.executeAfter)
+        },
+        new_recovery_agent,
+    )
+    .await;
+
+    // Inside the revert window the *effective* recovery agent is still the
+    // original one — that's the WIP-102 security property.
+    let effective = contract.getRecoveryAgent(leaf_index).call().await.unwrap();
+    assert_eq!(
+        effective, wallet_addr,
+        "during revert window, effective agent should remain the original signer"
+    );
+
+    // 2. Legacy URL → V2 `revertRecoveryAgentUpdate`.
+    let nonce = nonce + U256::from(1);
+    let sig_cancel =
+        sign_cancel_recovery_agent_update(&signer, leaf_index, nonce, &domain).unwrap();
+    let body_cancel = CancelRecoveryAgentUpdateRequest {
+        leaf_index,
+        signature: sig_cancel,
+        nonce,
+    };
+    let resp = gw
+        .client
+        .post(format!("{}/cancel-recovery-agent-update", gw.base_url))
+        .json(&body_cancel)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK, "cancel failed: {:?}", resp);
+    let accepted: GatewayStatusResponse = resp.json().await.unwrap();
+    let _ = wait_for_finalized(&gw.client, &gw.base_url, &accepted.request_id).await;
+
+    // Pending mapping cleared, original agent still effective.
+    wait_for_pending_recovery_agent_update_to_clear(|| async {
+        let pending = contract
+            .getPendingRecoveryAgentUpdate(leaf_index)
+            .call()
+            .await
+            .unwrap();
+        (pending.newRecoveryAgent, pending.executeAfter)
+    })
+    .await;
+    let effective = contract.getRecoveryAgent(leaf_index).call().await.unwrap();
+    assert_eq!(effective, wallet_addr, "agent should be the original");
+}
+
+/// WIP-102 mechanics: after `/initiate-` lands on V2, fast-forward past the
+/// revert window. The new agent becomes effective with no `/execute-` call
+/// required. Then call `/execute-recovery-agent-update` and verify it's a
+/// synthetic no-op (200 OK, status `Queued`, no on-chain side effect).
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn e2e_initiate_then_window_elapse_and_execute_noop_v2() {
+    let gw = spawn_test_gateway_v2(None).await;
+    let (signer, wallet_addr) = create_account(&gw).await;
+
+    let provider = alloy::providers::ProviderBuilder::new()
+        .wallet(alloy::network::EthereumWallet::from(signer.clone()))
+        .connect_http(gw.rpc_url.parse().expect("invalid anvil endpoint url"));
+    let contract = WorldIdRegistry::new(gw.registry_addr, provider.clone());
+    let chain_id = provider.get_chain_id().await.unwrap();
+    let domain = ag_domain(chain_id, gw.registry_addr);
+
+    let leaf_index: u64 = 1;
+    let nonce = U256::from(0);
+    let new_recovery_agent: Address = "0x000000000000000000000000000000000000cafe"
+        .parse()
+        .unwrap();
+
+    let pre = contract.getRecoveryAgent(leaf_index).call().await.unwrap();
+    assert_eq!(pre, wallet_addr);
+
+    // Legacy URL initiates the V2 update.
+    let sig_init = sign_initiate_recovery_agent_update(
+        &signer,
+        leaf_index,
+        new_recovery_agent,
+        nonce,
+        &domain,
+    )
+    .unwrap();
+    let body_init = UpdateRecoveryAgentRequest {
+        leaf_index,
+        new_recovery_agent,
+        signature: sig_init,
+        nonce,
+    };
+    let resp = gw
+        .client
+        .post(format!("{}/initiate-recovery-agent-update", gw.base_url))
+        .json(&body_init)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let accepted: GatewayStatusResponse = resp.json().await.unwrap();
+    let _ = wait_for_finalized(&gw.client, &gw.base_url, &accepted.request_id).await;
+
+    wait_for_pending_recovery_agent_update(
+        || async {
+            let pending = contract
+                .getPendingRecoveryAgentUpdate(leaf_index)
+                .call()
+                .await
+                .unwrap();
+            (pending.newRecoveryAgent, pending.executeAfter)
+        },
+        new_recovery_agent,
+    )
+    .await;
+
+    // Fast-forward anvil past the revert window.
+    advance_past_revert_window(&provider, gw.registry_addr).await;
+
+    // No execute call yet — the new agent should already be effective on its own.
+    wait_for_recovery_agent_update(
+        || async { contract.getRecoveryAgent(leaf_index).call().await.unwrap() },
+        new_recovery_agent,
+    )
+    .await;
+
+    // The translated `getPendingRecoveryAgentUpdate` view returns (0, 0) once
+    // the window has elapsed, since V2 considers the update no longer "pending".
+    let pending = contract
+        .getPendingRecoveryAgentUpdate(leaf_index)
+        .call()
+        .await
+        .unwrap();
+    assert_eq!(pending.newRecoveryAgent, Address::ZERO);
+    assert_eq!(pending.executeAfter, U256::ZERO);
+
+    // Now call `/execute-recovery-agent-update`. On V2 this is a synthetic
+    // no-op: the gateway returns 200 with state Queued without touching chain.
+    let body_exec = ExecuteRecoveryAgentUpdateRequest { leaf_index };
+    let resp = gw
+        .client
+        .post(format!("{}/execute-recovery-agent-update", gw.base_url))
+        .json(&body_exec)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body: GatewayStatusResponse = resp.json().await.unwrap();
+    assert!(
+        matches!(body.status, GatewayRequestState::Queued),
+        "execute should return synthetic Queued, got {:?}",
+        body.status
+    );
+
+    // On-chain state hasn't moved (no extra tx).
+    let still_effective = contract.getRecoveryAgent(leaf_index).call().await.unwrap();
+    assert_eq!(still_effective, new_recovery_agent);
+}
+
+/// New WIP-102 URLs: `/update-recovery-agent` and `/revert-recovery-agent-update`
+/// work directly against V2 with the (V1-compatible) signing helpers.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn e2e_update_and_revert_via_v2_urls() {
+    let gw = spawn_test_gateway_v2(None).await;
+    let (signer, wallet_addr) = create_account(&gw).await;
+
+    let provider = alloy::providers::ProviderBuilder::new()
+        .wallet(alloy::network::EthereumWallet::from(signer.clone()))
+        .connect_http(gw.rpc_url.parse().expect("invalid anvil endpoint url"));
+    let contract = WorldIdRegistry::new(gw.registry_addr, provider.clone());
+    let chain_id = provider.get_chain_id().await.unwrap();
+    let domain = ag_domain(chain_id, gw.registry_addr);
+
+    let leaf_index: u64 = 1;
+    let nonce = U256::from(0);
+    let new_recovery_agent: Address = "0x00000000000000000000000000000000000000aa"
+        .parse()
+        .unwrap();
+
+    // POST /update-recovery-agent
+    let sig_update = sign_initiate_recovery_agent_update(
+        &signer,
+        leaf_index,
+        new_recovery_agent,
+        nonce,
+        &domain,
+    )
+    .unwrap();
+    let body_update = UpdateRecoveryAgentRequest {
+        leaf_index,
+        new_recovery_agent,
+        signature: sig_update,
+        nonce,
+    };
+    let resp = gw
+        .client
+        .post(format!("{}/update-recovery-agent", gw.base_url))
+        .json(&body_update)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK, "update failed: {:?}", resp);
+    let accepted: GatewayStatusResponse = resp.json().await.unwrap();
+    let _ = wait_for_finalized(&gw.client, &gw.base_url, &accepted.request_id).await;
+
+    wait_for_pending_recovery_agent_update(
+        || async {
+            let pending = contract
+                .getPendingRecoveryAgentUpdate(leaf_index)
+                .call()
+                .await
+                .unwrap();
+            (pending.newRecoveryAgent, pending.executeAfter)
+        },
+        new_recovery_agent,
+    )
+    .await;
+    let effective = contract.getRecoveryAgent(leaf_index).call().await.unwrap();
+    assert_eq!(
+        effective, wallet_addr,
+        "prev agent still effective in window"
+    );
+
+    // POST /revert-recovery-agent-update
+    let nonce = nonce + U256::from(1);
+    let sig_revert =
+        sign_cancel_recovery_agent_update(&signer, leaf_index, nonce, &domain).unwrap();
+    let body_revert = CancelRecoveryAgentUpdateRequest {
+        leaf_index,
+        signature: sig_revert,
+        nonce,
+    };
+    let resp = gw
+        .client
+        .post(format!("{}/revert-recovery-agent-update", gw.base_url))
+        .json(&body_revert)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK, "revert failed: {:?}", resp);
+    let accepted: GatewayStatusResponse = resp.json().await.unwrap();
+    let _ = wait_for_finalized(&gw.client, &gw.base_url, &accepted.request_id).await;
+
+    wait_for_pending_recovery_agent_update_to_clear(|| async {
+        let pending = contract
+            .getPendingRecoveryAgentUpdate(leaf_index)
+            .call()
+            .await
+            .unwrap();
+        (pending.newRecoveryAgent, pending.executeAfter)
+    })
+    .await;
+    let effective = contract.getRecoveryAgent(leaf_index).call().await.unwrap();
+    assert_eq!(
+        effective, wallet_addr,
+        "after revert the original agent is restored"
     );
 }

--- a/services/gateway/tests/test_recovery_agent_update.rs
+++ b/services/gateway/tests/test_recovery_agent_update.rs
@@ -760,3 +760,64 @@ async fn e2e_update_and_revert_via_v2_urls() {
         "after revert the original agent is restored"
     );
 }
+
+/// Hitting the V2-only WIP-102 routes against a V1 registry should return
+/// 501 Not Implemented — never V2 calldata that would revert on-chain.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn e2e_v2_only_routes_against_v1_return_not_implemented() {
+    let gw = spawn_test_gateway(None).await;
+    let (signer, _wallet_addr) = create_account(&gw).await;
+
+    let provider = alloy::providers::ProviderBuilder::new()
+        .wallet(alloy::network::EthereumWallet::from(signer.clone()))
+        .connect_http(gw.rpc_url.parse().expect("invalid anvil endpoint url"));
+    let chain_id = provider.get_chain_id().await.unwrap();
+    let domain = ag_domain(chain_id, gw.registry_addr);
+
+    let leaf_index: u64 = 1;
+    let nonce = U256::from(0);
+    let new_recovery_agent: Address = "0x00000000000000000000000000000000000000bb"
+        .parse()
+        .unwrap();
+
+    // /update-recovery-agent against V1.
+    let sig_update = sign_initiate_recovery_agent_update(
+        &signer,
+        leaf_index,
+        new_recovery_agent,
+        nonce,
+        &domain,
+    )
+    .unwrap();
+    let body_update = UpdateRecoveryAgentRequest {
+        leaf_index,
+        new_recovery_agent,
+        signature: sig_update,
+        nonce,
+    };
+    let resp = gw
+        .client
+        .post(format!("{}/update-recovery-agent", gw.base_url))
+        .json(&body_update)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_IMPLEMENTED);
+
+    // /revert-recovery-agent-update against V1.
+    let sig_revert =
+        sign_cancel_recovery_agent_update(&signer, leaf_index, nonce, &domain).unwrap();
+    let body_revert = CancelRecoveryAgentUpdateRequest {
+        leaf_index,
+        signature: sig_revert,
+        nonce,
+    };
+    let resp = gw
+        .client
+        .post(format!("{}/revert-recovery-agent-update", gw.base_url))
+        .json(&body_revert)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_IMPLEMENTED);
+}

--- a/services/gateway/tests/test_recovery_agent_update.rs
+++ b/services/gateway/tests/test_recovery_agent_update.rs
@@ -15,8 +15,8 @@ use alloy::{
 };
 use reqwest::StatusCode;
 use world_id_primitives::api_types::{
-    CancelRecoveryAgentUpdateRequest, ExecuteRecoveryAgentUpdateRequest, GatewayRequestState,
-    GatewayStatusResponse, UpdateRecoveryAgentRequest,
+    CancelRecoveryAgentUpdateRequest, ExecuteRecoveryAgentUpdateRequest, GatewayStatusResponse,
+    UpdateRecoveryAgentRequest,
 };
 use world_id_registries::world_id::{
     WorldIdRegistry, domain as ag_domain, sign_cancel_recovery_agent_update,
@@ -543,9 +543,7 @@ async fn e2e_initiate_and_cancel_recovery_agent_update_v2() {
 }
 
 /// WIP-102 mechanics: after `/initiate-` lands on V2, fast-forward past the
-/// revert window. The new agent becomes effective with no `/execute-` call
-/// required. Then call `/execute-recovery-agent-update` and verify it's a
-/// synthetic no-op (200 OK, status `Queued`, no on-chain side effect).
+/// revert window.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn e2e_initiate_then_window_elapse_and_execute_noop_v2() {
     let gw = spawn_test_gateway_v2(None).await;
@@ -625,31 +623,6 @@ async fn e2e_initiate_then_window_elapse_and_execute_noop_v2() {
         .unwrap();
     assert_eq!(pending.newRecoveryAgent, Address::ZERO);
     assert_eq!(pending.executeAfter, U256::ZERO);
-
-    // Now call `/execute-recovery-agent-update`. On V2 this is a synthetic
-    // no-op: the gateway returns 200 with state Queued without touching chain.
-    let body_exec = ExecuteRecoveryAgentUpdateRequest { leaf_index };
-    let resp = gw
-        .client
-        .post(format!("{}/execute-recovery-agent-update", gw.base_url))
-        .json(&body_exec)
-        .send()
-        .await
-        .unwrap();
-    assert_eq!(resp.status(), StatusCode::OK);
-    let body: GatewayStatusResponse = resp.json().await.unwrap();
-    // V2 returns a terminal `Finalized` (with empty `tx_hash`)
-    match &body.status {
-        GatewayRequestState::Finalized { tx_hash } => assert!(
-            tx_hash.is_empty(),
-            "execute on V2 should return Finalized with empty tx_hash, got {tx_hash:?}"
-        ),
-        other => panic!("execute on V2 should return synthetic Finalized, got {other:?}"),
-    }
-
-    // On-chain state hasn't moved (no extra tx).
-    let still_effective = contract.getRecoveryAgent(leaf_index).call().await.unwrap();
-    assert_eq!(still_effective, new_recovery_agent);
 }
 
 /// New WIP-102 URLs: `/update-recovery-agent` and `/revert-recovery-agent-update`
@@ -750,65 +723,4 @@ async fn e2e_update_and_revert_via_v2_urls() {
         effective, wallet_addr,
         "after revert the original agent is restored"
     );
-}
-
-/// Hitting the V2-only WIP-102 routes against a V1 registry should return
-/// 501 Not Implemented — never V2 calldata that would revert on-chain.
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn e2e_v2_only_routes_against_v1_return_not_implemented() {
-    let gw = spawn_test_gateway(None).await;
-    let (signer, _wallet_addr) = create_account(&gw).await;
-
-    let provider = alloy::providers::ProviderBuilder::new()
-        .wallet(alloy::network::EthereumWallet::from(signer.clone()))
-        .connect_http(gw.rpc_url.parse().expect("invalid anvil endpoint url"));
-    let chain_id = provider.get_chain_id().await.unwrap();
-    let domain = ag_domain(chain_id, gw.registry_addr);
-
-    let leaf_index: u64 = 1;
-    let nonce = U256::from(0);
-    let new_recovery_agent: Address = "0x00000000000000000000000000000000000000bb"
-        .parse()
-        .unwrap();
-
-    // /update-recovery-agent against V1.
-    let sig_update = sign_initiate_recovery_agent_update(
-        &signer,
-        leaf_index,
-        new_recovery_agent,
-        nonce,
-        &domain,
-    )
-    .unwrap();
-    let body_update = UpdateRecoveryAgentRequest {
-        leaf_index,
-        new_recovery_agent,
-        signature: sig_update,
-        nonce,
-    };
-    let resp = gw
-        .client
-        .post(format!("{}/update-recovery-agent", gw.base_url))
-        .json(&body_update)
-        .send()
-        .await
-        .unwrap();
-    assert_eq!(resp.status(), StatusCode::NOT_IMPLEMENTED);
-
-    // /revert-recovery-agent-update against V1.
-    let sig_revert =
-        sign_cancel_recovery_agent_update(&signer, leaf_index, nonce, &domain).unwrap();
-    let body_revert = CancelRecoveryAgentUpdateRequest {
-        leaf_index,
-        signature: sig_revert,
-        nonce,
-    };
-    let resp = gw
-        .client
-        .post(format!("{}/revert-recovery-agent-update", gw.base_url))
-        .json(&body_revert)
-        .send()
-        .await
-        .unwrap();
-    assert_eq!(resp.status(), StatusCode::NOT_IMPLEMENTED);
 }

--- a/services/gateway/tests/test_recovery_agent_update.rs
+++ b/services/gateway/tests/test_recovery_agent_update.rs
@@ -15,8 +15,8 @@ use alloy::{
 };
 use reqwest::StatusCode;
 use world_id_primitives::api_types::{
-    CancelRecoveryAgentUpdateRequest, ExecuteRecoveryAgentUpdateRequest, GatewayStatusResponse,
-    UpdateRecoveryAgentRequest,
+    CancelRecoveryAgentUpdateRequest, ExecuteRecoveryAgentUpdateRequest, GatewayRequestState,
+    GatewayStatusResponse, UpdateRecoveryAgentRequest,
 };
 use world_id_registries::world_id::{
     WorldIdRegistry, domain as ag_domain, sign_cancel_recovery_agent_update,
@@ -623,6 +623,36 @@ async fn e2e_initiate_then_window_elapse_and_execute_noop_v2() {
         .unwrap();
     assert_eq!(pending.newRecoveryAgent, Address::ZERO);
     assert_eq!(pending.executeAfter, U256::ZERO);
+
+    // The legacy execute endpoint is a no-op on V2, but it should still record
+    // a terminal tracker entry so clients that poll status do not receive 404.
+    let body_exec = ExecuteRecoveryAgentUpdateRequest { leaf_index };
+    let resp = gw
+        .client
+        .post(format!("{}/execute-recovery-agent-update", gw.base_url))
+        .json(&body_exec)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK, "execute failed: {:?}", resp);
+    let accepted: GatewayStatusResponse = resp.json().await.unwrap();
+    assert!(matches!(
+        accepted.status,
+        GatewayRequestState::Finalized { .. }
+    ));
+
+    let resp = gw
+        .client
+        .get(format!("{}/status/{}", gw.base_url, accepted.request_id))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK, "status failed: {:?}", resp);
+    let status: GatewayStatusResponse = resp.json().await.unwrap();
+    assert!(matches!(
+        status.status,
+        GatewayRequestState::Finalized { .. }
+    ));
 }
 
 /// New WIP-102 URLs: `/update-recovery-agent` and `/revert-recovery-agent-update`

--- a/services/gateway/tests/test_recovery_agent_update.rs
+++ b/services/gateway/tests/test_recovery_agent_update.rs
@@ -647,11 +647,14 @@ async fn e2e_initiate_then_window_elapse_and_execute_noop_v2() {
         .unwrap();
     assert_eq!(resp.status(), StatusCode::OK);
     let body: GatewayStatusResponse = resp.json().await.unwrap();
-    assert!(
-        matches!(body.status, GatewayRequestState::Queued),
-        "execute should return synthetic Queued, got {:?}",
-        body.status
-    );
+    // V2 returns a terminal `Finalized` (with empty `tx_hash`)
+    match &body.status {
+        GatewayRequestState::Finalized { tx_hash } => assert!(
+            tx_hash.is_empty(),
+            "execute on V2 should return Finalized with empty tx_hash, got {tx_hash:?}"
+        ),
+        other => panic!("execute on V2 should return synthetic Finalized, got {other:?}"),
+    }
 
     // On-chain state hasn't moved (no extra tx).
     let still_effective = contract.getRecoveryAgent(leaf_index).call().await.unwrap();


### PR DESCRIPTION
- builds on top of WIP-104 changes including the v2 smart contract version for world id registry
- adds 2 new functions update/revert recovery agent on smart contracts
- adds respective handlers and backwards compatibility on gateway
- adds new functions to authenticator crate (world id core sdk)


- notably, initiated updates are invalidated 
- notably, for a smooth upgrade we should 
1. Upgrade Gateway
2. Upgrade Smart Contracts
3. Restart Gateways 

1) can happen far in advance, 3) should happen quickly after 2) since the gateway needs to be abware the contract upgrade happened. the usage of continuously polling or observing an event for the contract upgrade is deemed overkill here for a 1-time transition.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because it modifies on-chain account recovery and recovery-agent authorization semantics, and adds gateway routing/validation that conditionally targets new V2 selectors based on runtime version probing.
> 
> **Overview**
> Implements **WIP-102 recovery-agent updates** in `WorldIDRegistryV2`: adds `updateRecoveryAgent`/`revertRecoveryAgentUpdate` with a revert window, makes `recoverAccount` and `getRecoveryAgent` use the *effective* (previous-during-window) signer, and deprecates the V1 three-step update methods while translating `getPendingRecoveryAgentUpdate` into the legacy tuple shape.
> 
> Updates the Rust stack to support V2: generates/ships `WorldIDRegistryV2` ABI + bindings, adds SDK methods `update_recovery_agent` and `revert_recovery_agent_update` (and deprecates legacy calls), and updates the gateway to **probe registry version at startup** and route legacy endpoints to V2 selectors (plus new `/update-recovery-agent` and `/revert-recovery-agent-update` routes). Test utilities and E2E tests are expanded to cover V1 vs V2 behavior, including legacy-URL compatibility and the V2 no-op `execute` behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d851e1a183eca431e7e9f3f6f15b5425e2c3fb9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->