### PR TITLE
refactor!: model indexer/gateway as ServiceEndpoint enum on Config

### DIFF
--- a/crates/authenticator/src/authenticator.rs
+++ b/crates/authenticator/src/authenticator.rs
@@ -16,7 +16,6 @@ use crate::{
     },
     service_client::{ServiceClient, ServiceKind},
 };
-use serde::{Deserialize, Serialize};
 use world_id_primitives::{Credential, FieldElement, ProofResponse, Signer};
 
 pub use crate::ohttp::OhttpClientConfig;
@@ -33,7 +32,7 @@ use taceo_oprf::client::Connector;
 use world_id_primitives::{
     AuthenticatorPublicKeySet, PrimitiveError, SparseAuthenticatorPubkeysError,
 };
-pub use world_id_primitives::{Config, TREE_DEPTH, authenticator::ProtocolSigner};
+pub use world_id_primitives::{Config, ServiceEndpoint, TREE_DEPTH, authenticator::ProtocolSigner};
 use world_id_registries::world_id::WorldIdRegistry::WorldIdRegistryInstance;
 
 #[expect(unused_imports, reason = "used for docs")]
@@ -45,48 +44,6 @@ static MASK_PUBKEY_ID: U256 =
     uint!(0x00000000FFFFFFFF000000000000000000000000000000000000000000000000_U256);
 static MASK_LEAF_INDEX: U256 =
     uint!(0x000000000000000000000000000000000000000000000000FFFFFFFFFFFFFFFF_U256);
