### PR TITLE
fix: don't pass latest root for proof verification

### DIFF
--- a/contracts/src/crosschain/WorldIDSatellite.sol
+++ b/contracts/src/crosschain/WorldIDSatellite.sol
@@ -135,7 +135,7 @@ contract WorldIDSatellite is IWorldID, ERC7786Recipient, StateBridge {
             issuerPubKeyInfo.pubKey.y,
             uint256(expiresAtMin),
             credentialGenesisIssuedAtMin,
-            LATEST_ROOT(),
+            root,
             TREE_DEPTH,
             uint256(rpId),
             action,


### PR DESCRIPTION
Found in SEC-3604389

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches core proof verification inputs in `WorldIDSatellite`, which is security-critical; an incorrect root value could cause valid proofs to fail or, depending on circuit expectations, weaken verification guarantees.
> 
> **Overview**
> Updates `WorldIDSatellite.verifyProofAndSignals` to pass the Merkle `root` embedded in the submitted proof (`proofExt[4]`) into `VERIFIER.verifyCompressedProof` instead of always using `LATEST_ROOT()`, aligning verification with the caller-provided (and `isValidRoot`-checked) root.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7285f8588e7c0a94bc52db1184a86c016088b000. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->