### PR TITLE
chore: deploy tempo, base, and world chain prod bridge

### DIFF
--- a/contracts/deployments/crosschain/production.json
+++ b/contracts/deployments/crosschain/production.json
@@ -1,0 +1,40 @@
+{
+  "worldchain": {
+    "chainId": 480,
+    "deployer": "0x0393cdfC3957dba7Cb143DDaA564D6cE9Ed0BB19",
+    "tag": "world-id-core-v0.10.2-13-g0902d9d",
+    "timestamp": 1778800213,
+    "worldIDSource": {
+      "implementation": "0xde234F3479De16fA695BC17B4208b53E6DCf6f09",
+      "proxy": "0x12E8f92fE5901c17341E4A445F6CF991fFc2909E"
+    }
+  },
+  "base": {
+    "chainId": 8453,
+    "deployer": "0x0393cdfC3957dba7Cb143DDaA564D6cE9Ed0BB19",
+    "gateways": {
+      "permissionedGateway": "0x087DC354aDD2B37C7c713568CE126aB657F02962"
+    },
+    "tag": "world-id-core-v0.10.2-13-g0902d9d",
+    "timestamp": 1778800213,
+    "verifier": "0xF4A6ED193B0aE63270cd8703aed142bFcaf7F685",
+    "worldIDSatellite": {
+      "implementation": "0x36BdEe5366D9C5e672A58Fce9330F7349dCDeD15",
+      "proxy": "0x8127DB9301683553a2610a046dE24dde741A1B80"
+    }
+  },
+  "tempo": {
+    "chainId": 4217,
+    "deployer": "0x0393cdfC3957dba7Cb143DDaA564D6cE9Ed0BB19",
+    "gateways": {
+      "permissionedGateway": "0xA10aeA79C07d42fBd315cA1aD6b0E59454c20250"
+    },
+    "tag": "world-id-core-v0.10.2-13-g0902d9d",
+    "timestamp": 1778800214,
+    "verifier": "0x0A3B9e4531cB72112d0877684D9dD5ce49D6DD85",
+    "worldIDSatellite": {
+      "implementation": "0x68CD02688FAedeC8CF63eE12fbe8743Ffb30bffA",
+      "proxy": "0x0E874EAf3c634f1b3C74Ca56B56C8b0B24f3c1DE"
+    }
+  }
+}

--- a/contracts/script/crosschain/config/production.json
+++ b/contracts/script/crosschain/config/production.json
@@ -1,0 +1,41 @@
+{
+  "owner": "0x6348A4a4dF173F68eB28A452Ca6c13493e447aF1",
+  "bridgeName": "WorldID Bridge",
+  "bridgeVersion": "1.0.0",
+  "rootValidityWindow": 3600,
+  "treeDepth": 30,
+  "minExpirationThreshold": 18000,
+
+  "salts": {
+    "worldIDSource": "0x0000000000000000000000000000000000000000000000000000000000002111",
+    "worldIDSatellite": "0x0000000000000000000000000000000000000000000000000000000000002200",
+    "ownedGateway": "0x0000000000000000000000000000000000000000000000000000000000002300",
+    "l1Gateway": "0x0000000000000000000000000000000000000000000000000000000000002400",
+    "zkGateway": "0x0000000000000000000000000000000000000000000000000000000000002500",
+    "verifier": "0x0000000000000000000000000000000000000000000000000000000000002600"
+  },
+
+  "worldchain": {
+    "chainId": 480,
+    "alchemySlug": "worldchain-mainnet",
+    "registry": "0x0000000000aE079eB8a274cD51c0f44a9E4d67d4",
+    "issuerRegistry": "0x941239840F4d9668da8be76b568e836b50685d2c",
+    "oprfRegistry": "0x0D8b461799474207A3d223553d4d5e6609cb0c69"
+  },
+
+  "networks": ["base", "tempo"],
+
+  "base": {
+    "chainId": 8453,
+    "alchemySlug": "base-mainnet",
+    "verifier": "0x0000000000000000000000000000000000000000",
+    "ownedGateway": {}
+  },
+
+  "tempo": {
+    "chainId": 4217,
+    "alchemySlug": "tempo-mainnet",
+    "verifier": "0x0000000000000000000000000000000000000000",
+    "ownedGateway": {}
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it introduces new production network configuration and contract addresses that downstream scripts/tools may consume; incorrect values could misroute or break bridge interactions.
> 
> **Overview**
> Adds new `production.json` files for the cross-chain bridge, recording **production deployment addresses** (source/satellite proxies & implementations, verifiers, and permissioned gateways) for `worldchain`, `base`, and `tempo`.
> 
> Introduces the corresponding **production script config** (`owner`, bridge metadata, validity/expiration parameters, deterministic `salts`, and per-network RPC slugs/registries) for deploying/operating the bridge across `base` and `tempo` anchored to `worldchain`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f40f7476a20bb37942d1bde67650828b903bf896. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->