### PR TITLE
fix: Improve Registry Version Probe

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -395,9 +395,7 @@ jobs:
 
       - name: Run Docker container
         run: |
-          # We run the http-only mode to avoid having to set up the RPC provider.
-          # RPC_MAX_RETRIES=0 disables RPC retries so gateway fails fast on start-up.
-          docker run -d --network host --env-file services/${{ matrix.service }}/.env.example --env LISTEN_ADDR=0.0.0.0:8080 --env RUN_MODE=http-only --env RPC_MAX_RETRIES=0 --name ${{ matrix.service }}-container ${{ matrix.service }}:latest
+          docker run -d --network host --env-file services/${{ matrix.service }}/.env.example --env LISTEN_ADDR=0.0.0.0:8080 ${{ matrix.service == 'gateway' && '--env REGISTRY_VERSION=v1' || '--env RUN_MODE=http-only' }} --env RPC_MAX_RETRIES=0 --name ${{ matrix.service }}-container ${{ matrix.service }}:latest
 
           # Wait for the application to start
           sleep 10

--- a/crates/core/tests/authenticator_registration.rs
+++ b/crates/core/tests/authenticator_registration.rs
@@ -27,6 +27,7 @@ async fn test_authenticator_registration() {
     let signer_args = SignerArgs::from_wallet(hex::encode(deployer.to_bytes()));
     let gateway_config = GatewayConfig {
         registry_addr: registry_address,
+        registry_version: None,
         provider: world_id_gateway::ProviderArgs {
             http: Some(vec![anvil.endpoint().parse().unwrap()]),
             signer: Some(signer_args),

--- a/crates/core/tests/e2e_authenticator_insert_update_remove.rs
+++ b/crates/core/tests/e2e_authenticator_insert_update_remove.rs
@@ -109,6 +109,7 @@ async fn e2e_authenticator_insert_update_remove() {
     let signer_args = SignerArgs::from_wallet(hex::encode(deployer.to_bytes()));
     let gateway_config = GatewayConfig {
         registry_addr: registry_address,
+        registry_version: None,
         provider: world_id_gateway::ProviderArgs {
             http: Some(vec![anvil.endpoint().parse().unwrap()]),
             signer: Some(signer_args),

--- a/crates/core/tests/generate_proof.rs
+++ b/crates/core/tests/generate_proof.rs
@@ -87,6 +87,7 @@ async fn e2e_authenticator_generate_proof() -> Result<()> {
     let signer_args = SignerArgs::from_wallet(hex::encode(deployer.to_bytes()));
     let gateway_config = GatewayConfig {
         registry_addr: world_id_registry,
+        registry_version: None,
         provider: world_id_gateway::ProviderArgs {
             http: Some(vec![anvil.endpoint().parse().unwrap()]),
             signer: Some(signer_args),

--- a/services/gateway/src/config.rs
+++ b/services/gateway/src/config.rs
@@ -4,7 +4,10 @@ use alloy::primitives::Address;
 use clap::Parser;
 use world_id_services_common::ProviderArgs;
 
-use crate::error::{GatewayError, GatewayResult};
+use crate::{
+    error::{GatewayError, GatewayResult},
+    registry_version::RegistryVersion,
+};
 
 pub mod defaults {
     pub const MAX_CREATE_BATCH_SIZE: usize = 100;
@@ -102,6 +105,10 @@ pub struct GatewayConfig {
     /// The address of the `WorldIDRegistry` contract
     #[arg(long, env = "REGISTRY_ADDRESS")]
     pub registry_addr: Address,
+
+    /// Override registry version detection. If omitted, the gateway probes the registry on startup.
+    #[arg(long, env = "REGISTRY_VERSION")]
+    pub registry_version: Option<RegistryVersion>,
 
     /// The HTTP RPC endpoint to submit transactions
     #[command(flatten)]
@@ -291,6 +298,18 @@ mod tests {
     fn parse_valid_config() -> GatewayConfig {
         parse_with_signer_args(&["--wallet-private-key", TEST_PRIVATE_KEY])
             .expect("valid config should parse")
+    }
+
+    #[test]
+    fn registry_version_override_parses() {
+        let config = parse_with_signer_args(&[
+            "--wallet-private-key",
+            TEST_PRIVATE_KEY,
+            "--registry-version",
+            "v2",
+        ])
+        .expect("valid config should parse");
+        assert_eq!(config.registry_version, Some(RegistryVersion::V2));
     }
 
     #[test]

--- a/services/gateway/src/lib.rs
+++ b/services/gateway/src/lib.rs
@@ -36,7 +36,7 @@ async fn registry_version_from_config(
 ) -> GatewayResult<RegistryVersion> {
     match registry_version {
         Some(registry_version) => {
-            tracing::warn!(
+            tracing::info!(
                 ?registry_version,
                 "registry version override set; skipping startup probe"
             );

--- a/services/gateway/src/lib.rs
+++ b/services/gateway/src/lib.rs
@@ -8,6 +8,7 @@ pub use crate::{
     request_tracker::{RequestRecord, RequestTracker, now_unix_secs},
 };
 use crate::{registry_version::probe, routes::build_app, types::AppState};
+use alloy::{primitives::Address, providers::DynProvider};
 use std::{backtrace::Backtrace, net::SocketAddr, sync::Arc};
 use tokio::sync::oneshot;
 use world_id_registries::world_id::WorldIdRegistry::WorldIdRegistryInstance;
@@ -27,6 +28,23 @@ mod types;
 // Re-export common types
 pub use crate::error::{GatewayError, GatewayResult};
 pub use world_id_services_common::{ProviderArgs, SignerArgs, SignerConfig};
+
+async fn registry_version_from_config(
+    registry_version: Option<RegistryVersion>,
+    registry_addr: Address,
+    provider: Arc<DynProvider>,
+) -> GatewayResult<RegistryVersion> {
+    match registry_version {
+        Some(registry_version) => {
+            tracing::warn!(
+                ?registry_version,
+                "registry version override set; skipping startup probe"
+            );
+            Ok(registry_version)
+        }
+        None => probe(provider, registry_addr).await,
+    }
+}
 
 #[derive(Debug)]
 pub struct GatewayHandle {
@@ -57,7 +75,9 @@ pub async fn spawn_gateway_for_tests(cfg: GatewayConfig) -> GatewayResult<Gatewa
         cfg.registry_addr,
         provider.clone(),
     ));
-    let registry_version = probe(provider.clone(), cfg.registry_addr).await?;
+    let registry_version =
+        registry_version_from_config(cfg.registry_version, cfg.registry_addr, provider.clone())
+            .await?;
     let app = build_app(
         registry,
         registry_version,
@@ -113,7 +133,9 @@ pub async fn run() -> GatewayResult<()> {
         cfg.registry_addr,
         provider.clone(),
     ));
-    let registry_version = probe(provider.clone(), cfg.registry_addr).await?;
+    let registry_version =
+        registry_version_from_config(cfg.registry_version, cfg.registry_addr, provider.clone())
+            .await?;
 
     tracing::info!("Config is ready. Building app...");
     let app = build_app(

--- a/services/gateway/src/registry_version.rs
+++ b/services/gateway/src/registry_version.rs
@@ -16,15 +16,28 @@ pub enum RegistryVersion {
     V2,
 }
 
-/// Probes `MAX_AUTHENTICATORS_V2_HARD_LIMIT()` — a V2-only public constant (WIP-104).
-/// Success means V2.
+impl std::str::FromStr for RegistryVersion {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value.to_ascii_lowercase().as_str() {
+            "v1" | "1" => Ok(Self::V1),
+            "v2" | "2" => Ok(Self::V2),
+            _ => Err(format!(
+                "invalid registry version: {value}; expected v1 or v2"
+            )),
+        }
+    }
+}
+
+/// Probes a common V1/V2 selector first, then a V2-only selector.
+/// Common selector failure means the registry/RPC path is broken; V2 selector failure means V1.
 pub async fn probe(
     provider: Arc<DynProvider>,
     proxy_addr: Address,
 ) -> GatewayResult<RegistryVersion> {
     let v2 = WorldIdRegistryV2Instance::new(proxy_addr, provider);
 
-    //  Call constant available on v1 and v2 to check connection
     if let Err(err) = v2.MAX_AUTHENTICATORS_HARD_LIMIT().call().await {
         warn!(error = ?err, "registry baseline probe failed");
         return Err(GatewayError::Config(format!(
@@ -32,7 +45,6 @@ pub async fn probe(
         )));
     }
 
-    // Call v2 function to assess if upgrade happened
     match v2.MAX_AUTHENTICATORS_V2_HARD_LIMIT().call().await {
         Ok(_) => {
             info!("registry version detected: V2");

--- a/services/gateway/src/registry_version.rs
+++ b/services/gateway/src/registry_version.rs
@@ -4,16 +4,11 @@
 
 use std::sync::Arc;
 
-use alloy::{contract::Error as ContractError, primitives::Address, providers::DynProvider};
+use alloy::{primitives::Address, providers::DynProvider};
 use tracing::{info, warn};
 use world_id_registries::world_id::WorldIdRegistryV2::WorldIdRegistryV2Instance;
 
 use crate::error::{GatewayError, GatewayResult};
-
-fn http_only_run_mode() -> bool {
-    std::env::var("RUN_MODE")
-        .is_ok_and(|value| matches!(value.to_ascii_lowercase().as_str(), "http" | "http-only"))
-}
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum RegistryVersion {
@@ -28,32 +23,63 @@ pub async fn probe(
     proxy_addr: Address,
 ) -> GatewayResult<RegistryVersion> {
     let v2 = WorldIdRegistryV2Instance::new(proxy_addr, provider);
+
+    //  Call constant available on v1 and v2 to check connection
+    if let Err(err) = v2.MAX_AUTHENTICATORS_HARD_LIMIT().call().await {
+        warn!(error = ?err, "registry baseline probe failed");
+        return Err(GatewayError::Config(format!(
+            "failed to probe registry version: baseline selector failed: {err}"
+        )));
+    }
+
+    // Call v2 function to assess if upgrade happened
     match v2.MAX_AUTHENTICATORS_V2_HARD_LIMIT().call().await {
         Ok(_) => {
             info!("registry version detected: V2");
             Ok(RegistryVersion::V2)
         }
-        Err(err) if is_v2_selector_unavailable(&err) => {
+        Err(err) => {
             warn!(error = ?err, "V2 selector unavailable; defaulting to V1");
             Ok(RegistryVersion::V1)
-        }
-        Err(err) => {
-            if http_only_run_mode() {
-                warn!(
-                    error = ?err,
-                    "registry version probe failed in http-only mode; defaulting to V1"
-                );
-                Ok(RegistryVersion::V1)
-            } else {
-                warn!(error = ?err, "registry version probe failed");
-                Err(GatewayError::Config(format!(
-                    "failed to probe registry version: {err}"
-                )))
-            }
         }
     }
 }
 
-fn is_v2_selector_unavailable(err: &ContractError) -> bool {
-    matches!(err, ContractError::ZeroData(_, _)) || err.as_revert_data().is_some()
+#[cfg(test)]
+mod tests {
+    use world_id_test_utils::anvil::TestAnvil;
+
+    use super::*;
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn probe_detects_v1_on_anvil_registry_proxy() {
+        let anvil = TestAnvil::spawn().expect("failed to spawn anvil");
+        let deployer = anvil.signer(0).expect("failed to fetch deployer signer");
+        let registry_addr = anvil
+            .deploy_world_id_registry(deployer)
+            .await
+            .expect("failed to deploy WorldIDRegistry");
+        let provider = Arc::new(anvil.provider().expect("failed to build anvil provider"));
+
+        assert_eq!(
+            probe(provider, registry_addr).await.unwrap(),
+            RegistryVersion::V1
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn probe_detects_v2_on_anvil_registry_proxy() {
+        let anvil = TestAnvil::spawn().expect("failed to spawn anvil");
+        let deployer = anvil.signer(0).expect("failed to fetch deployer signer");
+        let registry_addr = anvil
+            .deploy_world_id_registry_v2(deployer)
+            .await
+            .expect("failed to deploy WorldIDRegistry V2");
+        let provider = Arc::new(anvil.provider().expect("failed to build anvil provider"));
+
+        assert_eq!(
+            probe(provider, registry_addr).await.unwrap(),
+            RegistryVersion::V2
+        );
+    }
 }

--- a/services/gateway/src/registry_version.rs
+++ b/services/gateway/src/registry_version.rs
@@ -45,6 +45,8 @@ pub async fn probe(
         )));
     }
 
+    info!("registry baseline probe succeeded");
+
     match v2.MAX_AUTHENTICATORS_V2_HARD_LIMIT().call().await {
         Ok(_) => {
             info!("registry version detected: V2");

--- a/services/gateway/tests/common.rs
+++ b/services/gateway/tests/common.rs
@@ -90,6 +90,7 @@ async fn spawn_test_gateway_for_registry(
     let cfg = match batch_ms {
         None => GatewayConfig {
             registry_addr,
+            registry_version: None,
             provider: ProviderArgs {
                 http: Some(vec![rpc_url.parse().unwrap()]),
                 signer: Some(signer_args),
@@ -112,6 +113,7 @@ async fn spawn_test_gateway_for_registry(
             let reeval_ms = ms.min(200);
             GatewayConfig {
                 registry_addr,
+                registry_version: None,
                 provider: ProviderArgs {
                     http: Some(vec![rpc_url.parse().unwrap()]),
                     signer: Some(signer_args),

--- a/services/gateway/tests/test_orphan_sweeper.rs
+++ b/services/gateway/tests/test_orphan_sweeper.rs
@@ -684,6 +684,7 @@ async fn sweep_submitted_with_real_receipt() {
     let signer_args = SignerArgs::from_wallet(GW_PRIVATE_KEY.to_string());
     let cfg = GatewayConfig {
         registry_addr,
+        registry_version: None,
         provider: ProviderArgs {
             http: Some(vec![rpc_url.parse().unwrap()]),
             signer: Some(signer_args),

--- a/services/gateway/tests/test_rate_limiting.rs
+++ b/services/gateway/tests/test_rate_limiting.rs
@@ -62,6 +62,7 @@ async fn test_rate_limit_basic() {
     let signer_args = SignerArgs::from_wallet(GW_PRIVATE_KEY.to_string());
     let cfg = GatewayConfig {
         registry_addr,
+        registry_version: None,
         provider: ProviderArgs {
             http: Some(vec![rpc_url.parse().unwrap()]),
             signer: Some(signer_args),
@@ -269,6 +270,7 @@ async fn test_rate_limit_different_leaf_indexes() {
     let signer_args = SignerArgs::from_wallet(GW_PRIVATE_KEY.to_string());
     let cfg = GatewayConfig {
         registry_addr,
+        registry_version: None,
         provider: ProviderArgs {
             http: Some(vec![rpc_url.parse().unwrap()]),
             signer: Some(signer_args),
@@ -425,6 +427,7 @@ async fn test_rate_limit_sliding_window() {
     let signer_args = SignerArgs::from_wallet(GW_PRIVATE_KEY.to_string());
     let cfg = GatewayConfig {
         registry_addr,
+        registry_version: None,
         provider: ProviderArgs {
             http: Some(vec![rpc_url.parse().unwrap()]),
             signer: Some(signer_args),
@@ -578,6 +581,7 @@ async fn test_rate_limit_multiple_endpoints() {
     let signer_args = SignerArgs::from_wallet(GW_PRIVATE_KEY.to_string());
     let cfg = GatewayConfig {
         registry_addr,
+        registry_version: None,
         provider: ProviderArgs {
             http: Some(vec![rpc_url.parse().unwrap()]),
             signer: Some(signer_args),

--- a/services/gateway/tests/test_with_redis.rs
+++ b/services/gateway/tests/test_with_redis.rs
@@ -37,6 +37,7 @@ async fn redis_integration() {
     let signer_args = SignerArgs::from_wallet(GW_PRIVATE_KEY.to_string());
     let cfg = GatewayConfig {
         registry_addr,
+        registry_version: None,
         provider: ProviderArgs {
             http: Some(vec![rpc_url.parse().unwrap()]),
             signer: Some(signer_args),

--- a/tools/generate-solidity-fixtures/src/main.rs
+++ b/tools/generate-solidity-fixtures/src/main.rs
@@ -85,6 +85,7 @@ async fn main() -> Result<()> {
     let signer_args = SignerArgs::from_wallet(hex::encode(deployer.to_bytes()));
     let gateway_config = GatewayConfig {
         registry_addr: world_id_registry,
+        registry_version: None,
         provider: world_id_gateway::ProviderArgs {
             http: Some(vec![anvil.endpoint().parse().unwrap()]),
             signer: Some(signer_args),


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes startup-time registry probing behavior by defaulting to `V1` on any failure of the V2-only selector (after a baseline call succeeds), which could mask unexpected contract/provider errors and alter how misconfigurations surface.
> 
> **Overview**
> Improves the WorldIDRegistry version probe by first calling a v1/v2-shared constant to fail fast on connectivity/ABI issues, then treating any failure of the v2-only `MAX_AUTHENTICATORS_V2_HARD_LIMIT` call as “assume V1” (removing the prior `RUN_MODE`-based special-casing).
> 
> Adds Anvil-based integration tests to verify `probe` detects both v1 and v2 deployments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9b257e3ec8081cb9449fc539e461c7a8ff638fb. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->