-
-/// Configuration for an [`Authenticator`], extends base protocol [`Config`] by
-/// optional OHTTP relay settings for the indexer and gateway services.
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct AuthenticatorConfig {
-    /// Base protocol configuration (indexer URL, gateway URL, RPC, etc.).
-    #[serde(flatten)]
-    pub config: Config,
-    /// Optional OHTTP relay configuration for indexer requests.
-    #[serde(default)]
-    pub ohttp_indexer: Option<OhttpClientConfig>,
-    /// Optional OHTTP relay configuration for gateway requests.
-    #[serde(default)]
-    pub ohttp_gateway: Option<OhttpClientConfig>,
-}
-
-impl AuthenticatorConfig {
-    /// Loads an authenticator configuration from JSON.
-    ///
-    /// Accepts both plain `Config` JSON (OHTTP fields default to `None`) and
-    /// extended JSON with `ohttp_indexer` / `ohttp_gateway` fields.
-    ///
-    /// # Errors
-    /// Will error if the JSON is not valid.
-    pub fn from_json(json_str: &str) -> Result<Self, AuthenticatorError> {
-        serde_json::from_str(json_str).map_err(|e| {
-            AuthenticatorError::from(PrimitiveError::Serialization(format!(
-                "failed to parse authenticator config: {e}"
-            )))
-        })
-    }
-}
-
-impl From<Config> for AuthenticatorConfig {
-    fn from(config: Config) -> Self {
-        Self {
-            config,
-            ohttp_indexer: None,
-            ohttp_gateway: None,
-        }
-    }
-}
 
 /// Input for a single credential proof within a proof request.
 pub struct CredentialInput {
@@ -169,16 +126,7 @@ impl Authenticator {
     /// - Will return [`AuthenticatorError::AccountDoesNotExist`] if the authenticator address
     ///   derived from `seed` is not currently registered on-chain, whether permanently or because a
     ///   relevant on-chain operation has not finalized yet.
-    pub async fn init(
-        seed: &[u8],
-        config: AuthenticatorConfig,
-    ) -> Result<Self, AuthenticatorError> {
-        let AuthenticatorConfig {
-            config,
-            ohttp_indexer,
-            ohttp_gateway,
-        } = config;
-
+    pub async fn init(seed: &[u8], config: Config) -> Result<Self, AuthenticatorError> {
         let signer = Signer::from_seed_bytes(seed)?;
 
         let registry: Option<Arc<WorldIdRegistryInstance<DynProvider>>> =
@@ -197,16 +145,11 @@ impl Authenticator {
         let indexer_client = ServiceClient::new(
             http_client.clone(),
             ServiceKind::Indexer,
-            config.indexer_url(),
-            ohttp_indexer,
+            config.indexer(),
         )?;
 
-        let gateway_client = ServiceClient::new(
-            http_client,
-            ServiceKind::Gateway,
-            config.gateway_url(),
-            ohttp_gateway,
-        )?;
+        let gateway_client =
+            ServiceClient::new(http_client, ServiceKind::Gateway, config.gateway())?;
 
         let packed_account_data = Self::fetch_packed_account_data_for(
             signer.onchain_signer_address(),
@@ -268,19 +211,13 @@ impl Authenticator {
     /// - See `init` for additional error details.
     pub async fn register(
         seed: &[u8],
-        config: AuthenticatorConfig,
+        config: Config,
         recovery_address: Option<Address>,
     ) -> Result<InitializingAuthenticator, AuthenticatorError> {
-        let AuthenticatorConfig {
-            config,
-            ohttp_gateway,
-            ..
-        } = config;
         let gateway_client = ServiceClient::new(
             reqwest::Client::new(),
             ServiceKind::Gateway,
-            config.gateway_url(),
-            ohttp_gateway,
+            config.gateway(),
         )?;
         InitializingAuthenticator::new(seed, config, recovery_address, gateway_client).await
     }
@@ -299,7 +236,7 @@ impl Authenticator {
     /// - See `init` for additional error details.
     pub async fn init_or_register(
         seed: &[u8],
-        config: AuthenticatorConfig,
+        config: Config,
         recovery_address: Option<Address>,
     ) -> Result<Self, AuthenticatorError> {
         match Self::init(seed, config.clone()).await {
@@ -308,12 +245,11 @@ impl Authenticator {
                 let gateway_client = ServiceClient::new(
                     reqwest::Client::new(),
                     ServiceKind::Gateway,
-                    config.config.gateway_url(),
-                    config.ohttp_gateway.clone(),
+                    config.gateway(),
                 )?;
                 let initializing_authenticator = InitializingAuthenticator::new(
                     seed,
-                    config.config.clone(),
+                    config.clone(),
                     recovery_address,
                     gateway_client,
                 )
@@ -723,8 +659,8 @@ mod tests {
             None,
             1,
             address!("0x0000000000000000000000000000000000000001"),
-            indexer_url,
-            "http://gateway.example.com".to_string(),
+            ServiceEndpoint::direct(indexer_url),
+            ServiceEndpoint::direct("http://gateway.example.com".to_string()),
             Vec::new(),
             2,
         )
@@ -733,8 +669,7 @@ mod tests {
         let indexer_client = ServiceClient::new(
             reqwest::Client::new(),
             ServiceKind::Indexer,
-            config.indexer_url(),
-            None,
+            config.indexer(),
         )
         .unwrap();
 
@@ -768,8 +703,8 @@ mod tests {
             None,
             1,
             address!("0x0000000000000000000000000000000000000001"),
-            indexer_url,
-            "http://gateway.example.com".to_string(),
+            ServiceEndpoint::direct(indexer_url),
+            ServiceEndpoint::direct("http://gateway.example.com".to_string()),
             Vec::new(),
             2,
         )
@@ -778,8 +713,7 @@ mod tests {
         let indexer_client = ServiceClient::new(
             reqwest::Client::new(),
             ServiceKind::Indexer,
-            config.indexer_url(),
-            None,
+            config.indexer(),
         )
         .unwrap();
 
@@ -824,8 +758,8 @@ mod tests {
             None,
             1,
             address!("0x0000000000000000000000000000000000000001"),
-            indexer_url,
-            "http://gateway.example.com".to_string(),
+            ServiceEndpoint::direct(indexer_url),
+            ServiceEndpoint::direct("http://gateway.example.com".to_string()),
             Vec::new(),
             2,
         )
@@ -840,15 +774,13 @@ mod tests {
             indexer_client: ServiceClient::new(
                 http_client.clone(),
                 ServiceKind::Indexer,
-                config.indexer_url(),
-                None,
+                config.indexer(),
             )
             .unwrap(),
             gateway_client: ServiceClient::new(
                 http_client,
                 ServiceKind::Gateway,
-                config.gateway_url(),
-                None,
+                config.gateway(),
             )
             .unwrap(),
             ws_connector: Connector::Plain,
@@ -867,8 +799,8 @@ mod tests {
             None,
             1,
             address!("0x0000000000000000000000000000000000000001"),
-            "http://indexer.example.com".to_string(),
-            "http://gateway.example.com".to_string(),
+            ServiceEndpoint::direct("http://indexer.example.com".to_string()),
+            ServiceEndpoint::direct("http://gateway.example.com".to_string()),
             Vec::new(),
             2,
         )
@@ -878,15 +810,13 @@ mod tests {
             indexer_client: ServiceClient::new(
                 http_client.clone(),
                 ServiceKind::Indexer,
-                config.indexer_url(),
-                None,
+                config.indexer(),
             )
             .unwrap(),
             gateway_client: ServiceClient::new(
                 http_client,
                 ServiceKind::Gateway,
-                config.gateway_url(),
-                None,
+                config.gateway(),
             )
             .unwrap(),
             config,
@@ -911,8 +841,8 @@ mod tests {
             None,
             1,
             address!("0x0000000000000000000000000000000000000001"),
-            "http://indexer.example.com".to_string(),
-            "http://gateway.example.com".to_string(),
+            ServiceEndpoint::direct("http://indexer.example.com".to_string()),
+            ServiceEndpoint::direct("http://gateway.example.com".to_string()),
             Vec::new(),
             2,
         )
@@ -922,15 +852,13 @@ mod tests {
             indexer_client: ServiceClient::new(
                 http_client.clone(),
                 ServiceKind::Indexer,
-                config.indexer_url(),
-                None,
+                config.indexer(),
             )
             .unwrap(),
             gateway_client: ServiceClient::new(
                 http_client,
                 ServiceKind::Gateway,
-                config.gateway_url(),
-                None,
+                config.gateway(),
             )
             .unwrap(),
             config,
@@ -952,8 +880,8 @@ mod tests {
             None,
             1,
             address!("0x0000000000000000000000000000000000000001"),
-            "http://indexer.example.com".to_string(),
-            "http://gateway.example.com".to_string(),
+            ServiceEndpoint::direct("http://indexer.example.com".to_string()),
+            ServiceEndpoint::direct("http://gateway.example.com".to_string()),
             Vec::new(),
             2,
         )
@@ -963,15 +891,13 @@ mod tests {
             indexer_client: ServiceClient::new(
                 http_client.clone(),
                 ServiceKind::Indexer,
-                config.indexer_url(),
-                None,
+                config.indexer(),
             )
             .unwrap(),
             gateway_client: ServiceClient::new(
                 http_client,
                 ServiceKind::Gateway,
-                config.gateway_url(),
-                None,
+                config.gateway(),
             )
             .unwrap(),
             config,
@@ -1004,8 +930,8 @@ mod tests {
             None,
             1,
             address!("0x0000000000000000000000000000000000000001"),
-            indexer_url,
-            "http://gateway.example.com".to_string(),
+            ServiceEndpoint::direct(indexer_url),
+            ServiceEndpoint::direct("http://gateway.example.com".to_string()),
             Vec::new(),
             2,
         )
@@ -1020,15 +946,13 @@ mod tests {
             indexer_client: ServiceClient::new(
                 http_client.clone(),
                 ServiceKind::Indexer,
-                config.indexer_url(),
-                None,
+                config.indexer(),
             )
             .unwrap(),
             gateway_client: ServiceClient::new(
                 http_client,
                 ServiceKind::Gateway,
-                config.gateway_url(),
-                None,
+                config.gateway(),
             )
             .unwrap(),
             ws_connector: Connector::Plain,
@@ -1044,48 +968,4 @@ mod tests {
         drop(server);
     }
 
-    #[test]
-    fn test_authenticator_config_from_json_plain_config() {
-        let json = serde_json::json!({
-            "chain_id": 480,
-            "registry_address": "0x0000000000000000000000000000000000000001",
-            "indexer_url": "http://indexer.example.com",
-            "gateway_url": "http://gateway.example.com",
-            "nullifier_oracle_urls": [],
-            "nullifier_oracle_threshold": 2
-        });
-
-        let config = AuthenticatorConfig::from_json(&json.to_string()).unwrap();
-        assert!(config.ohttp_indexer.is_none());
-        assert!(config.ohttp_gateway.is_none());
-        assert_eq!(config.config.gateway_url(), "http://gateway.example.com");
-    }
-
-    #[test]
-    fn test_authenticator_config_from_json_with_ohttp() {
-        let json = serde_json::json!({
-            "chain_id": 480,
-            "registry_address": "0x0000000000000000000000000000000000000001",
-            "indexer_url": "http://indexer.example.com",
-            "gateway_url": "http://gateway.example.com",
-            "nullifier_oracle_urls": [],
-            "nullifier_oracle_threshold": 2,
-            "ohttp_indexer": {
-                "relay_url": "https://relay.example.com/gateway",
-                "key_config_base64": "dGVzdC1rZXk="
-            },
-            "ohttp_gateway": {
-                "relay_url": "https://relay.example.com/gateway",
-                "key_config_base64": "dGVzdC1rZXk="
-            }
-        });
-
-        let config = AuthenticatorConfig::from_json(&json.to_string()).unwrap();
-        let ohttp_indexer = config.ohttp_indexer.unwrap();
-        assert_eq!(ohttp_indexer.relay_url, "https://relay.example.com/gateway");
-        assert_eq!(ohttp_indexer.key_config_base64, "dGVzdC1rZXk=");
-        let ohttp_gateway = config.ohttp_gateway.unwrap();
-        assert_eq!(ohttp_gateway.relay_url, "https://relay.example.com/gateway");
-        assert_eq!(ohttp_gateway.key_config_base64, "dGVzdC1rZXk=");
-    }
 }

--- a/crates/authenticator/src/authenticator.rs
+++ b/crates/authenticator/src/authenticator.rs
@@ -142,11 +142,8 @@ impl Authenticator {
 
         let http_client = reqwest::Client::new();
 
-        let indexer_client = ServiceClient::new(
-            http_client.clone(),
-            ServiceKind::Indexer,
-            config.indexer(),
-        )?;
+        let indexer_client =
+            ServiceClient::new(http_client.clone(), ServiceKind::Indexer, config.indexer())?;
 
         let gateway_client =
             ServiceClient::new(http_client, ServiceKind::Gateway, config.gateway())?;
@@ -777,12 +774,8 @@ mod tests {
                 config.indexer(),
             )
             .unwrap(),
-            gateway_client: ServiceClient::new(
-                http_client,
-                ServiceKind::Gateway,
-                config.gateway(),
-            )
-            .unwrap(),
+            gateway_client: ServiceClient::new(http_client, ServiceKind::Gateway, config.gateway())
+                .unwrap(),
             ws_connector: Connector::Plain,
             query_material: None,
             nullifier_material: None,
@@ -813,12 +806,8 @@ mod tests {
                 config.indexer(),
             )
             .unwrap(),
-            gateway_client: ServiceClient::new(
-                http_client,
-                ServiceKind::Gateway,
-                config.gateway(),
-            )
-            .unwrap(),
+            gateway_client: ServiceClient::new(http_client, ServiceKind::Gateway, config.gateway())
+                .unwrap(),
             config,
             packed_account_data: U256::from(1),
             signer: Signer::from_seed_bytes(&[1u8; 32]).unwrap(),
@@ -855,12 +844,8 @@ mod tests {
                 config.indexer(),
             )
             .unwrap(),
-            gateway_client: ServiceClient::new(
-                http_client,
-                ServiceKind::Gateway,
-                config.gateway(),
-            )
-            .unwrap(),
+            gateway_client: ServiceClient::new(http_client, ServiceKind::Gateway, config.gateway())
+                .unwrap(),
             config,
             packed_account_data: U256::from(1),
             signer: Signer::from_seed_bytes(&[1u8; 32]).unwrap(),
@@ -894,12 +879,8 @@ mod tests {
                 config.indexer(),
             )
             .unwrap(),
-            gateway_client: ServiceClient::new(
-                http_client,
-                ServiceKind::Gateway,
-                config.gateway(),
-            )
-            .unwrap(),
+            gateway_client: ServiceClient::new(http_client, ServiceKind::Gateway, config.gateway())
+                .unwrap(),
             config,
             packed_account_data: U256::from(1),
             signer: Signer::from_seed_bytes(&[1u8; 32]).unwrap(),
@@ -949,12 +930,8 @@ mod tests {
                 config.indexer(),
             )
             .unwrap(),
-            gateway_client: ServiceClient::new(
-                http_client,
-                ServiceKind::Gateway,
-                config.gateway(),
-            )
-            .unwrap(),
+            gateway_client: ServiceClient::new(http_client, ServiceKind::Gateway, config.gateway())
+                .unwrap(),
             ws_connector: Connector::Plain,
             query_material: None,
             nullifier_material: None,
@@ -967,5 +944,4 @@ mod tests {
         mock.assert_async().await;
         drop(server);
     }
-
 }

--- a/crates/authenticator/src/ohttp.rs
+++ b/crates/authenticator/src/ohttp.rs
@@ -9,9 +9,8 @@ use crate::AuthenticatorError;
 /// Configuration for routing requests through a single OHTTP relay endpoint.
 ///
 /// Stores the relay URL and the relay's `application/ohttp-keys` payload as a
-/// base64-encoded string. The target origin is supplied separately (from the
-/// service URL already present in [`AuthenticatorConfig`](crate::AuthenticatorConfig)) when constructing an
-/// [`OhttpClient`].
+/// base64-encoded string. The target origin is supplied separately when
+/// constructing an [`OhttpClient`].
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct OhttpClientConfig {
     /// URL of the OHTTP relay that receives encrypted requests.

--- a/crates/authenticator/src/prove.rs
+++ b/crates/authenticator/src/prove.rs
@@ -511,7 +511,8 @@ mod tests {
     use ruint::aliases::U256;
     use taceo_oprf::client::Connector;
     use world_id_primitives::{
-        Config, Credential, FieldElement, Signer, TREE_DEPTH, merkle::AccountInclusionProof,
+        Config, Credential, FieldElement, ServiceEndpoint, Signer, TREE_DEPTH,
+        merkle::AccountInclusionProof,
     };
     use world_id_test_utils::fixtures::single_leaf_merkle_fixture;
 
@@ -531,8 +532,8 @@ mod tests {
             None,
             1,
             address!("0x0000000000000000000000000000000000000001"),
-            "http://indexer.example.com".to_string(),
-            "http://gateway.example.com".to_string(),
+            ServiceEndpoint::direct("http://indexer.example.com".to_string()),
+            ServiceEndpoint::direct("http://gateway.example.com".to_string()),
             Vec::new(),
             2,
         )
@@ -547,15 +548,13 @@ mod tests {
             indexer_client: ServiceClient::new(
                 http_client.clone(),
                 ServiceKind::Indexer,
-                config.indexer_url(),
-                None,
+                config.indexer(),
             )
             .expect("valid indexer client"),
             gateway_client: ServiceClient::new(
                 http_client,
                 ServiceKind::Gateway,
-                config.gateway_url(),
-                None,
+                config.gateway(),
             )
             .expect("valid gateway client"),
             ws_connector: Connector::Plain,

--- a/crates/authenticator/src/prove.rs
+++ b/crates/authenticator/src/prove.rs
@@ -551,12 +551,8 @@ mod tests {
                 config.indexer(),
             )
             .expect("valid indexer client"),
-            gateway_client: ServiceClient::new(
-                http_client,
-                ServiceKind::Gateway,
-                config.gateway(),
-            )
-            .expect("valid gateway client"),
+            gateway_client: ServiceClient::new(http_client, ServiceKind::Gateway, config.gateway())
+                .expect("valid gateway client"),
             ws_connector: Connector::Plain,
             query_material: None,
             nullifier_material: None,

--- a/crates/authenticator/src/service_client.rs
+++ b/crates/authenticator/src/service_client.rs
@@ -4,6 +4,7 @@ use crate::{
 };
 use reqwest::StatusCode;
 use serde::de::DeserializeOwned;
+use world_id_primitives::ServiceEndpoint;
 
 #[derive(Clone, Copy, Debug)]
 pub(crate) enum ServiceKind {
@@ -39,26 +40,30 @@ struct TransportResponse {
 }
 
 impl ServiceClient {
-    /// Creates a new [`ServiceClient`] that routes through OHTTP when `ohttp_config` is
-    /// `Some`, and falls back to direct HTTP otherwise.
+    /// Creates a new [`ServiceClient`] for the given endpoint.
     ///
-    /// `target_url` is the origin of the upstream service (e.g. the gateway or
-    /// indexer URL). It is forwarded into the encrypted BHTTP envelope when
-    /// OHTTP is enabled.
+    /// Routes through OHTTP for [`ServiceEndpoint::Ohttp`] and falls back to direct
+    /// HTTP for [`ServiceEndpoint::Direct`].
     pub(crate) fn new(
         client: reqwest::Client,
         service_kind: ServiceKind,
-        target_url: &str,
-        ohttp_config: Option<OhttpClientConfig>,
+        endpoint: &ServiceEndpoint,
     ) -> Result<Self, AuthenticatorError> {
-        let transport = match ohttp_config {
-            Some(config) => HttpTransport::Ohttp(OhttpClient::new(
+        let transport = match endpoint {
+            ServiceEndpoint::Direct { .. } => HttpTransport::Direct(client),
+            ServiceEndpoint::Ohttp {
+                url,
+                relay_url,
+                key_config_base64,
+            } => HttpTransport::Ohttp(OhttpClient::new(
                 client,
                 service_kind.ohttp_config_scope(),
-                target_url,
-                config,
+                url,
+                OhttpClientConfig {
+                    relay_url: relay_url.clone(),
+                    key_config_base64: key_config_base64.clone(),
+                },
             )?),
-            None => HttpTransport::Direct(client),
         };
 
         Ok(Self {

--- a/crates/authenticator/tests/ohttp_authenticator_integration.rs
+++ b/crates/authenticator/tests/ohttp_authenticator_integration.rs
@@ -16,15 +16,14 @@ use testcontainers::{
 };
 use tokio::{net::TcpListener, sync::Mutex};
 use world_id_authenticator::{
-    Authenticator, AuthenticatorConfig, AuthenticatorError,
+    Authenticator, AuthenticatorError,
     api_types::{
         CreateAccountRequest, GatewayRequestState, IndexerAuthenticatorPubkeysResponse,
         IndexerPackedAccountResponse, IndexerQueryRequest, IndexerSignatureNonceResponse,
         InsertAuthenticatorRequest, RemoveAuthenticatorRequest, UpdateAuthenticatorRequest,
     },
-    ohttp::OhttpClientConfig,
 };
-use world_id_primitives::Config;
+use world_id_primitives::{Config, ServiceEndpoint};
 
 const OHTTP_GATEWAY_IMAGE: &str = "ghcr.io/worldcoin/ohttp-tools/ohttp-gateway";
 const OHTTP_GATEWAY_TAG: &str = "latest";
@@ -112,8 +111,8 @@ async fn start_stub_server(state: SharedState) -> u16 {
 struct OhttpFixture {
     gateway_state: SharedState,
     indexer_state: SharedState,
-    ohttp_gateway_config: OhttpClientConfig,
-    ohttp_indexer_config: OhttpClientConfig,
+    relay_url: String,
+    key_config_base64: String,
     gateway_target_url: String,
     indexer_target_url: String,
     _container: testcontainers::ContainerAsync<GenericImage>,
@@ -164,41 +163,38 @@ impl OhttpFixture {
         let gateway_target_url = format!("http://{gw_authority}");
         let indexer_target_url = format!("http://{idx_authority}");
 
-        let ohttp_gateway_config =
-            OhttpClientConfig::new(format!("{relay_base}/gateway"), key_b64.clone());
-
-        let ohttp_indexer_config = OhttpClientConfig::new(format!("{relay_base}/gateway"), key_b64);
-
         Ok(Self {
             gateway_state,
             indexer_state,
-            ohttp_gateway_config,
-            ohttp_indexer_config,
+            relay_url: format!("{relay_base}/gateway"),
+            key_config_base64: key_b64,
             gateway_target_url,
             indexer_target_url,
             _container: container,
         })
     }
 
-    fn authenticator_config(&self) -> AuthenticatorConfig {
-        let config = Config::new(
+    fn authenticator_config(&self) -> Config {
+        Config::new(
             None,
             31337,
             "0x0000000000000000000000000000000000000001"
                 .parse()
                 .unwrap(),
-            self.indexer_target_url.clone(),
-            self.gateway_target_url.clone(),
+            ServiceEndpoint::ohttp(
+                self.indexer_target_url.clone(),
+                self.relay_url.clone(),
+                self.key_config_base64.clone(),
+            ),
+            ServiceEndpoint::ohttp(
+                self.gateway_target_url.clone(),
+                self.relay_url.clone(),
+                self.key_config_base64.clone(),
+            ),
             vec![],
             2,
         )
-        .expect("test config should be valid");
-
-        AuthenticatorConfig {
-            config,
-            ohttp_indexer: Some(self.ohttp_indexer_config.clone()),
-            ohttp_gateway: Some(self.ohttp_gateway_config.clone()),
-        }
+        .expect("test config should be valid")
     }
 
     #[allow(dead_code)]

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -10,8 +10,8 @@ pub use eddsa_babyjubjub::{EdDSAPrivateKey, EdDSAPublicKey, EdDSASignature};
 
 #[cfg(feature = "authenticator")]
 pub use world_id_authenticator::{
-    Authenticator, AuthenticatorConfig, AuthenticatorError, CredentialInput,
-    InitializingAuthenticator, OhttpClientConfig, OnchainKeyRepresentable, ProofResult,
+    Authenticator, AuthenticatorError, CredentialInput, InitializingAuthenticator,
+    OhttpClientConfig, OnchainKeyRepresentable, ProofResult,
 };
 
 /// Re-export registry contract bindings for convenience

--- a/crates/core/tests/authenticator_registration.rs
+++ b/crates/core/tests/authenticator_registration.rs
@@ -6,7 +6,7 @@ use world_id_core::{Authenticator, AuthenticatorError, api_types::GatewayRequest
 use world_id_gateway::{
     BatchPolicyConfig, GatewayConfig, SignerArgs, defaults, spawn_gateway_for_tests,
 };
-use world_id_primitives::Config;
+use world_id_primitives::{Config, ServiceEndpoint};
 use world_id_test_utils::anvil::TestAnvil;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -55,8 +55,8 @@ async fn test_authenticator_registration() {
         Some(anvil.endpoint().to_string()),
         anvil.instance.chain_id(),
         registry_address,
-        "http://127.0.0.1:0".to_string(), // not needed for this test
-        gateway_url.clone(),
+        ServiceEndpoint::direct("http://127.0.0.1:0".to_string()), // not needed for this test
+        ServiceEndpoint::direct(gateway_url.clone()),
         Vec::new(),
         2,
     )
@@ -65,7 +65,7 @@ async fn test_authenticator_registration() {
     let seed = [1u8; 32];
     let recovery_address = anvil.signer(1).unwrap().address();
     // Account doesn't exist, so init will error
-    let result = Authenticator::init(&seed, config.clone().into()).await;
+    let result = Authenticator::init(&seed, config.clone()).await;
     assert!(matches!(
         result,
         Err(AuthenticatorError::AccountDoesNotExist)
@@ -75,7 +75,7 @@ async fn test_authenticator_registration() {
     // NOTE how we use `register()` instead of `init_or_register()` to test this specific flow.
     let start = std::time::Instant::now();
     let initializing_account =
-        Authenticator::register(&seed, config.clone().into(), Some(recovery_address))
+        Authenticator::register(&seed, config.clone(), Some(recovery_address))
             .await
             .unwrap();
 
@@ -91,7 +91,7 @@ async fn test_authenticator_registration() {
         .await
         .unwrap();
 
-    let authenticator = Authenticator::init(&seed, config.clone().into())
+    let authenticator = Authenticator::init(&seed, config.clone())
         .await
         .unwrap();
     let elapsed = start.elapsed();
@@ -100,6 +100,6 @@ async fn test_authenticator_registration() {
     assert_eq!(authenticator.recovery_counter(), U256::from(0));
 
     // If we initialize again, it will work
-    let authenticator = Authenticator::init(&seed, config.into()).await.unwrap();
+    let authenticator = Authenticator::init(&seed, config).await.unwrap();
     assert_eq!(authenticator.leaf_index(), 1);
 }

--- a/crates/core/tests/authenticator_registration.rs
+++ b/crates/core/tests/authenticator_registration.rs
@@ -91,9 +91,7 @@ async fn test_authenticator_registration() {
         .await
         .unwrap();
 
-    let authenticator = Authenticator::init(&seed, config.clone())
-        .await
-        .unwrap();
+    let authenticator = Authenticator::init(&seed, config.clone()).await.unwrap();
     let elapsed = start.elapsed();
     tracing::info!("Account creation successful in {elapsed:?}");
     assert_eq!(authenticator.leaf_index(), 1);

--- a/crates/core/tests/e2e_authenticator_insert_update_remove.rs
+++ b/crates/core/tests/e2e_authenticator_insert_update_remove.rs
@@ -154,10 +154,9 @@ async fn e2e_authenticator_insert_update_remove() {
         Err(AuthenticatorError::AccountDoesNotExist)
     ));
 
-    let primary =
-        Authenticator::init_or_register(&primary_seed, config, Some(recovery_address))
-            .await
-            .unwrap();
+    let primary = Authenticator::init_or_register(&primary_seed, config, Some(recovery_address))
+        .await
+        .unwrap();
 
     assert_eq!(primary.leaf_index(), 1);
     assert_eq!(primary.signing_nonce().await.unwrap(), U256::from(0));
@@ -183,9 +182,7 @@ async fn e2e_authenticator_insert_update_remove() {
         &indexer.url,
         &gateway_url,
     );
-    let auth = Authenticator::init(&primary_seed, config)
-        .await
-        .unwrap();
+    let auth = Authenticator::init(&primary_seed, config).await.unwrap();
 
     assert_eq!(auth.signing_nonce().await.unwrap(), U256::from(0));
     let req_id = auth
@@ -223,9 +220,7 @@ async fn e2e_authenticator_insert_update_remove() {
         &indexer.url,
         &gateway_url,
     );
-    let auth = Authenticator::init(&primary_seed, config)
-        .await
-        .unwrap();
+    let auth = Authenticator::init(&primary_seed, config).await.unwrap();
 
     let updated_pubkey = EdDSAPrivateKey::random(&mut rand::thread_rng()).public();
     let updated_address = anvil.signer(3).unwrap().address();
@@ -278,9 +273,7 @@ async fn e2e_authenticator_insert_update_remove() {
         &indexer.url,
         &gateway_url,
     );
-    let auth = Authenticator::init(&secondary_seed, config)
-        .await
-        .unwrap();
+    let auth = Authenticator::init(&secondary_seed, config).await.unwrap();
 
     assert_eq!(auth.signing_nonce().await.unwrap(), U256::from(2));
     let req_id = auth.remove_authenticator(updated_address, 0).await.unwrap();

--- a/crates/core/tests/e2e_authenticator_insert_update_remove.rs
+++ b/crates/core/tests/e2e_authenticator_insert_update_remove.rs
@@ -16,7 +16,7 @@ use world_id_core::{
 use world_id_gateway::{
     BatchPolicyConfig, GatewayConfig, SignerArgs, defaults, spawn_gateway_for_tests,
 };
-use world_id_primitives::{Config, TREE_DEPTH, merkle::AccountInclusionProof};
+use world_id_primitives::{Config, ServiceEndpoint, TREE_DEPTH, merkle::AccountInclusionProof};
 use world_id_test_utils::{
     anvil::{TestAnvil, WorldIDRegistry},
     fixtures::{MerkleFixture, single_leaf_merkle_fixture},
@@ -82,8 +82,8 @@ fn make_config(
         Some(rpc_url.to_string()),
         chain_id,
         registry,
-        indexer_url.to_string(),
-        gateway_url.to_string(),
+        ServiceEndpoint::direct(indexer_url.to_string()),
+        ServiceEndpoint::direct(gateway_url.to_string()),
         Vec::new(),
         2,
     )
@@ -148,14 +148,14 @@ async fn e2e_authenticator_insert_update_remove() {
         "http://127.0.0.1:0",
         &gateway_url,
     );
-    let result = Authenticator::init(&primary_seed, config.clone().into()).await;
+    let result = Authenticator::init(&primary_seed, config.clone()).await;
     assert!(matches!(
         result,
         Err(AuthenticatorError::AccountDoesNotExist)
     ));
 
     let primary =
-        Authenticator::init_or_register(&primary_seed, config.into(), Some(recovery_address))
+        Authenticator::init_or_register(&primary_seed, config, Some(recovery_address))
             .await
             .unwrap();
 
@@ -183,7 +183,7 @@ async fn e2e_authenticator_insert_update_remove() {
         &indexer.url,
         &gateway_url,
     );
-    let auth = Authenticator::init(&primary_seed, config.into())
+    let auth = Authenticator::init(&primary_seed, config)
         .await
         .unwrap();
 
@@ -223,7 +223,7 @@ async fn e2e_authenticator_insert_update_remove() {
         &indexer.url,
         &gateway_url,
     );
-    let auth = Authenticator::init(&primary_seed, config.into())
+    let auth = Authenticator::init(&primary_seed, config)
         .await
         .unwrap();
 
@@ -278,7 +278,7 @@ async fn e2e_authenticator_insert_update_remove() {
         &indexer.url,
         &gateway_url,
     );
-    let auth = Authenticator::init(&secondary_seed, config.into())
+    let auth = Authenticator::init(&secondary_seed, config)
         .await
         .unwrap();
 

--- a/crates/core/tests/generate_proof.rs
+++ b/crates/core/tests/generate_proof.rs
@@ -138,13 +138,10 @@ async fn e2e_authenticator_generate_proof() -> Result<()> {
 
     // Create the account via the gateway, blocking until confirmed.
     let start = SystemTime::now();
-    let authenticator = Authenticator::init_or_register(
-        &seed,
-        creation_config.clone(),
-        Some(recovery_address),
-    )
-    .await
-    .unwrap();
+    let authenticator =
+        Authenticator::init_or_register(&seed, creation_config.clone(), Some(recovery_address))
+            .await
+            .unwrap();
     info!(
         elapsed_ms = SystemTime::now().duration_since(start).unwrap().as_millis(),
         "authenticator account creation finished"

--- a/crates/core/tests/generate_proof.rs
+++ b/crates/core/tests/generate_proof.rs
@@ -24,7 +24,9 @@ use world_id_core::{
 use world_id_gateway::{
     BatchPolicyConfig, GatewayConfig, SignerArgs, defaults, spawn_gateway_for_tests,
 };
-use world_id_primitives::{Config, FieldElement, TREE_DEPTH, merkle::AccountInclusionProof};
+use world_id_primitives::{
+    Config, FieldElement, ServiceEndpoint, TREE_DEPTH, merkle::AccountInclusionProof,
+};
 use world_id_test_utils::{
     anvil::WorldIDVerifier,
     fixtures::{
@@ -121,14 +123,14 @@ async fn e2e_authenticator_generate_proof() -> Result<()> {
         Some(anvil.endpoint().to_string()),
         anvil.instance.chain_id(),
         world_id_registry,
-        "http://127.0.0.1:0".to_string(), // placeholder for future indexer stub
-        gateway_url.clone(),
+        ServiceEndpoint::direct("http://127.0.0.1:0".to_string()), // placeholder for future indexer stub
+        ServiceEndpoint::direct(gateway_url.clone()),
         Vec::new(),
         3,
     )
     .unwrap();
     // World ID should not yet exist.
-    let init_result = Authenticator::init(&seed, creation_config.clone().into()).await;
+    let init_result = Authenticator::init(&seed, creation_config.clone()).await;
     assert!(
         matches!(init_result, Err(AuthenticatorError::AccountDoesNotExist)),
         "expected missing account error before creation"
@@ -138,7 +140,7 @@ async fn e2e_authenticator_generate_proof() -> Result<()> {
     let start = SystemTime::now();
     let authenticator = Authenticator::init_or_register(
         &seed,
-        creation_config.clone().into(),
+        creation_config.clone(),
         Some(recovery_address),
     )
     .await
@@ -152,7 +154,7 @@ async fn e2e_authenticator_generate_proof() -> Result<()> {
     assert_eq!(authenticator.recovery_counter(), U256::ZERO);
 
     // Re-initialize to ensure account metadata is persisted.
-    let authenticator = Authenticator::init(&seed, creation_config.into())
+    let authenticator = Authenticator::init(&seed, creation_config)
         .await
         .wrap_err("expected authenticator to initialize after account creation")?;
     assert_eq!(authenticator.leaf_index(), 1);
@@ -258,15 +260,15 @@ async fn e2e_authenticator_generate_proof() -> Result<()> {
         Some(anvil.endpoint().to_string()),
         anvil.instance.chain_id(),
         world_id_registry,
-        indexer_url.clone(),
-        gateway_url.clone(),
+        ServiceEndpoint::direct(indexer_url.clone()),
+        ServiceEndpoint::direct(gateway_url.clone()),
         nodes.to_vec(),
         3,
     )
     .unwrap();
 
     let (query_material, nullifier_material) = load_embedded_materials();
-    let authenticator = Authenticator::init(&seed, proof_config.into())
+    let authenticator = Authenticator::init(&seed, proof_config)
         .await
         .wrap_err("failed to reinitialize authenticator with proof config")?
         .with_proof_materials(query_material, nullifier_material);

--- a/crates/primitives/src/config.rs
+++ b/crates/primitives/src/config.rs
@@ -9,6 +9,56 @@ const fn default_nullifier_oracle_threshold() -> usize {
     2
 }
 
+/// Configuration for a protocol service endpoint (indexer or gateway).
+///
+/// The target URL is required in both variants. The OHTTP variant additionally
+/// carries the relay configuration needed to encrypt and route requests through
+/// an Oblivious HTTP relay.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ServiceEndpoint {
+    /// Direct HTTP(S) connection to `url`.
+    Direct {
+        /// Target service URL.
+        url: String,
+    },
+    /// OHTTP-routed connection: encrypted requests pass through `relay_url` to `url`.
+    Ohttp {
+        /// Target service URL (placed inside the encrypted BHTTP envelope).
+        url: String,
+        /// URL of the OHTTP relay that receives encrypted requests.
+        relay_url: String,
+        /// Base64-encoded `application/ohttp-keys` payload listing the gateway HPKE configs.
+        key_config_base64: String,
+    },
+}
+
+impl ServiceEndpoint {
+    /// Convenience constructor for a direct (non-OHTTP) endpoint.
+    #[must_use]
+    pub const fn direct(url: String) -> Self {
+        Self::Direct { url }
+    }
+
+    /// Convenience constructor for an OHTTP-routed endpoint.
+    #[must_use]
+    pub const fn ohttp(url: String, relay_url: String, key_config_base64: String) -> Self {
+        Self::Ohttp {
+            url,
+            relay_url,
+            key_config_base64,
+        }
+    }
+
+    /// Target service URL (works for both variants).
+    #[must_use]
+    pub fn url(&self) -> &str {
+        match self {
+            Self::Direct { url } | Self::Ohttp { url, .. } => url,
+        }
+    }
+}
+
 /// Global configuration to interact with the different components of the Protocol.
 ///
 /// Used by Authenticators and RPs.
@@ -22,10 +72,10 @@ pub struct Config {
     chain_id: u64,
     /// The address of the `WorldIDRegistry` contract
     registry_address: Address,
-    /// Base URL of a deployed `world-id-indexer`. Used to fetch inclusion proofs from the `WorldIDRegistry`.
-    indexer_url: String,
-    /// Base URL of a deployed `world-id-gateway`. Used to submit management operations on authenticators.
-    gateway_url: String,
+    /// Indexer endpoint (`world-id-indexer`). Used to fetch inclusion proofs from the `WorldIDRegistry`.
+    indexer: ServiceEndpoint,
+    /// Gateway endpoint (`world-id-gateway`). Used to submit management operations on authenticators.
+    gateway: ServiceEndpoint,
     /// The Base URLs of all Nullifier Oracles to use
     nullifier_oracle_urls: Vec<String>,
     /// Minimum number of Nullifier Oracle responses required to build a nullifier.
@@ -43,8 +93,8 @@ impl Config {
         rpc_url: Option<String>,
         chain_id: u64,
         registry_address: Address,
-        indexer_url: String,
-        gateway_url: String,
+        indexer: ServiceEndpoint,
+        gateway: ServiceEndpoint,
         nullifier_oracle_urls: Vec<String>,
         nullifier_oracle_threshold: usize,
     ) -> Result<Self, PrimitiveError> {
@@ -61,8 +111,8 @@ impl Config {
             rpc_url,
             chain_id,
             registry_address,
-            indexer_url,
-            gateway_url,
+            indexer,
+            gateway,
             nullifier_oracle_urls,
             nullifier_oracle_threshold,
         })
@@ -95,17 +145,30 @@ impl Config {
         &self.registry_address
     }
 
-    /// The URL of the `world-id-indexer` service to use. The indexer is used to fetch inclusion proofs from the `WorldIDRegistry` contract.
+    /// The indexer endpoint configuration. The indexer is used to fetch inclusion
+    /// proofs from the `WorldIDRegistry` contract.
     #[must_use]
-    pub const fn indexer_url(&self) -> &String {
-        &self.indexer_url
+    pub const fn indexer(&self) -> &ServiceEndpoint {
+        &self.indexer
     }
 
-    /// The URL of the `world-id-gateway` service to use. The gateway is used to perform operations on the `WorldIDRegistry` contract
-    /// without leaking a wallet address.
+    /// The gateway endpoint configuration. The gateway is used to perform operations
+    /// on the `WorldIDRegistry` contract without leaking a wallet address.
     #[must_use]
-    pub const fn gateway_url(&self) -> &String {
-        &self.gateway_url
+    pub const fn gateway(&self) -> &ServiceEndpoint {
+        &self.gateway
+    }
+
+    /// Convenience accessor for the indexer's target URL.
+    #[must_use]
+    pub fn indexer_url(&self) -> &str {
+        self.indexer.url()
+    }
+
+    /// Convenience accessor for the gateway's target URL.
+    #[must_use]
+    pub fn gateway_url(&self) -> &str {
+        self.gateway.url()
     }
 
     /// The list of URLs of all and each node of the Nullifier Oracle.
@@ -118,5 +181,76 @@ impl Config {
     #[must_use]
     pub const fn nullifier_oracle_threshold(&self) -> usize {
         self.nullifier_oracle_threshold
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_json_direct_endpoints() {
+        let json = serde_json::json!({
+            "chain_id": 480,
+            "registry_address": "0x0000000000000000000000000000000000000001",
+            "indexer": { "type": "direct", "url": "http://indexer.example.com" },
+            "gateway": { "type": "direct", "url": "http://gateway.example.com" },
+            "nullifier_oracle_urls": [],
+            "nullifier_oracle_threshold": 2
+        });
+
+        let config = Config::from_json(&json.to_string()).unwrap();
+        assert!(matches!(config.indexer(), ServiceEndpoint::Direct { .. }));
+        assert!(matches!(config.gateway(), ServiceEndpoint::Direct { .. }));
+        assert_eq!(config.indexer_url(), "http://indexer.example.com");
+        assert_eq!(config.gateway_url(), "http://gateway.example.com");
+    }
+
+    #[test]
+    fn from_json_ohttp_endpoints() {
+        let json = serde_json::json!({
+            "chain_id": 480,
+            "registry_address": "0x0000000000000000000000000000000000000001",
+            "indexer": {
+                "type": "ohttp",
+                "url": "http://indexer.example.com",
+                "relay_url": "https://relay.example.com/gateway",
+                "key_config_base64": "dGVzdC1rZXk="
+            },
+            "gateway": {
+                "type": "ohttp",
+                "url": "http://gateway.example.com",
+                "relay_url": "https://relay.example.com/gateway",
+                "key_config_base64": "dGVzdC1rZXk="
+            },
+            "nullifier_oracle_urls": [],
+            "nullifier_oracle_threshold": 2
+        });
+
+        let config = Config::from_json(&json.to_string()).unwrap();
+        match config.indexer() {
+            ServiceEndpoint::Ohttp {
+                url,
+                relay_url,
+                key_config_base64,
+            } => {
+                assert_eq!(url, "http://indexer.example.com");
+                assert_eq!(relay_url, "https://relay.example.com/gateway");
+                assert_eq!(key_config_base64, "dGVzdC1rZXk=");
+            }
+            other => panic!("expected Ohttp variant, got: {other:?}"),
+        }
+        match config.gateway() {
+            ServiceEndpoint::Ohttp {
+                url,
+                relay_url,
+                key_config_base64,
+            } => {
+                assert_eq!(url, "http://gateway.example.com");
+                assert_eq!(relay_url, "https://relay.example.com/gateway");
+                assert_eq!(key_config_base64, "dGVzdC1rZXk=");
+            }
+            other => panic!("expected Ohttp variant, got: {other:?}"),
+        }
     }
 }

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -29,7 +29,7 @@ pub use key_set::{
 
 /// Contains the global configuration for interacting with the World ID Protocol.
 mod config;
-pub use config::Config;
+pub use config::{Config, ServiceEndpoint};
 
 /// SAFE-style sponge utilities and helpers.
 pub mod sponge;

--- a/services/gateway/tests/test_inflight.rs
+++ b/services/gateway/tests/test_inflight.rs
@@ -6,7 +6,7 @@ use eddsa_babyjubjub::{EdDSAPrivateKey, EdDSAPublicKey};
 use reqwest::StatusCode;
 use world_id_authenticator::{Authenticator, AuthenticatorError, OnchainKeyRepresentable};
 use world_id_primitives::{
-    Config, TREE_DEPTH,
+    Config, ServiceEndpoint, TREE_DEPTH,
     api_types::{
         GatewayRequestId, GatewayRequestKind, GatewayStatusResponse, RecoverAccountRequest,
     },
@@ -45,8 +45,8 @@ fn make_config(gw: &TestGateway, indexer_url: &str) -> Config {
         Some(gw.rpc_url.clone()),
         gw.chain_id,
         gw.registry_addr,
-        indexer_url.to_string(),
-        gw.base_url.clone(),
+        ServiceEndpoint::direct(indexer_url.to_string()),
+        ServiceEndpoint::direct(gw.base_url.clone()),
         Vec::new(),
         2,
     )
@@ -80,14 +80,14 @@ async fn register_and_init(
 ) -> (Authenticator, MutableIndexerStub) {
     ensure_crypto_provider();
     let config = make_config(gw, "http://127.0.0.1:0");
-    let initializing = Authenticator::register(&seed, config.into(), recovery_address)
+    let initializing = Authenticator::register(&seed, config, recovery_address)
         .await
         .expect("register failed");
     wait_for_finalized(&gw.client, &gw.base_url, initializing.request_id()).await;
 
     let (pubkey, _) = derive_keys_from_seed(seed);
     let tmp_config = make_config(gw, "http://127.0.0.1:0");
-    let auth = Authenticator::init(&seed, tmp_config.into())
+    let auth = Authenticator::init(&seed, tmp_config)
         .await
         .expect("init failed after register");
 
@@ -98,7 +98,7 @@ async fn register_and_init(
         .expect("failed to spawn indexer stub");
 
     let config = make_config(gw, &stub.url);
-    let auth = Authenticator::init(&seed, config.into())
+    let auth = Authenticator::init(&seed, config)
         .await
         .expect("init with indexer stub failed");
 
@@ -269,7 +269,7 @@ async fn test_lock_created_on_submit() {
     let seed: [u8; 32] = rand::random();
     let (_, addr) = derive_keys_from_seed(seed);
     let config = make_config(&gw, "http://127.0.0.1:0");
-    let _initializing = Authenticator::register(&seed, config.into(), None)
+    let _initializing = Authenticator::register(&seed, config, None)
         .await
         .expect("register failed");
     let auth_key = format!("gateway:inflight:create:{addr}");
@@ -349,7 +349,7 @@ async fn test_lock_removed_after_finalization() {
     let seed: [u8; 32] = rand::random();
     let (_, addr) = derive_keys_from_seed(seed);
     let config = make_config(&gw, "http://127.0.0.1:0");
-    let initializing = Authenticator::register(&seed, config.into(), None)
+    let initializing = Authenticator::register(&seed, config, None)
         .await
         .expect("register failed");
     wait_for_finalized(&gw.client, &gw.base_url, initializing.request_id()).await;

--- a/services/oprf-dev-client/src/lib.rs
+++ b/services/oprf-dev-client/src/lib.rs
@@ -186,8 +186,8 @@ pub async fn init_authenticator(
         Some(config.chain_rpc_url.expose_secret().to_string()),
         if anvil { 31_337 } else { 480 },
         world_id_registry_contract,
-        indexer_url.clone(),
-        gateway_url.clone(),
+        world_id_primitives::ServiceEndpoint::direct(indexer_url.clone()),
+        world_id_primitives::ServiceEndpoint::direct(gateway_url.clone()),
         config.nodes.clone(),
         config.threshold,
     )
@@ -198,7 +198,7 @@ pub async fn init_authenticator(
 
     tracing::info!("creating account..");
     let seed = [7u8; 32];
-    let authenticator = Authenticator::init_or_register(&seed, world_config.into(), None)
+    let authenticator = Authenticator::init_or_register(&seed, world_config, None)
         .await?
         .with_proof_materials(query_material, Arc::new(nullifier_material));
     let authenticator_private_key = EdDSAPrivateKey::from_bytes(seed);

--- a/tools/generate-solidity-fixtures/src/main.rs
+++ b/tools/generate-solidity-fixtures/src/main.rs
@@ -124,13 +124,10 @@ async fn main() -> Result<()> {
         3,
     )
     .unwrap();
-    let _authenticator = Authenticator::init_or_register(
-        &seed,
-        creation_config.clone(),
-        Some(recovery_address),
-    )
-    .await
-    .unwrap();
+    let _authenticator =
+        Authenticator::init_or_register(&seed, creation_config.clone(), Some(recovery_address))
+            .await
+            .unwrap();
 
     let authenticator = Authenticator::init(&seed, creation_config)
         .await

--- a/tools/generate-solidity-fixtures/src/main.rs
+++ b/tools/generate-solidity-fixtures/src/main.rs
@@ -35,7 +35,8 @@ use world_id_gateway::{
     BatchPolicyConfig, GatewayConfig, SignerArgs, defaults, spawn_gateway_for_tests,
 };
 use world_id_primitives::{
-    Config, FieldElement, SessionFieldElement, SessionId, TREE_DEPTH, merkle::AccountInclusionProof,
+    Config, FieldElement, ServiceEndpoint, SessionFieldElement, SessionId, TREE_DEPTH,
+    merkle::AccountInclusionProof,
 };
 use world_id_test_utils::{
     anvil::WorldIDVerifier,
@@ -117,21 +118,21 @@ async fn main() -> Result<()> {
         Some(anvil.endpoint().to_string()),
         anvil.instance.chain_id(),
         world_id_registry,
-        "http://127.0.0.1:0".to_string(),
-        format!("http://127.0.0.1:{gw_port}"),
+        ServiceEndpoint::direct("http://127.0.0.1:0".to_string()),
+        ServiceEndpoint::direct(format!("http://127.0.0.1:{gw_port}")),
         Vec::new(),
         3,
     )
     .unwrap();
     let _authenticator = Authenticator::init_or_register(
         &seed,
-        creation_config.clone().into(),
+        creation_config.clone(),
         Some(recovery_address),
     )
     .await
     .unwrap();
 
-    let authenticator = Authenticator::init(&seed, creation_config.into())
+    let authenticator = Authenticator::init(&seed, creation_config)
         .await
         .wrap_err("expected authenticator to initialize after account creation")?;
 
@@ -226,15 +227,15 @@ async fn main() -> Result<()> {
         Some(anvil.endpoint().to_string()),
         anvil.instance.chain_id(),
         world_id_registry,
-        indexer_url.clone(),
-        format!("http://127.0.0.1:{gw_port}"),
+        ServiceEndpoint::direct(indexer_url.clone()),
+        ServiceEndpoint::direct(format!("http://127.0.0.1:{gw_port}")),
         nodes.to_vec(),
         3,
     )
     .unwrap();
 
     let (query_material, nullifier_material) = load_embedded_materials();
-    let authenticator = Authenticator::init(&seed, proof_config.into())
+    let authenticator = Authenticator::init(&seed, proof_config)
         .await
         .wrap_err("failed to reinitialize authenticator with proof config")?
         .with_proof_materials(query_material, nullifier_material);


### PR DESCRIPTION
## Summary
General goal: Move the OHTTP config into the shared `Config` struct, to make the overal config structure less confusing

- Replaces the flat `indexer_url` / `gateway_url` `String` fields on `Config` with a `ServiceEndpoint` enum that captures the transport choice explicitly: `Direct { url }` or `Ohttp { url, relay_url, key_config_base64 }`. The URL is required in both variants; OHTTP-specific fields only exist in the `Ohttp` variant.
- Removes `AuthenticatorConfig` and its lossy `From<Config>` conversion. `Authenticator::init` / `register` / `init_or_register` now take `Config` directly. This eliminates the seam that silently dropped OHTTP relay configuration on conversion (see walletkit `init_with_defaults` regression).
- `OhttpClientConfig` is retained as the runtime input to `OhttpClient::new`; `ServiceClient::new` now takes `&ServiceEndpoint` and builds the OHTTP client only for the `Ohttp` variant.
- JSON shape on `Config::from_json` becomes internally-tagged: `{ "indexer": { "type": "direct", "url": "..." }, "gateway": { "type": "ohttp", "url": "...", "relay_url": "...", "key_config_base64": "..." } }`. Walletkit's defaults JSON will need to be updated alongside the version bump (tracked separately).

## Breaking changes

- `Config::new` signature: `indexer_url: String, gateway_url: String` -> `indexer: ServiceEndpoint, gateway: ServiceEndpoint`.
- `AuthenticatorConfig` removed. Callers pass `Config` directly to `Authenticator::*`.
- `Config::indexer_url()` / `gateway_url()` now return `&str` (convenience accessors over the variant URL). The full endpoint is available via `Config::indexer()` / `gateway()`.
- `Config` JSON shape changed for the indexer/gateway fields (see Summary).