### PR TITLE
chore: Add Workflow dispatch to Rust CI

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
for easier debugging on flaky breaking CI 