### PR TITLE
fix: world-id-relay release binaries

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -84,11 +84,3 @@ release = true
 publish = false
 changelog_update = false
 git_release_enable = true
-
-
-[[package]]
-name = "world-id-relay"
-release = true
-publish = false
-changelog_update = false
-git_release_enable = true

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -84,3 +84,11 @@ release = true
 publish = false
 changelog_update = false
 git_release_enable = true
+
+
+[[package]]
+name = "world-id-relay"
+release = true
+publish = false
+changelog_update = false
+git_release_enable = true

--- a/services/relay/Cargo.toml
+++ b/services/relay/Cargo.toml
@@ -59,3 +59,7 @@ rand = { workspace = true }
 world-id-primitives = { workspace = true }
 world-id-relay = { workspace = true }
 world-id-test-utils = { workspace = true }
+
+[[bin]]
+name = "world-id-relay"
+path = "src/bin/main.rs"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk config-only change affecting release automation and crate metadata; main impact is whether `world-id-relay` gets a GitHub release tag/binary as intended.
> 
> **Overview**
> Adjusts release automation so `release-plz.toml` no longer treats `world-id-relay` as a managed release package.
> 
> Adds an explicit `[[bin]]` target to `services/relay/Cargo.toml` pointing to `src/bin/main.rs`, ensuring the `world-id-relay` executable is built/named correctly for release binaries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b48b637ecf7e190419019b866fbfb07ad5a5a38. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->