### PR TITLE
chore: deploy arc testnet state bridge

### DIFF
--- a/contracts/deployments/crosschain/staging.json
+++ b/contracts/deployments/crosschain/staging.json
@@ -22,5 +22,19 @@
       "implementation": "0xc8270816a943d68369133FeEe500C54BC44C2BeE",
       "proxy": "0xcC72Ca7BfB5E55613505EceBB6C97dA5E1131E21"
     }
+  },
+  "arcTestnet": {
+    "chainId": 5042002,
+    "deployer": "0x0393cdfC3957dba7Cb143DDaA564D6cE9Ed0BB19",
+    "gateways": {
+      "permissionedGateway": "0x2940Ce2f0f852230Cde632e203D327513b090206"
+    },
+    "tag": "world-id-core-v0.10.2-11-g4fa80cb",
+    "timestamp": 1778715705,
+    "verifier": "0x0fdB202F2228C732e0662fa48F6c5C382489216f",
+    "worldIDSatellite": {
+      "implementation": "0x2dDeF03a67f1DbD7de4151F5f8be5b278A879F37",
+      "proxy": "0x304E14e4dC0508C0927e3b307a2C18422C07E394"
+    }
   }
 }

--- a/contracts/script/crosschain/DeployTempo.s.sol
+++ b/contracts/script/crosschain/DeployTempo.s.sol
@@ -23,6 +23,7 @@ contract DeployTempo is Script {
         uint64 minExpThreshold = 18000;
 
         uint256 pk = vm.envUint("PRIVATE_KEY");
+        address broadcaster = vm.addr(pk);
 
         vm.startBroadcast(pk);
 
@@ -55,6 +56,11 @@ contract DeployTempo is Script {
         // 5. Authorize gateway
         console2.log("  Authorizing gateway...");
         WorldIDSatellite(address(proxy)).addGateway(address(gateway));
+
+        if (owner != broadcaster) {
+            console2.log("  Transferring ownership...");
+            WorldIDSatellite(address(proxy)).transferOwnership(owner);
+        }
 
         vm.stopBroadcast();
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Updates deployment state for a new chain and tweaks deployment scripting to conditionally transfer contract ownership, which could affect who controls newly deployed proxies if misconfigured.
> 
> **Overview**
> Adds an `arcTestnet` entry to `contracts/deployments/crosschain/staging.json` with the deployed `Verifier`, `WorldIDSatellite` (impl/proxy), and `permissionedGateway` addresses.
> 
> Updates `DeployTempo.s.sol` to derive the broadcast address from `PRIVATE_KEY` and **conditionally transfer `WorldIDSatellite` proxy ownership** to the configured `owner` after authorizing the gateway.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50647f244fee5ae7835420ec272be02afd24a67f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->