### PR TITLE
chore: add relay to release

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -9,6 +9,7 @@ on:
       - 'world-id-indexer-v*'
       - 'world-id-gateway-v*'
       - 'world-id-oprf-node-v*'
+      - 'world-id-relay-v*'
   workflow_dispatch:
 
 permissions:
@@ -28,13 +29,15 @@ jobs:
           REF_NAME: ${{ github.ref_name }}
         run: |
           if [[ "$REF_TYPE" == "branch" ]]; then
-            echo 'services=["indexer","gateway","oprf-node"]' >> "$GITHUB_OUTPUT"
+            echo 'services=["indexer","gateway","oprf-node","relay"]' >> "$GITHUB_OUTPUT"
           elif [[ "$REF_NAME" == world-id-indexer-v* ]]; then
             echo 'services=["indexer"]' >> "$GITHUB_OUTPUT"
           elif [[ "$REF_NAME" == world-id-gateway-v* ]]; then
             echo 'services=["gateway"]' >> "$GITHUB_OUTPUT"
           elif [[ "$REF_NAME" == world-id-oprf-node-v* ]]; then
             echo 'services=["oprf-node"]' >> "$GITHUB_OUTPUT"
+          elif [[ "$REF_NAME" == world-id-relay-v* ]]; then
+            echo 'services=["relay"]' >> "$GITHUB_OUTPUT"
           else
             echo 'services=[]' >> "$GITHUB_OUTPUT"
           fi

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -84,3 +84,11 @@ release = true
 publish = false
 changelog_update = false
 git_release_enable = true
+
+
+[[package]]
+name = "world-id-relay"
+release = true
+publish = false
+changelog_update = false
+git_release_enable = true


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: this only updates CI/release configuration to add `world-id-relay` to existing tag/build automation, without touching service runtime code.
> 
> **Overview**
> Adds `world-id-relay` to the release/build automation.
> 
> The Docker build workflow now triggers on `world-id-relay-v*` tags and includes `relay` in the main-branch build matrix, and `release-plz.toml` now defines `world-id-relay` as a GitHub-released (non-published) package.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c8932afac7b2c16773fbe17768f7dd434adf074. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->