### PR TITLE
feat: introduce issuer version attribute to credential

### DIFF
--- a/crates/primitives/src/credential.rs
+++ b/crates/primitives/src/credential.rs
@@ -1,4 +1,5 @@
 use ark_babyjubjub::EdwardsAffine;
+use ark_ff::BigInt;
 use eddsa_babyjubjub::{EdDSAPrivateKey, EdDSAPublicKey, EdDSASignature};
 use rand::Rng;
 use ruint::aliases::U256;
@@ -111,6 +112,16 @@ pub struct Credential {
     pub id: u64,
     /// The version of the Credential determines its structure.
     pub version: CredentialVersion,
+    /// A reference version field for issuer use. Different versions can determine how
+    /// the issuer-defined fields are constructed for a Credential.
+    ///
+    /// # Usage Examples
+    /// - Different claims values and their meaning could be determined from
+    ///   distinct issuer versions.
+    /// - Different construction of associated data or its commitment can be
+    ///   determined from distinct issuer versions.
+    #[serde(default)]
+    pub issuer_version: u8,
     /// Unique issuer schema id represents the unique combination of the credential's
     /// schema and the issuer.
     ///
@@ -175,6 +186,7 @@ impl Credential {
         Self {
             id: rng.r#gen(),
             version: CredentialVersion::V1,
+            issuer_version: 0,
             issuer_schema_id: 0,
             sub: FieldElement::ZERO,
             genesis_issued_at: 0,
@@ -199,6 +211,13 @@ impl Credential {
     #[must_use]
     pub const fn version(mut self, version: CredentialVersion) -> Self {
         self.version = version;
+        self
+    }
+
+    /// Set the `issuer_version` of the credential.
+    #[must_use]
+    pub const fn issuer_version(mut self, issuer_version: u8) -> Self {
+        self.issuer_version = issuer_version;
         self
     }
 
@@ -329,6 +348,8 @@ impl Credential {
     pub fn hash(&self) -> Result<FieldElement, eyre::Error> {
         match self.version {
             CredentialVersion::V1 => {
+                let id_issuer_version = BigInt([self.id, self.issuer_version as u64, 0, 0]);
+
                 let mut input = [
                     *self.get_cred_ds(),
                     self.issuer_schema_id.into(),
@@ -337,7 +358,7 @@ impl Credential {
                     self.expires_at.into(),
                     *self.claims_hash()?,
                     *self.associated_data_commitment,
-                    self.id.into(),
+                    id_issuer_version.into(),
                 ];
                 poseidon2::bn254::t8::permutation_in_place(&mut input);
                 Ok(input[1].into())
@@ -482,6 +503,21 @@ where
 mod tests {
     use super::*;
 
+    /// Tests the hash is deterministically computed for a default credential, this
+    /// helps detect issues where hashing inadvertently changed.
+    ///
+    /// Particularly relevant to ensure the introduction of other attributes into the last
+    /// item of the permutation does not bring in breaking changes.
+    #[test]
+    fn test_deterministic_credential_hash() {
+        let mut credential = Credential::new();
+        credential.id = 1;
+        assert_eq!(
+            hex::encode(credential.hash().unwrap().to_be_bytes()),
+            "2bc705762cbe8f31e0c3045ca347109ba3630b4b7ea955dc71515f182a079ae9"
+        );
+    }
+
     #[test]
     fn test_associated_data_matches_direct_hash() {
         let data = vec![1u8, 2, 3, 4, 5, 6, 7, 8, 9, 10];
@@ -533,5 +569,34 @@ mod tests {
 
         // Should have a non-zero claim hash
         assert_ne!(credential.claims[1], FieldElement::ZERO);
+    }
+
+    /// Tests that `issuer_version` is bound into the credential hash so that it
+    /// cannot be tampered with after issuance without invalidating the signature.
+    #[test]
+    fn test_issuer_version_is_bound_to_credential_hash() {
+        let mut credential = Credential::new();
+        credential.id = 1;
+        credential.issuer_version = 1;
+
+        let mut tampered = credential.clone();
+        tampered.issuer_version = 2;
+
+        let original_hash = credential.hash().unwrap();
+        let tampered_hash = tampered.hash().unwrap();
+        assert_ne!(original_hash, tampered_hash);
+
+        let signer = EdDSAPrivateKey::random(&mut rand::thread_rng());
+        let signed = credential.sign(&signer).unwrap();
+        let issuer_pubkey = signer.public();
+
+        assert!(signed.verify_signature(&issuer_pubkey).unwrap());
+
+        let mut tampered_signed = signed.clone();
+        tampered_signed.issuer_version = signed.issuer_version.wrapping_add(1);
+        assert!(
+            !tampered_signed.verify_signature(&issuer_pubkey).unwrap(),
+            "tampering with issuer_version must invalidate the signature"
+        );
     }
 }

--- a/crates/proof/src/circuit_inputs.rs
+++ b/crates/proof/src/circuit_inputs.rs
@@ -130,7 +130,10 @@ pub struct NullifierProofCircuitInput<const MAX_DEPTH: usize> {
     pub cred_genesis_issued_at_min: BaseField,
     /// The `cred_user_id_r` blinding factor used to generate the `sub`.
     pub cred_sub_blinding_factor: BaseField,
-    /// The unique identifier of the `Credential`.
+    /// Packed `Credential` `id` and `issuer_version` that occupies the last
+    /// slot of the credential hash permutation. The value is the field element
+    /// representation of `BigInt([id, issuer_version, 0, 0])`, i.e.
+    /// `id + issuer_version`.
     pub cred_id: BaseField,
 
     // SECTION: User Inputs

--- a/crates/proof/src/proof.rs
+++ b/crates/proof/src/proof.rs
@@ -13,6 +13,7 @@
 
 use crate::ProofError;
 use ark_bn254::Bn254;
+use ark_ff::BigInt;
 use rand::{CryptoRng, Rng};
 use std::{io::Read, path::Path};
 use world_id_primitives::{Credential, FieldElement, Nullifier, RequestItem, TREE_DEPTH};
@@ -332,7 +333,7 @@ pub fn generate_nullifier_proof<R: Rng + CryptoRng>(
         cred_genesis_issued_at: credential.genesis_issued_at.into(),
         cred_genesis_issued_at_min: request_item.genesis_issued_at_min.unwrap_or(0).into(),
         cred_expires_at: credential.expires_at.into(),
-        cred_id: credential.id.into(),
+        cred_id: BigInt([credential.id, u64::from(credential.issuer_version), 0, 0]).into(),
         cred_sub_blinding_factor: *credential_sub_blinding_factor,
         cred_s: cred_signature.s,
         cred_r: cred_signature.r,

--- a/crates/proof/src/proof/errors.rs
+++ b/crates/proof/src/proof/errors.rs
@@ -853,4 +853,67 @@ mod tests {
             ));
         }
     }
+
+    /// Verifies that the `cred_id` slot of the credential hash, which packs the
+    /// `Credential::id` and `Credential::issuer_version`, is computed
+    /// consistently between `Credential::hash` and the validation path used by
+    /// `check_nullifier_input_validity`.
+    ///
+    /// This protects against the proof-input validator silently diverging from
+    /// the issuer's actual signed hash when `issuer_version` is non-zero.
+    #[test]
+    fn test_packed_cred_id_matches_credential_hash() {
+        use super::hash_credential;
+        use ark_ff::BigInt;
+        use world_id_primitives::{Credential, FieldElement};
+
+        let mut credential = Credential::new();
+        credential.id = 0x1234_5678_9ABC_DEF0;
+        credential.issuer_version = 7;
+        credential.issuer_schema_id = 42;
+        credential.sub = FieldElement::from(100u64);
+        credential.genesis_issued_at = 1_000_000;
+        credential.expires_at = 2_000_000;
+
+        let direct = credential.hash().unwrap();
+
+        let packed_cred_id: ark_babyjubjub::Fq = BigInt([
+            credential.id,
+            u64::from(credential.issuer_version),
+            0,
+            0,
+        ])
+        .into();
+
+        let via_validation = hash_credential(
+            FieldElement::from(credential.issuer_schema_id),
+            credential.sub,
+            FieldElement::from(credential.genesis_issued_at),
+            FieldElement::from(credential.expires_at),
+            credential.claims_hash().unwrap(),
+            credential.associated_data_commitment,
+            FieldElement::from(packed_cred_id),
+        );
+
+        assert_eq!(
+            direct, via_validation,
+            "packed cred_id must reproduce Credential::hash"
+        );
+
+        let unpacked_cred_id: ark_babyjubjub::Fq = credential.id.into();
+        let via_validation_unpacked = hash_credential(
+            FieldElement::from(credential.issuer_schema_id),
+            credential.sub,
+            FieldElement::from(credential.genesis_issued_at),
+            FieldElement::from(credential.expires_at),
+            credential.claims_hash().unwrap(),
+            credential.associated_data_commitment,
+            FieldElement::from(unpacked_cred_id),
+        );
+
+        assert_ne!(
+            direct, via_validation_unpacked,
+            "passing only id (without issuer_version) must NOT reproduce Credential::hash"
+        );
+    }
 }

--- a/crates/proof/src/proof/errors.rs
+++ b/crates/proof/src/proof/errors.rs
@@ -877,13 +877,8 @@ mod tests {
 
         let direct = credential.hash().unwrap();
 
-        let packed_cred_id: ark_babyjubjub::Fq = BigInt([
-            credential.id,
-            u64::from(credential.issuer_version),
-            0,
-            0,
-        ])
-        .into();
+        let packed_cred_id: ark_babyjubjub::Fq =
+            BigInt([credential.id, u64::from(credential.issuer_version), 0, 0]).into();
 
         let via_validation = hash_credential(
             FieldElement::from(credential.issuer_schema_id),

--- a/crates/zk-mobile-bench/src/lib.rs
+++ b/crates/zk-mobile-bench/src/lib.rs
@@ -10,6 +10,7 @@ mod fixtures;
 
 use ark_babyjubjub::Fq;
 use ark_ec::CurveGroup;
+use ark_ff::BigInt;
 use eddsa_babyjubjub::EdDSAPrivateKey;
 use groth16_material::circom::CircomGroth16Material;
 use rand::SeedableRng;
@@ -205,7 +206,7 @@ fn generate_nullifier_input() -> (
         cred_genesis_issued_at: credential.genesis_issued_at.into(),
         cred_genesis_issued_at_min: 0u64.into(),
         cred_expires_at: credential.expires_at.into(),
-        cred_id: credential.id.into(),
+        cred_id: BigInt([credential.id, u64::from(credential.issuer_version), 0, 0]).into(),
         cred_sub_blinding_factor: *credential_sub_blinding_factor,
         cred_s: cred_signature.s,
         cred_r: cred_signature.r,


### PR DESCRIPTION
### Motivation
Issuers can define the content and meaning of the `claims` and `associated_data` of a credential. It's natural to expect this to change over time. In order for an issuer to know how to treat a credential, having a versioning system for the issuer makes sense.

### Changes
Introduces an `issuer_version` attribute that issuers can use to determine their own versioning scheme. This attribute is included in the signature of the credential. The attribute is introduced in a **backwards compatible** way.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the credential hashing/signature input and the proof-circuit `cred_id` field encoding; while `issuer_version` defaults to `0` to preserve existing hashes, any mismatch in packing across components would break signature/proof verification.
> 
> **Overview**
> Adds a new `Credential.issuer_version` (defaulting to `0`) and **binds it into the signed credential hash** by packing `(id, issuer_version)` into the final Poseidon2 permutation slot.
> 
> Updates proof generation and circuit inputs to pass this packed value as `cred_id`, and adds targeted tests to lock in deterministic hashing and ensure `issuer_version` tampering invalidates signatures and that proof-input validation reproduces the same credential hash.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e528ab93314f8fab22a6556707bc87488656b62b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->