### PR TITLE
fix: latex typo in specs

### DIFF
--- a/docs/world-id-4-specs/README.md
+++ b/docs/world-id-4-specs/README.md
@@ -255,8 +255,8 @@ participant rp as RP
 critical initial/enrollment
 rp ->> a: Initial session request
 a->>a: Generate oprf_seed locally (CSPRNG)
-a->>o: $$r=\texttt{OPRF}(pk_{rpId}, DS_C || \texttt{leafIndex} || \texttt{oprf\_seed})$$
-a->>a: Compute C = H($$DS_C$$ || leafIndex || r)
+a->>o: r=OPRF(rpPublicKey, DS_C || leafIndex || oprf_seed)
+a->>a: Compute C = H(DS_C || leafIndex || r)
 a->>a: sessionId = encode(C, oprf_seed)
 a ->> rp: sessionId
 end
@@ -264,9 +264,9 @@ end
 rp->>a: session proof request (incl. sessionId)
 
 alt [Recover r from sessionId.oprf_seed]
-a->>o: $$r=\texttt{OPRF}(pk_{rpId}, DS_C || \texttt{leafIndex} || \texttt{sessionId.oprf\_seed})$$
+a->>o: r=OPRF(rpPublicKey, DS_C || leafIndex || sessionId.oprf_seed)
 end
-a->>a: C'=H($$DS_C$$ || leafIndex || r) as public output of proof
+a->>a: C'=H(DS_C || leafIndex || r) as public output of proof
 a->>a: check if sessionId == C' (in ZK-circuit)
 a->>rp: proof + sessionNullifier
 rp->>rp: verify proof (checking sessionId == C' in verifier contract)

--- a/docs/world-id-4-specs/README.md
+++ b/docs/world-id-4-specs/README.md
@@ -255,7 +255,7 @@ participant rp as RP
 critical initial/enrollment
 rp ->> a: Initial session request
 a->>a: Generate oprf_seed locally (CSPRNG)
-a->>o: $$r=\texttt{OPRF}(pk_{rpId}, DS_C || \texttt{leafIndex} || \texttt{oprf_seed})$$
+a->>o: $$r=\texttt{OPRF}(pk_{rpId}, DS_C || \texttt{leafIndex} || \texttt{oprf\_seed})$$
 a->>a: Compute C = H($$DS_C$$ || leafIndex || r)
 a->>a: sessionId = encode(C, oprf_seed)
 a ->> rp: sessionId

--- a/docs/world-id-4-specs/README.md
+++ b/docs/world-id-4-specs/README.md
@@ -264,7 +264,7 @@ end
 rp->>a: session proof request (incl. sessionId)
 
 alt [Recover r from sessionId.oprf_seed]
-a->>o: $$r=\texttt{OPRF}(pk_{rpId}, DS_C || \texttt{leafIndex} || \texttt{sessionId.oprf_seed})$$
+a->>o: $$r=\texttt{OPRF}(pk_{rpId}, DS_C || \texttt{leafIndex} || \texttt{sessionId.oprf\_seed})$$
 end
 a->>a: C'=H($$DS_C$$ || leafIndex || r) as public output of proof
 a->>a: check if sessionId == C' (in ZK-circuit)


### PR DESCRIPTION
This was bugging me. 

<img width="832" height="557" alt="image" src="https://github.com/user-attachments/assets/f85d23cd-6746-44cd-ace9-c0c1c316bc7d" />



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change limited to the `Session Proofs` mermaid sequence diagram; no code or protocol logic is modified.
> 
> **Overview**
> Fixes formatting/LaTeX issues in the `Session Proofs` mermaid sequence diagram in `docs/world-id-4-specs/README.md` by replacing broken inline math with plain-text `OPRF(...)`/`H(...)` expressions and consistent parameter naming (`rpPublicKey`, `DS_C`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b80613b7f4bcc867f1f54816f01c665038c4e959. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->