### PR TITLE
chore: add simple health probe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12669,6 +12669,7 @@ dependencies = [
  "alloy-primitives",
  "ark-ff 0.5.0",
  "ark-serialize 0.5.0",
+ "axum",
  "clap",
  "config",
  "dashmap",

--- a/services/relay/Cargo.toml
+++ b/services/relay/Cargo.toml
@@ -9,6 +9,9 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
+# http
+axum = { workspace = true }
+
 # alloy
 alloy = { workspace = true, features = [
     "full",

--- a/services/relay/src/cli/mod.rs
+++ b/services/relay/src/cli/mod.rs
@@ -29,6 +29,10 @@ pub struct Cli {
     /// Relay config as a JSON string.
     #[arg(long, env = "RELAY_CONFIG")]
     pub config: String,
+
+    /// Address the health-check HTTP server binds to.
+    #[arg(long, env = "HEALTH_BIND_ADDR", default_value = "0.0.0.0:8081")]
+    pub health_bind_addr: std::net::SocketAddr,
 }
 
 // ---------------------------------------------------------------------------
@@ -323,6 +327,14 @@ impl Cli {
     pub async fn run(self) -> eyre::Result<()> {
         let shutdown = tokio::signal::ctrl_c();
 
+        let health_app = axum::Router::new().route(
+            "/health",
+            axum::routing::get(|| async { axum::http::StatusCode::OK }),
+        );
+        let health_listener = tokio::net::TcpListener::bind(self.health_bind_addr).await?;
+        tracing::info!(addr = %self.health_bind_addr, "starting health check server");
+        let health_server = axum::serve(health_listener, health_app);
+
         let config = parse_config(&self.config)?;
 
         // Build a wallet for relay transactions.
@@ -423,6 +435,7 @@ impl Cli {
 
         tokio::select! {
             result = engine.run() => result,
+            result = health_server => result.map_err(eyre::Report::from),
             _ = shutdown => {
                 tracing::info!("received shutdown signal");
                 Ok(())


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: adds an auxiliary Axum server and a new bind-address option without changing relay/bridging logic; main risk is operational (port binding or unexpected server exit).
> 
> **Overview**
> Adds a simple health probe to `world-id-relay` by introducing an Axum-based HTTP server exposing `GET /health` (returns `200 OK`).
> 
> The server bind address is configurable via `--health-bind-addr`/`HEALTH_BIND_ADDR` (default `0.0.0.0:8081`) and is run concurrently with the relay engine via `tokio::select!`; `axum` is added as a dependency (and reflected in `Cargo.lock`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b123cdf7a971e8b21c367cddc9557f767eaa593. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->