### PR TITLE
feat: expose validate_constraints on ProofRequest for pre-flight checks

### DIFF
--- a/crates/primitives/src/request/mod.rs
+++ b/crates/primitives/src/request/mod.rs
@@ -512,6 +512,30 @@ impl ProofRequest {
         matches!(self.proof_type, ProofType::CreateSession)
     }
 
+    /// Validates the structural integrity of the constraint expression.
+    ///
+    /// Checks that the constraint tree (when present) does not exceed the maximum
+    /// nesting depth of 2 or the maximum node count. This is the same check
+    /// performed inside [`validate_response`]; exposing it separately allows
+    /// callers to pre-flight a request before attempting proof generation.
+    ///
+    /// # Errors
+    /// Returns [`ValidationError::ConstraintTooDeep`] or [`ValidationError::ConstraintTooLarge`]
+    /// if the expression exceeds protocol limits.
+    ///
+    /// [`validate_response`]: Self::validate_response
+    pub fn validate_constraints(&self) -> Result<(), ValidationError> {
+        if let Some(expr) = &self.constraints {
+            if !expr.validate_max_depth(2) {
+                return Err(ValidationError::ConstraintTooDeep);
+            }
+            if !expr.validate_max_nodes(MAX_CONSTRAINT_NODES) {
+                return Err(ValidationError::ConstraintTooLarge);
+            }
+        }
+        Ok(())
+    }
+
     /// Validate that a response satisfies this request: id match and constraints semantics.
     ///
     /// # Errors
@@ -606,12 +630,7 @@ impl ProofRequest {
                 Ok(())
             }
             Some(expr) => {
-                if !expr.validate_max_depth(2) {
-                    return Err(ValidationError::ConstraintTooDeep);
-                }
-                if !expr.validate_max_nodes(MAX_CONSTRAINT_NODES) {
-                    return Err(ValidationError::ConstraintTooLarge);
-                }
+                self.validate_constraints()?;
                 if expr.evaluate(&|t| provided.contains(t)) {
                     Ok(())
                 } else {


### PR DESCRIPTION
## Why
Clients (e.g. walletkit) need to validate a proof request's constraint expression before attempting proof generation. The same depth/node-count checks inside `validate_response` were not accessible as a standalone call.

## What
- New `validate_constraints` method on `ProofRequest`
- `validate_response` delegates to it — no behavior change
- All 30 existing tests pass

## Risk
Low — refactor only inside `validate_response`; new method is purely additive.