### PR TITLE
fix: use correct field in error msg

### DIFF
--- a/crates/proof/src/proof/errors.rs
+++ b/crates/proof/src/proof/errors.rs
@@ -229,7 +229,7 @@ pub fn check_nullifier_input_validity<const TREE_DEPTH: usize>(
     let credential_expires_at_u64 = u64::try_from(FieldElement::from(inputs.cred_expires_at))
         .map_err(|_| ProofInputError::ValueOutOfBounds {
             name: "credential expiry timestamp",
-            is: inputs.current_timestamp,
+            is: inputs.cred_expires_at,
             limit: BaseField::new(u64::MAX.into()),
         })?;
     // Check that the credential has not expired.


### PR DESCRIPTION
This PR fixes a small error found by the Nethermind audit

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only the reported `is` field in a `ValueOutOfBounds` error when parsing `cred_expires_at`, with no effect on proof validation logic.
> 
> **Overview**
> Fixes an incorrect error payload in `check_nullifier_input_validity` where the `ValueOutOfBounds` for the "credential expiry timestamp" incorrectly reported `current_timestamp` as the offending value.
> 
> The error now correctly reports `inputs.cred_expires_at`, improving debugging and auditability without changing validation behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8abc456656c33d849cf5b19914bf1e0eba97048. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->