### PR TITLE
fix: Change fillers order to make ours a winner for gas_limit.

### DIFF
--- a/services/common/src/provider.rs
+++ b/services/common/src/provider.rs
@@ -373,8 +373,8 @@ impl ProviderArgs {
 
         let provider = if let Some(signer) = maybe_signer {
             let provider = ProviderBuilder::default()
-                .filler(GasEstimateWithFallbackFiller)
-                .with_gas_estimation()
+                .with_gas_estimation() // It is important to have default run first
+                .filler(GasEstimateWithFallbackFiller) // And then our custom filler
                 .with_blob_gas_estimation()
                 .with_nonce_management(nonce_manager)
                 .fetch_chain_id()


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes transaction filling order for signed providers, which can alter computed `gas_limit` and transaction submission behavior across services.
> 
> **Overview**
> Reorders `ProviderBuilder` configuration for signed HTTP providers so `.with_gas_estimation()` runs before `GasEstimateWithFallbackFiller`, ensuring the custom filler applies last (and can override `gas_limit`) while keeping blob gas estimation, nonce management, and chain-id/wallet setup unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e102647d71e95546bc478175ff40c6a35131d3c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->