### PR TITLE
fix(oprf-node): propagate cancellation to cache maintenance tasks

### DIFF
--- a/services/oprf-node/src/auth.rs
+++ b/services/oprf-node/src/auth.rs
@@ -24,6 +24,20 @@ pub(crate) mod rp_module;
 pub(crate) mod rp_registry_watcher;
 pub(crate) mod schema_issuer_registry_watcher;
 
+/// A handle to a background task that returns `eyre::Result<()>`.
+pub(crate) type BackgroundTask = tokio::task::JoinHandle<eyre::Result<()>>;
+
+/// Handles to the long-running background tasks spawned by a watcher's `init`
+/// method: a subscribe task that processes contract events and a cache
+/// maintenance task that runs periodic upkeep on the watcher's cache. Both
+/// tasks observe the watcher's [`tokio_util::sync::CancellationToken`] and
+/// should be awaited during graceful shutdown so that panics or unexpected
+/// errors are surfaced rather than silently dropped.
+pub(crate) struct WatcherBackgroundTasks {
+    pub(crate) subscribe: BackgroundTask,
+    pub(crate) maintenance: BackgroundTask,
+}
+
 pub(crate) fn verify_query_proof(
     vk: &PreparedVerifyingKey<Bn254>,
     proof: &ark_groth16::Proof<Bn254>,
@@ -275,9 +289,10 @@ mod tests {
             )
             .await?;
 
-            let nonce_history = NonceHistory::init(
+            let (nonce_history, _) = NonceHistory::init(
                 current_time_stamp_max_difference * 2,
                 cache_maintenance_interval,
+                cancellation_token.clone(),
             );
 
             Ok(Self {

--- a/services/oprf-node/src/auth/merkle_watcher.rs
+++ b/services/oprf-node/src/auth/merkle_watcher.rs
@@ -41,9 +41,12 @@ use world_id_registries::world_id::WorldIdRegistry::{
     self, RootRecorded, RootValidityWindowUpdated, WorldIdRegistryInstance,
 };
 
-use crate::metrics::{
-    METRICS_ID_NODE_MERKLE_WATCHER_CACHE_HITS, METRICS_ID_NODE_MERKLE_WATCHER_CACHE_MISSES,
-    METRICS_ID_NODE_MERKLE_WATCHER_CACHE_SIZE,
+use crate::{
+    auth::WatcherBackgroundTasks,
+    metrics::{
+        METRICS_ID_NODE_MERKLE_WATCHER_CACHE_HITS, METRICS_ID_NODE_MERKLE_WATCHER_CACHE_MISSES,
+        METRICS_ID_NODE_MERKLE_WATCHER_CACHE_SIZE,
+    },
 };
 
 /// Error returned by the [`MerkleWatcher`] implementation.
@@ -108,7 +111,7 @@ impl MerkleWatcher {
         cache_maintenance_interval: Duration,
         started: Arc<AtomicBool>,
         cancellation_token: CancellationToken,
-    ) -> eyre::Result<(Self, tokio::task::JoinHandle<eyre::Result<()>>)> {
+    ) -> eyre::Result<(Self, WatcherBackgroundTasks)> {
         ::metrics::gauge!(METRICS_ID_NODE_MERKLE_WATCHER_CACHE_SIZE).set(0.0);
 
         eyre::ensure!(
@@ -184,27 +187,19 @@ impl MerkleWatcher {
         started.store(true, Ordering::Relaxed);
 
         tracing::info!("listening for events...");
-        let subscribe_task = tokio::spawn(subscribe_task(
+        let subscribe = tokio::spawn(subscribe_task(
             subscription,
             Arc::clone(&latest_root),
             merkle_root_cache.clone(),
             root_validity_window,
-            cancellation_token,
+            cancellation_token.clone(),
         ));
 
-        // periodically run maintenance tasks on the cache and update metrics
-        tokio::spawn({
-            let merkle_root_cache = merkle_root_cache.clone();
-            let mut interval = tokio::time::interval(cache_maintenance_interval);
-            async move {
-                loop {
-                    interval.tick().await;
-                    merkle_root_cache.run_pending_tasks().await;
-                    let size = merkle_root_cache.entry_count() as f64;
-                    ::metrics::gauge!(METRICS_ID_NODE_MERKLE_WATCHER_CACHE_SIZE).set(size);
-                }
-            }
-        });
+        let maintenance = tokio::spawn(maintenance_task(
+            merkle_root_cache.clone(),
+            cache_maintenance_interval,
+            cancellation_token,
+        ));
 
         let merkle_watcher = Self {
             latest_root,
@@ -212,7 +207,13 @@ impl MerkleWatcher {
             contract,
         };
 
-        Ok((merkle_watcher, subscribe_task))
+        Ok((
+            merkle_watcher,
+            WatcherBackgroundTasks {
+                subscribe,
+                maintenance,
+            },
+        ))
     }
 
     #[instrument(level = "debug", skip_all, fields(root=%root))]
@@ -330,6 +331,32 @@ async fn subscribe_task(
         }
     }
     tracing::info!("Successfully shutdown MerkleWatcher");
+    eyre::Ok(())
+}
+
+/// Periodically runs cache maintenance tasks and updates the cache size metric
+/// until cancellation is requested.
+async fn maintenance_task(
+    merkle_root_cache: Cache<FieldElement, Duration>,
+    cache_maintenance_interval: Duration,
+    cancellation_token: CancellationToken,
+) -> eyre::Result<()> {
+    // shutdown service if the maintenance task panics or exits unexpectedly
+    let _drop_guard = cancellation_token.clone().drop_guard();
+    let mut interval = tokio::time::interval(cache_maintenance_interval);
+    loop {
+        tokio::select! {
+            _ = interval.tick() => {
+                merkle_root_cache.run_pending_tasks().await;
+                let size = merkle_root_cache.entry_count() as f64;
+                ::metrics::gauge!(METRICS_ID_NODE_MERKLE_WATCHER_CACHE_SIZE).set(size);
+            }
+            () = cancellation_token.cancelled() => {
+                break;
+            }
+        }
+    }
+    tracing::info!("Successfully shutdown MerkleWatcher cache maintenance task");
     eyre::Ok(())
 }
 

--- a/services/oprf-node/src/auth/nonce_history.rs
+++ b/services/oprf-node/src/auth/nonce_history.rs
@@ -8,8 +8,9 @@
 
 use std::time::Duration;
 
-use crate::metrics::METRICS_ID_NODE_NONCE_HISTORY_SIZE;
+use crate::{auth::BackgroundTask, metrics::METRICS_ID_NODE_NONCE_HISTORY_SIZE};
 use moka::future::Cache;
+use tokio_util::sync::CancellationToken;
 use world_id_primitives::FieldElement;
 
 #[derive(Debug, thiserror::Error)]
@@ -28,31 +29,31 @@ pub(crate) struct NonceHistory {
 impl NonceHistory {
     /// Initializes a new nonce history with automatic expiration.
     ///
-    /// Nonces are automatically evicted after `max_nonce_age`.
+    /// Nonces are automatically evicted after `max_nonce_age`. Spawns a
+    /// background cache maintenance task that respects the supplied
+    /// cancellation token; the returned [`tokio::task::JoinHandle`] should
+    /// be awaited during graceful shutdown.
     ///
     /// # Arguments
     /// * `max_nonce_age` - Maximum age for nonces before they expire
     /// * `cache_maintenance_interval` - Interval for running cache maintenance tasks
-    pub(crate) fn init(max_nonce_age: Duration, cache_maintenance_interval: Duration) -> Self {
+    /// * `cancellation_token` - Token used to signal the maintenance task to shut down
+    pub(crate) fn init(
+        max_nonce_age: Duration,
+        cache_maintenance_interval: Duration,
+        cancellation_token: CancellationToken,
+    ) -> (Self, BackgroundTask) {
         ::metrics::gauge!(METRICS_ID_NODE_NONCE_HISTORY_SIZE).set(0.0);
 
         let nonces = Cache::builder().time_to_live(max_nonce_age).build();
 
-        // periodically run maintenance tasks on the cache and update metrics
-        tokio::spawn({
-            let nonces = nonces.clone();
-            let mut interval = tokio::time::interval(cache_maintenance_interval);
-            async move {
-                loop {
-                    interval.tick().await;
-                    nonces.run_pending_tasks().await;
-                    let size = nonces.entry_count() as f64;
-                    ::metrics::gauge!(METRICS_ID_NODE_NONCE_HISTORY_SIZE).set(size);
-                }
-            }
-        });
+        let maintenance_task = tokio::spawn(maintenance_task(
+            nonces.clone(),
+            cache_maintenance_interval,
+            cancellation_token,
+        ));
 
-        NonceHistory { nonces }
+        (NonceHistory { nonces }, maintenance_task)
     }
 
     /// Adds a nonce to the history.
@@ -74,6 +75,32 @@ impl NonceHistory {
     }
 }
 
+/// Periodically runs cache maintenance tasks and updates the nonce history
+/// size metric until cancellation is requested.
+async fn maintenance_task(
+    nonces: Cache<FieldElement, ()>,
+    cache_maintenance_interval: Duration,
+    cancellation_token: CancellationToken,
+) -> eyre::Result<()> {
+    // shutdown service if the maintenance task panics or exits unexpectedly
+    let _drop_guard = cancellation_token.clone().drop_guard();
+    let mut interval = tokio::time::interval(cache_maintenance_interval);
+    loop {
+        tokio::select! {
+            _ = interval.tick() => {
+                nonces.run_pending_tasks().await;
+                let size = nonces.entry_count() as f64;
+                ::metrics::gauge!(METRICS_ID_NODE_NONCE_HISTORY_SIZE).set(size);
+            }
+            () = cancellation_token.cancelled() => {
+                break;
+            }
+        }
+    }
+    tracing::info!("Successfully shutdown NonceHistory cache maintenance task");
+    eyre::Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -83,7 +110,12 @@ mod tests {
         let mut rng = rand::thread_rng();
         let max_nonce_age = Duration::from_secs(60);
         let cache_maintenance_interval = Duration::from_secs(60);
-        let nonce_history = NonceHistory::init(max_nonce_age, cache_maintenance_interval);
+        let cancellation_token = CancellationToken::new();
+        let (nonce_history, _maintenance_task) = NonceHistory::init(
+            max_nonce_age,
+            cache_maintenance_interval,
+            cancellation_token,
+        );
 
         let foo = FieldElement::random(&mut rng);
         let bar = FieldElement::random(&mut rng);
@@ -120,7 +152,12 @@ mod tests {
     async fn test_nonce_history_is_clone() {
         let max_nonce_age = Duration::from_secs(60);
         let cache_maintenance_interval = Duration::from_secs(60);
-        let history1 = NonceHistory::init(max_nonce_age, cache_maintenance_interval);
+        let cancellation_token = CancellationToken::new();
+        let (history1, _maintenance_task) = NonceHistory::init(
+            max_nonce_age,
+            cache_maintenance_interval,
+            cancellation_token,
+        );
         let history2 = history1.clone();
 
         let shared = FieldElement::random(&mut rand::thread_rng());
@@ -140,7 +177,12 @@ mod tests {
         let nonce = FieldElement::random(&mut rand::thread_rng());
         let max_nonce_age = Duration::from_secs(1);
         let cache_maintenance_interval = Duration::from_millis(100);
-        let nonce_history = NonceHistory::init(max_nonce_age, cache_maintenance_interval);
+        let cancellation_token = CancellationToken::new();
+        let (nonce_history, _maintenance_task) = NonceHistory::init(
+            max_nonce_age,
+            cache_maintenance_interval,
+            cancellation_token,
+        );
 
         // Add nonce — should succeed
         nonce_history.add_nonce(nonce).await.expect("can add nonce");

--- a/services/oprf-node/src/auth/rp_registry_watcher.rs
+++ b/services/oprf-node/src/auth/rp_registry_watcher.rs
@@ -8,6 +8,7 @@ use std::{
 
 use crate::{
     auth::{
+        WatcherBackgroundTasks,
         rp_module::{RelyingParty, wip101},
         rp_registry_watcher::RpRegistry::{RpRegistryInstance, RpUpdated},
     },
@@ -100,7 +101,7 @@ impl RpRegistryWatcher {
     #[instrument(level = "info", skip_all)]
     pub(crate) async fn init(
         args: RpRegistryWatcherArgs<'_>,
-    ) -> eyre::Result<(Self, tokio::task::JoinHandle<eyre::Result<()>>)> {
+    ) -> eyre::Result<(Self, WatcherBackgroundTasks)> {
         let RpRegistryWatcherArgs {
             contract_address,
             http_rpc_provider,
@@ -145,20 +146,17 @@ impl RpRegistryWatcher {
             })
             .build();
         tracing::info!("starting subscribe task");
-        let subscribe_task =
-            tokio::task::spawn(subscribe_task(stream, rp_store.clone(), cancellation_token));
+        let subscribe = tokio::task::spawn(subscribe_task(
+            stream,
+            rp_store.clone(),
+            cancellation_token.clone(),
+        ));
 
-        // periodically run maintenance tasks on the cache and update metrics
-        tokio::spawn({
-            let rp_store = rp_store.clone();
-            let mut interval = tokio::time::interval(maintenance_interval);
-            async move {
-                loop {
-                    interval.tick().await;
-                    rp_store.run_pending_tasks().await;
-                }
-            }
-        });
+        let maintenance = tokio::spawn(maintenance_task(
+            rp_store.clone(),
+            maintenance_interval,
+            cancellation_token,
+        ));
 
         let rp_registry = Self {
             rp_store,
@@ -167,7 +165,13 @@ impl RpRegistryWatcher {
             http_rpc_provider,
         };
 
-        Ok((rp_registry, subscribe_task))
+        Ok((
+            rp_registry,
+            WatcherBackgroundTasks {
+                subscribe,
+                maintenance,
+            },
+        ))
     }
 
     #[instrument(level = "debug", skip_all, fields(rp_id=%rp_id))]
@@ -285,5 +289,28 @@ async fn subscribe_task(
         }
     }
     tracing::info!("Successfully shutdown RpRegistry");
+    eyre::Ok(())
+}
+
+/// Periodically runs cache maintenance tasks until cancellation is requested.
+async fn maintenance_task(
+    rp_store: Cache<RpId, RelyingParty>,
+    maintenance_interval: Duration,
+    cancellation_token: CancellationToken,
+) -> eyre::Result<()> {
+    // shutdown service if the maintenance task panics or exits unexpectedly
+    let _drop_guard = cancellation_token.clone().drop_guard();
+    let mut interval = tokio::time::interval(maintenance_interval);
+    loop {
+        tokio::select! {
+            _ = interval.tick() => {
+                rp_store.run_pending_tasks().await;
+            }
+            () = cancellation_token.cancelled() => {
+                break;
+            }
+        }
+    }
+    tracing::info!("Successfully shutdown RpRegistry cache maintenance task");
     eyre::Ok(())
 }

--- a/services/oprf-node/src/auth/schema_issuer_registry_watcher.rs
+++ b/services/oprf-node/src/auth/schema_issuer_registry_watcher.rs
@@ -7,8 +7,11 @@ use std::{
 };
 
 use crate::{
-    auth::schema_issuer_registry_watcher::CredentialSchemaIssuerRegistry::{
-        CredentialSchemaIssuerRegistryInstance, IssuerSchemaRemoved,
+    auth::{
+        WatcherBackgroundTasks,
+        schema_issuer_registry_watcher::CredentialSchemaIssuerRegistry::{
+            CredentialSchemaIssuerRegistryInstance, IssuerSchemaRemoved,
+        },
     },
     config::WatcherCacheConfig,
     metrics::{
@@ -20,7 +23,8 @@ use alloy::{
     eips::BlockNumberOrTag,
     primitives::Address,
     providers::{DynProvider, Provider as _},
-    rpc::types::Filter,
+    pubsub::SubscriptionStream,
+    rpc::types::{Filter, Log},
     sol_types::SolEvent,
 };
 use eyre::Context;
@@ -69,14 +73,14 @@ impl SchemaIssuerRegistryWatcher {
         maintenance_interval: Duration,
         started: Arc<AtomicBool>,
         cancellation_token: CancellationToken,
-    ) -> eyre::Result<(Self, tokio::task::JoinHandle<eyre::Result<()>>)> {
+    ) -> eyre::Result<(Self, WatcherBackgroundTasks)> {
         tracing::info!("listening for events...");
         let filter = Filter::new()
             .address(contract_address)
             .from_block(BlockNumberOrTag::Latest)
             .event_signature(IssuerSchemaRemoved::SIGNATURE_HASH);
         let sub = ws_rpc_provider.subscribe_logs(&filter).await?;
-        let mut stream = sub.into_stream();
+        let stream = sub.into_stream();
 
         ::metrics::gauge!(METRICS_ID_NODE_SCHEMA_ISSUER_REGISTRY_WATCHER_CACHE_SIZE).set(0.0);
 
@@ -94,59 +98,18 @@ impl SchemaIssuerRegistryWatcher {
             .time_to_live(time_to_live)
             .time_to_idle(time_to_idle)
             .build();
-        let subscribe_task = tokio::task::spawn({
-            let issuer_schema_store = issuer_schema_store.clone();
-            async move {
-                // shutdown service if issuer registry watcher encounters an error and drops this guard
-                let _drop_guard = cancellation_token.clone().drop_guard();
+        let subscribe = tokio::task::spawn(subscribe_task(
+            stream,
+            issuer_schema_store.clone(),
+            cancellation_token.clone(),
+        ));
 
-                loop {
-                    let log = tokio::select! {
-                        log = stream.next() => {
-                            log.ok_or_else(||{
-                                tracing::warn!("SchemaIssuerRegistryWatcher subscribe stream was closed");
-                                eyre::eyre!("SchemaIssuerRegistryWatcher subscribe stream was closed")
-                            })?
-                        }
-                        () = cancellation_token.cancelled() => {
-                            break;
-                        }
-                    };
+        let maintenance = tokio::spawn(maintenance_task(
+            issuer_schema_store.clone(),
+            maintenance_interval,
+            cancellation_token,
+        ));
 
-                    match IssuerSchemaRemoved::decode_log(log.as_ref()) {
-                        Ok(event) => {
-                            let issuer_schema_id = event.issuerSchemaId;
-                            tracing::info!(
-                                "got issuer-schema-removed event for issuer_schema_id: {issuer_schema_id}"
-                            );
-                            issuer_schema_store.invalidate(&issuer_schema_id).await;
-                        }
-                        Err(err) => {
-                            tracing::warn!(
-                                "failed to decode IssuerSchemaRemoved contract event: {err:?}"
-                            );
-                        }
-                    }
-                }
-                tracing::info!("Successfully shutdown SchemaIssuerRegistryWatcher");
-                eyre::Ok(())
-            }
-        });
-
-        // periodically run maintenance tasks on the cache and update metrics
-        tokio::spawn({
-            let issuer_schema_store = issuer_schema_store.clone();
-            let mut interval = tokio::time::interval(maintenance_interval);
-            async move {
-                loop {
-                    interval.tick().await;
-                    issuer_schema_store.run_pending_tasks().await;
-                    let size = issuer_schema_store.entry_count() as f64;
-                    ::metrics::gauge!(METRICS_ID_NODE_SCHEMA_ISSUER_REGISTRY_WATCHER_CACHE_SIZE)
-                        .set(size);
-                }
-            }
-        });
         let schema_issuer_registry = Self {
             issuer_schema_store,
             contract: CredentialSchemaIssuerRegistryInstance::new(
@@ -154,7 +117,13 @@ impl SchemaIssuerRegistryWatcher {
                 http_rpc_provider.inner(),
             ),
         };
-        Ok((schema_issuer_registry, subscribe_task))
+        Ok((
+            schema_issuer_registry,
+            WatcherBackgroundTasks {
+                subscribe,
+                maintenance,
+            },
+        ))
     }
 
     #[instrument(level = "debug", skip_all, fields(issuer_schema_id=issuer_schema_id))]
@@ -190,4 +159,69 @@ impl SchemaIssuerRegistryWatcher {
             SchemaIssuerRegistryWatcherError::Internal(report) => SchemaIssuerRegistryWatcherError::Internal(eyre::eyre!("{report:?}")),
         })
     }
+}
+
+async fn subscribe_task(
+    mut stream: SubscriptionStream<Log>,
+    issuer_schema_store: Cache<u64, ()>,
+    cancellation_token: CancellationToken,
+) -> eyre::Result<()> {
+    // shutdown service if issuer registry watcher encounters an error and drops this guard
+    let _drop_guard = cancellation_token.clone().drop_guard();
+
+    loop {
+        let log = tokio::select! {
+            log = stream.next() => {
+                log.ok_or_else(||{
+                    tracing::warn!("SchemaIssuerRegistryWatcher subscribe stream was closed");
+                    eyre::eyre!("SchemaIssuerRegistryWatcher subscribe stream was closed")
+                })?
+            }
+            () = cancellation_token.cancelled() => {
+                break;
+            }
+        };
+
+        match IssuerSchemaRemoved::decode_log(log.as_ref()) {
+            Ok(event) => {
+                let issuer_schema_id = event.issuerSchemaId;
+                tracing::info!(
+                    "got issuer-schema-removed event for issuer_schema_id: {issuer_schema_id}"
+                );
+                issuer_schema_store.invalidate(&issuer_schema_id).await;
+            }
+            Err(err) => {
+                tracing::warn!("failed to decode IssuerSchemaRemoved contract event: {err:?}");
+            }
+        }
+    }
+    tracing::info!("Successfully shutdown SchemaIssuerRegistryWatcher");
+    eyre::Ok(())
+}
+
+/// Periodically runs cache maintenance tasks and updates the cache size metric
+/// until cancellation is requested.
+async fn maintenance_task(
+    issuer_schema_store: Cache<u64, ()>,
+    maintenance_interval: Duration,
+    cancellation_token: CancellationToken,
+) -> eyre::Result<()> {
+    // shutdown service if the maintenance task panics or exits unexpectedly
+    let _drop_guard = cancellation_token.clone().drop_guard();
+    let mut interval = tokio::time::interval(maintenance_interval);
+    loop {
+        tokio::select! {
+            _ = interval.tick() => {
+                issuer_schema_store.run_pending_tasks().await;
+                let size = issuer_schema_store.entry_count() as f64;
+                ::metrics::gauge!(METRICS_ID_NODE_SCHEMA_ISSUER_REGISTRY_WATCHER_CACHE_SIZE)
+                    .set(size);
+            }
+            () = cancellation_token.cancelled() => {
+                break;
+            }
+        }
+    }
+    tracing::info!("Successfully shutdown SchemaIssuerRegistryWatcher cache maintenance task");
+    eyre::Ok(())
 }

--- a/services/oprf-node/src/lib.rs
+++ b/services/oprf-node/src/lib.rs
@@ -40,6 +40,7 @@ use world_id_primitives::oprf::OprfModule;
 
 use crate::{
     auth::{
+        BackgroundTask,
         credential_blinding_factor::CredentialBlindingFactorModuleAuth,
         merkle_watcher::MerkleWatcher,
         nonce_history::NonceHistory,
@@ -60,10 +61,14 @@ pub mod metrics;
 /// The tasks spawned by the oprf-node. Should call [`WorldOprfNodeTasks::join`] when shutting down for graceful shutdown.
 #[allow(clippy::struct_field_names, reason = "Has the watcher suffix in name")]
 pub struct WorldOprfNodeTasks {
-    key_event_watcher: tokio::task::JoinHandle<eyre::Result<()>>,
-    merkle_watcher: tokio::task::JoinHandle<eyre::Result<()>>,
-    rp_registry_watcher: tokio::task::JoinHandle<eyre::Result<()>>,
-    schema_issuer_registry_watcher: tokio::task::JoinHandle<eyre::Result<()>>,
+    key_event_watcher: BackgroundTask,
+    merkle_watcher: BackgroundTask,
+    rp_registry_watcher: BackgroundTask,
+    schema_issuer_registry_watcher: BackgroundTask,
+    // Cache maintenance tasks for the watcher caches and the nonce histories.
+    // Tracked so panics or unexpected exits are surfaced during graceful shutdown
+    // instead of being silently dropped.
+    cache_maintenance_tasks: Vec<BackgroundTask>,
     // We also store the web-socket RPC provider here.
     //
     // We want it to live at least as long as the sub-tasks need to complete their graceful shutdown.
@@ -87,16 +92,21 @@ impl WorldOprfNodeTasks {
             merkle_watcher,
             rp_registry_watcher,
             schema_issuer_registry_watcher,
+            cache_maintenance_results,
         ) = tokio::join!(
             self.key_event_watcher,
             self.merkle_watcher,
             self.rp_registry_watcher,
-            self.schema_issuer_registry_watcher
+            self.schema_issuer_registry_watcher,
+            futures::future::join_all(self.cache_maintenance_tasks),
         );
         key_event_watcher??;
         merkle_watcher??;
         rp_registry_watcher??;
         schema_issuer_registry_watcher??;
+        for result in cache_maintenance_results {
+            result??;
+        }
         Ok(())
     }
 }
@@ -162,8 +172,10 @@ pub async fn start(
         .context("while connecting ws provider")?
         .erased();
 
+    let mut cache_maintenance_tasks = Vec::new();
+
     tracing::info!("init merkle watcher..");
-    let (merkle_watcher, merkle_watcher_task) = MerkleWatcher::init(
+    let (merkle_watcher, merkle_watcher_tasks) = MerkleWatcher::init(
         config.world_id_registry_contract,
         &http_rpc_provider,
         &ws_rpc_provider,
@@ -174,9 +186,10 @@ pub async fn start(
     )
     .await
     .context("while starting merkle watcher")?;
+    cache_maintenance_tasks.push(merkle_watcher_tasks.maintenance);
 
     tracing::info!("init RpRegistry watcher..");
-    let (rp_registry_watcher, rp_registry_watcher_task) =
+    let (rp_registry_watcher, rp_registry_watcher_tasks) =
         RpRegistryWatcher::init(RpRegistryWatcherArgs {
             contract_address: config.rp_registry_contract,
             http_rpc_provider: http_rpc_provider.clone(),
@@ -189,20 +202,24 @@ pub async fn start(
         })
         .await
         .context("while starting rp registry watcher")?;
+    cache_maintenance_tasks.push(rp_registry_watcher_tasks.maintenance);
 
     let query_vk = serde_json::from_str::<VerificationKey<Bn254>>(QUERY_VERIFICATION_KEY)
         .expect("can deserialize embedded vk");
     let query_vk = Arc::new(ark_groth16::prepare_verifying_key(&query_vk.into()));
 
     tracing::info!("init nullifier oprf request auth service..");
+    let (nullifier_nonce_history, nullifier_nonce_history_maintenance_task) = NonceHistory::init(
+        // keep cache for 2x so that we catch all replays that would be valid and some that would be invalid anyways
+        config.current_time_stamp_max_difference * 2,
+        config.cache_maintenance_interval,
+        cancellation_token.clone(),
+    );
+    cache_maintenance_tasks.push(nullifier_nonce_history_maintenance_task);
     let nullifier_oprf_req_auth_service = Arc::new(RpModuleAuth::new_uniqueness(
         merkle_watcher.clone(),
         rp_registry_watcher.clone(),
-        NonceHistory::init(
-            // keep cache for 2x so that we catch all replays that would be valid and some that would be invalid anyways
-            config.current_time_stamp_max_difference * 2,
-            config.cache_maintenance_interval,
-        ),
+        nullifier_nonce_history,
         config.current_time_stamp_max_difference,
         config.timeout_external_eth_call,
         http_rpc_provider.clone(),
@@ -212,14 +229,17 @@ pub async fn start(
     tracing::info!("init session oprf request auth service..");
     // Session and uniqueness use separate nonce histories intentionally.
     // We use the same nonce for both signatures
+    let (session_nonce_history, session_nonce_history_maintenance_task) = NonceHistory::init(
+        // keep cache for 2x so that we catch all replays that would be valid and some that would be invalid anyways
+        config.current_time_stamp_max_difference * 2,
+        config.cache_maintenance_interval,
+        cancellation_token.clone(),
+    );
+    cache_maintenance_tasks.push(session_nonce_history_maintenance_task);
     let session_oprf_req_auth_service = Arc::new(RpModuleAuth::new_session(
         merkle_watcher.clone(),
         rp_registry_watcher.clone(),
-        NonceHistory::init(
-            // keep cache for 2x so that we catch all replays that would be valid and some that would be invalid anyways
-            config.current_time_stamp_max_difference * 2,
-            config.cache_maintenance_interval,
-        ),
+        session_nonce_history,
         config.current_time_stamp_max_difference,
         config.timeout_external_eth_call,
         http_rpc_provider.clone(),
@@ -227,7 +247,7 @@ pub async fn start(
     ));
 
     tracing::info!("init CredentialSchemaIssuerRegistry watcher..");
-    let (schema_issuer_registry_watcher, schema_issuer_registry_watcher_task) =
+    let (schema_issuer_registry_watcher, schema_issuer_registry_watcher_tasks) =
         SchemaIssuerRegistryWatcher::init(
             config.credential_schema_issuer_registry_contract,
             &http_rpc_provider,
@@ -239,6 +259,7 @@ pub async fn start(
         )
         .await
         .context("while starting schema issuer registry watcher")?;
+    cache_maintenance_tasks.push(schema_issuer_registry_watcher_tasks.maintenance);
 
     tracing::info!("init credential blinding factor oprf request auth service..");
     let credential_blinding_factor_oprf_req_auth_service =
@@ -272,9 +293,10 @@ pub async fn start(
     .build();
     let tasks = WorldOprfNodeTasks {
         key_event_watcher,
-        merkle_watcher: merkle_watcher_task,
-        rp_registry_watcher: rp_registry_watcher_task,
-        schema_issuer_registry_watcher: schema_issuer_registry_watcher_task,
+        merkle_watcher: merkle_watcher_tasks.subscribe,
+        rp_registry_watcher: rp_registry_watcher_tasks.subscribe,
+        schema_issuer_registry_watcher: schema_issuer_registry_watcher_tasks.subscribe,
+        cache_maintenance_tasks,
         _ws_rpc_provider: ws_rpc_provider,
     };
 


### PR DESCRIPTION
### Problem

Each watcher (`MerkleWatcher`, `RpRegistryWatcher`, `SchemaIssuerRegistryWatcher`) and `NonceHistory` in the OPRF node spawn a background cache maintenance task that runs `run_pending_tasks` and updates metrics on a fixed interval. Unlike the corresponding subscribe tasks, these maintenance tasks:

- did not check the shared `CancellationToken`, so they kept running until the tokio runtime was dropped at process exit.
- had their `JoinHandles` dropped immediately after spawning, so panics or unexpected exits were silently swallowed instead of surfacing during graceful shutdown.
- in the case of `NonceHistory::init`, did not even receive a `CancellationToken`, so there was no way to wire one in.
This meant the service's shutdown path `WorldOprfNodeTasks::join` only observed the subscribe tasks, leaving the maintenance tasks untracked and unobservable.

### Solution

Introduced a small `BackgroundTask` alias and a `WatcherBackgroundTasks { subscribe, maintenance }` struct to keep watcher init signatures readable. Extracted each maintenance loop into a top-level `maintenance_task` function that:

- installs a `cancellation_token.drop_guard()` so a panic triggers global shutdown, mirroring the subscribe tasks.
- uses `tokio::select!` between `interval.tick()` and `cancellation_token.cancelled()` to exit cleanly on shutdown.
- added a `cache_maintenance_tasks: Vec<BackgroundTask>` field to `WorldOprfNodeTasks`, collected every maintenance handle in `start`, and joined them via `futures::future::join_all` in `WorldOprfNodeTasks::join` so panics and errors are now propagated rather than silently lost.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how long-running watcher/nonce cache maintenance tasks are spawned, cancelled, and awaited; mistakes here could cause hangs or missed shutdown/error propagation. No changes to auth/verification logic or on-chain semantics.
> 
> **Overview**
> Improves graceful shutdown observability by **tracking and cancelling cache maintenance loops** for `MerkleWatcher`, `RpRegistryWatcher`, `SchemaIssuerRegistryWatcher`, and `NonceHistory`.
> 
> Watcher `init` methods now return `WatcherBackgroundTasks { subscribe, maintenance }`, maintenance loops are extracted into cancellable tasks (using `tokio::select!` on `CancellationToken`) and guarded so panics/unexpected exits trigger shutdown. `WorldOprfNodeTasks` collects all maintenance `JoinHandle`s and joins them in `WorldOprfNodeTasks::join`, ensuring errors/panics surface instead of being silently dropped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09dec8d55d0c738f0fcb0afe254be1636898623d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->