### PR TITLE
feat: add proof inputs validation

### DIFF
--- a/crates/proof/src/oprf_query.rs
+++ b/crates/proof/src/oprf_query.rs
@@ -174,6 +174,14 @@ impl<'a> OprfEntrypoint<'a> {
         };
 
         // quick validation before performing the compute heavy `generate_query_proof` fn
+        if proof_request.created_at > proof_request.expires_at {
+            return Err(ProofError::ProofInputError(
+                errors::ProofInputError::InvalidExpiresAt {
+                    created_at: proof_request.created_at,
+                    expires_at: proof_request.expires_at,
+                },
+            ));
+        }
         let now = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .expect("time cannot go backward")
@@ -182,14 +190,6 @@ impl<'a> OprfEntrypoint<'a> {
             return Err(ProofError::ProofInputError(
                 errors::ProofInputError::CredentialExpired {
                     current_timestamp: now,
-                    expires_at: proof_request.expires_at,
-                },
-            ));
-        }
-        if proof_request.created_at > proof_request.expires_at {
-            return Err(ProofError::ProofInputError(
-                errors::ProofInputError::InvalidExpiresAt {
-                    created_at: proof_request.created_at,
                     expires_at: proof_request.expires_at,
                 },
             ));

--- a/crates/proof/src/oprf_query.rs
+++ b/crates/proof/src/oprf_query.rs
@@ -1,6 +1,8 @@
 //! Shared helpers for generating query proofs and executing
 //! distributed generic OPRF computations.
 
+use std::time::{self, SystemTime, UNIX_EPOCH};
+
 use ark_bn254::Bn254;
 use ark_ff::PrimeField;
 use ark_groth16::Proof;
@@ -170,6 +172,28 @@ impl<'a> OprfEntrypoint<'a> {
             let action = proof_request.action.unwrap_or(FieldElement::ZERO);
             (action, OprfModule::Nullifier)
         };
+
+        // quick validation before performing the compute heavy `generate_query_proof` fn
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("time cannot go backward")
+            .as_nanos() as u64;
+        if proof_request.is_expired(now) {
+            return Err(ProofError::ProofInputError(
+                errors::ProofInputError::CredentialExpired {
+                    current_timestamp: now,
+                    expires_at: proof_request.expires_at,
+                },
+            ));
+        }
+        if proof_request.created_at > proof_request.expires_at {
+            return Err(ProofError::ProofInputError(
+                errors::ProofInputError::InvalidExpiresAt {
+                    created_at: proof_request.created_at,
+                    expires_at: proof_request.expires_at,
+                },
+            ));
+        }
 
         let result = Self::generate_query_proof(
             self.query_material,

--- a/crates/proof/src/oprf_query.rs
+++ b/crates/proof/src/oprf_query.rs
@@ -188,7 +188,7 @@ impl<'a> OprfEntrypoint<'a> {
             .as_secs();
         if proof_request.is_expired(now) {
             return Err(ProofError::ProofInputError(
-                errors::ProofInputError::CredentialExpired {
+                errors::ProofInputError::ProofRequestExpired {
                     current_timestamp: now,
                     expires_at: proof_request.expires_at,
                 },

--- a/crates/proof/src/oprf_query.rs
+++ b/crates/proof/src/oprf_query.rs
@@ -1,7 +1,7 @@
 //! Shared helpers for generating query proofs and executing
 //! distributed generic OPRF computations.
 
-use std::time::{self, SystemTime, UNIX_EPOCH};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use ark_bn254::Bn254;
 use ark_ff::PrimeField;

--- a/crates/proof/src/oprf_query.rs
+++ b/crates/proof/src/oprf_query.rs
@@ -177,7 +177,7 @@ impl<'a> OprfEntrypoint<'a> {
         let now = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .expect("time cannot go backward")
-            .as_nanos() as u64;
+            .as_secs();
         if proof_request.is_expired(now) {
             return Err(ProofError::ProofInputError(
                 errors::ProofInputError::CredentialExpired {

--- a/crates/proof/src/proof/errors.rs
+++ b/crates/proof/src/proof/errors.rs
@@ -91,6 +91,8 @@ pub enum ProofInputError {
         "The provided session ID commitment is invalid for the given id and session id randomness."
     )]
     InvalidSessionId,
+    #[error("The proof's expires_at {expires_at} happens before the created_at {created_at}.")]
+    InvalidExpiresAt { created_at: u64, expires_at: u64 },
 }
 
 /// This method checks the validity of the input parameters by emulating the operations that are proved in ZK and raising Errors that would result in an invalid proof.

--- a/crates/proof/src/proof/errors.rs
+++ b/crates/proof/src/proof/errors.rs
@@ -91,6 +91,17 @@ pub enum ProofInputError {
         "The provided session ID commitment is invalid for the given id and session id randomness."
     )]
     InvalidSessionId,
+    /// The proof request is expired.
+    #[error(
+        "The provided proof request has expired (expires_at: {expires_at}, check_timestamp: {current_timestamp})."
+    )]
+    ProofRequestExpired {
+        /// Current timestamp.
+        current_timestamp: u64,
+        /// Expiration timestamp.
+        expires_at: u64,
+    },
+    /// The proof's expires_at is greater than the created_at.
     #[error("The proof's expires_at {expires_at} happens before the created_at {created_at}.")]
     InvalidExpiresAt { created_at: u64, expires_at: u64 },
 }


### PR DESCRIPTION
### Problem

Nethermind audit found a best practice issue here: we were not performing any pre-validation on the proof inputs before calling the compute heavy `generate_query_proof` fn. Therefore we were:

- wasting computation when the proof inputs were invalid
- delaying error handling to oprf nodes

### Solution

Add a quick and small pre-validation to proof inputs to ensure that:

- proof request is not expired
- created_at is never bigger than expires_at


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new timestamp-based validation to the nullifier OPRF flow, which can cause previously accepted requests to be rejected if callers rely on clock skew or malformed `created_at`/`expires_at` values.
> 
> **Overview**
> Adds lightweight pre-validation in `OprfEntrypoint::gen_nullifier` to fail fast before the expensive `generate_query_proof` call by rejecting proof requests where `created_at > expires_at` or the request is already expired (using current Unix time).
> 
> Extends `ProofInputError` with `InvalidExpiresAt` and `ProofRequestExpired` variants so these cases surface as explicit `ProofError::ProofInputError` outcomes instead of being handled later by OPRF nodes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17a2229350d926252d38ba956cdb01afae1447df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->