### PR TITLE
fix: poseidon-solidity

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,7 +9,7 @@
 	url = https://github.com/OpenZeppelin/openzeppelin-contracts-upgradeable
 [submodule "contracts/lib/poseidon-solidity"]
 	path = contracts/lib/poseidon-solidity
-	url = https://github.com/chancehudson/poseidon-solidity
+	url = https://github.com/0xOsiris/poseidon-solidity
 [submodule "contracts/lib/oprf-key-registry"]
 	path = contracts/lib/oprf-key-registry
 	url = https://github.com/TaceoLabs/oprf-key-registry


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk config-only change that updates the `poseidon-solidity` git submodule URL; main risk is supply-chain/compatibility if the fork differs from the prior upstream.
> 
> **Overview**
> Updates the `contracts/lib/poseidon-solidity` git submodule to point to `https://github.com/0xOsiris/poseidon-solidity` instead of the previous `chancehudson` repository, effectively switching the dependency source/fork used when initializing/updating submodules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6280db6f4c224d14efd0ea5141942490ba6afd3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->