### PR TITLE
chore: fix check_query_input_validity errors

### DIFF
--- a/crates/proof/src/proof/errors.rs
+++ b/crates/proof/src/proof/errors.rs
@@ -176,8 +176,8 @@ pub fn check_query_input_validity<const TREE_DEPTH: usize>(
     let _rp_id_u64 = u64::try_from(FieldElement::from(inputs.rp_id)).map_err(|_| {
         ProofInputError::ValueOutOfBounds {
             name: "RP Id",
-            is: inputs.pk_index,
-            limit: BaseField::new((MAX_AUTHENTICATOR_KEYS as u64).into()),
+            is: inputs.rp_id,
+            limit: BaseField::new(u64::MAX.into()),
         }
     })?;
     let query = world_id_primitives::authenticator::oprf_query_digest(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: only adjusts which value/limit are reported when `rp_id` fails `u64` conversion, without changing proof verification logic.
> 
> **Overview**
> Fixes `check_query_input_validity` error construction for out-of-bounds `rp_id` values: the `ValueOutOfBounds` now reports `is: inputs.rp_id` and uses `u64::MAX` as the limit instead of incorrectly referencing `pk_index`/`MAX_AUTHENTICATOR_KEYS`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d723259347813d6e4d82d8c6669c7f5adbc8b5b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->