### PR TITLE
fix: Check Block Number before querying getLogs in `async fn find_last_valid_root`

### DIFF
--- a/services/indexer/src/rollback_executor.rs
+++ b/services/indexer/src/rollback_executor.rs
@@ -52,6 +52,10 @@ async fn find_last_valid_root(
     registry_address: Address,
 ) -> IndexerResult<Option<WorldIdRegistryEventId>> {
     const BATCH_SIZE: u64 = 100;
+    let chain_head = provider
+        .get_block_number()
+        .await
+        .map_err(|e| IndexerError::ContractCall(e.to_string()))?;
 
     // Sentinel: starts "after everything" so the first batch includes the latest events.
     // Use i64::MAX (not u64::MAX) because block numbers are stored as i64 in PostgreSQL;
@@ -72,6 +76,17 @@ async fn find_last_valid_root(
         }
 
         for event in &batch {
+            if event.block_number > chain_head {
+                tracing::info!(
+                    block_number = event.block_number,
+                    chain_head,
+                    log_index = event.log_index,
+                    root = %format!("0x{:x}", event.details.root),
+                    "RootRecorded log is above the current chain head, skipping"
+                );
+                continue;
+            }
+
             let filter = Filter::new()
                 .address(registry_address)
                 .event_signature(WorldIdRegistry::RootRecorded::SIGNATURE_HASH)


### PR DESCRIPTION
Since newest Anvil Release, it mirrors accurate Geth and other clients behavior 
https://github.com/foundry-rs/foundry/pull/14371

In our indexer when finding last valid root we just assumed a getLogs call would return empty result and act accordingly, but now Anvil mirrors real world behavior of clients and we error if the block doesn't exist.

Fix: check the block number of the event in the table first and omit the getLogs if the block does not exist anymore (either due to reorg or maliciously input event on the DB)
the downside of having one additional RPC call per entry is negligible here.