### PR TITLE
feat: add better metrics and telemetry to world-id-state bridge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12678,6 +12678,7 @@ dependencies = [
  "futures",
  "futures-util",
  "hex",
+ "metrics",
  "parking_lot",
  "rand 0.8.5",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12669,6 +12669,7 @@ dependencies = [
  "alloy-primitives",
  "ark-ff 0.5.0",
  "ark-serialize 0.5.0",
+ "axum",
  "clap",
  "config",
  "dashmap",

--- a/services/relay/Cargo.toml
+++ b/services/relay/Cargo.toml
@@ -39,6 +39,7 @@ serde_json = { workspace = true }
 # telemetry
 tracing = { workspace = true }
 telemetry-batteries = { workspace = true }
+metrics = { workspace = true }
 
 # misc
 clap = { workspace = true, features = ["derive", "env"] }

--- a/services/relay/Cargo.toml
+++ b/services/relay/Cargo.toml
@@ -9,6 +9,9 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
+# http
+axum = { workspace = true }
+
 # alloy
 alloy = { workspace = true, features = [
     "full",

--- a/services/relay/src/bin/main.rs
+++ b/services/relay/src/bin/main.rs
@@ -8,6 +8,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     let _guard = telemetry_batteries::init();
+    world_id_relay::metrics::describe_metrics();
 
     tracing::info!("starting world-id-relay");
 

--- a/services/relay/src/cli/chain.rs
+++ b/services/relay/src/cli/chain.rs
@@ -36,6 +36,9 @@ pub struct WorldChain {
 
     /// Block number at which the WorldIDSource contract was deployed.
     deployment_block: u64,
+
+    /// Chain ID of the source chain (label value for per-chain metrics).
+    chain_id: u64,
 }
 
 impl WorldChain {
@@ -60,8 +63,14 @@ impl WorldChain {
             world_id_source: IWorldIDSourceInstance::new(config.world_id_source, provider.clone()),
             bridge_interval: Duration::from_secs(config.bridge_interval),
             deployment_block: config.deployment_block,
+            chain_id: config.chain_id,
             provider,
         }
+    }
+
+    /// Chain ID of the source chain.
+    pub fn chain_id(&self) -> u64 {
+        self.chain_id
     }
 
     pub fn provider(&self) -> &Arc<DynProvider> {

--- a/services/relay/src/cli/chain.rs
+++ b/services/relay/src/cli/chain.rs
@@ -36,9 +36,6 @@ pub struct WorldChain {
 
     /// Block number at which the WorldIDSource contract was deployed.
     deployment_block: u64,
-
-    /// Chain ID of the source chain (label value for per-chain metrics).
-    chain_id: u64,
 }
 
 impl WorldChain {
@@ -63,14 +60,8 @@ impl WorldChain {
             world_id_source: IWorldIDSourceInstance::new(config.world_id_source, provider.clone()),
             bridge_interval: Duration::from_secs(config.bridge_interval),
             deployment_block: config.deployment_block,
-            chain_id: config.chain_id,
             provider,
         }
-    }
-
-    /// Chain ID of the source chain.
-    pub fn chain_id(&self) -> u64 {
-        self.chain_id
     }
 
     pub fn provider(&self) -> &Arc<DynProvider> {

--- a/services/relay/src/cli/mod.rs
+++ b/services/relay/src/cli/mod.rs
@@ -427,14 +427,6 @@ impl Cli {
     pub async fn run(self) -> eyre::Result<()> {
         let shutdown = tokio::signal::ctrl_c();
 
-        let health_app = axum::Router::new().route(
-            "/health",
-            axum::routing::get(|| async { axum::http::StatusCode::OK }),
-        );
-        let health_listener = tokio::net::TcpListener::bind(self.health_bind_addr).await?;
-        tracing::info!(addr = %self.health_bind_addr, "starting health check server");
-        let health_server = axum::serve(health_listener, health_app);
-
         let config = parse_config(&self.config)?;
 
         // Build a wallet for relay transactions.

--- a/services/relay/src/cli/mod.rs
+++ b/services/relay/src/cli/mod.rs
@@ -378,8 +378,8 @@ async fn log_wallet_status<P: Provider>(
 }
 
 /// Spawns a fire-and-forget background task that periodically refreshes the
-/// per-chain wallet `balance_wei` and `nonce` gauges. Intentionally NOT added
-/// to `tokio::select!` / `JoinSet`: this is observability, not business logic,
+/// per-chain wallet `balance_wei` gauge. Intentionally NOT added to
+/// `tokio::select!` / `JoinSet`: this is observability, not business logic,
 /// and a panicking metrics task must never bring down the engine.
 fn spawn_wallet_metrics_task(provider: Arc<DynProvider>, chain_id: u64, wallet_address: Address) {
     tokio::spawn(async move {
@@ -466,8 +466,8 @@ impl Cli {
         .await;
 
         // Spawn a fire-and-forget background task that periodically refreshes
-        // the World Chain wallet `balance_wei` / `nonce` gauges. This MUST
-        // live off the propagate hot path — observability code can never pay
+        // the World Chain wallet `balance_wei` gauge. This MUST live off the
+        // propagate hot path — observability code can never pay
         // network-latency tax on the critical path.
         spawn_wallet_metrics_task(wc_provider.clone(), wc_config.chain_id, wallet_address);
 

--- a/services/relay/src/cli/mod.rs
+++ b/services/relay/src/cli/mod.rs
@@ -7,11 +7,14 @@ use alloy::{
     providers::{DynProvider, Provider, ProviderBuilder},
     signers::local::PrivateKeySigner,
 };
-use alloy_primitives::Address;
+use alloy_primitives::{Address, utils::format_ether};
+use axum::{Router, extract::State, http::StatusCode, routing::get};
 use tempo_alloy::{TempoNetwork, provider::TempoProviderBuilderExt};
 
 use crate::{
     engine::Engine,
+    log::CommitmentLog,
+    metrics as relay_metrics,
     satellite::{EthereumMptSatellite, PermissionedSatellite, TempoSatellite},
 };
 
@@ -320,20 +323,109 @@ impl From<&SourceConfig> for WorldChainConfig {
 }
 
 // ---------------------------------------------------------------------------
+// Startup wallet snapshot
+// ---------------------------------------------------------------------------
+
+/// Logs the relay wallet's address, balance, and nonce on the given chain,
+/// and publishes the corresponding metrics. Errors are demoted to `warn!` —
+/// a wallet snapshot must never fail process startup.
+async fn log_wallet_status<P: Provider>(
+    provider: &P,
+    address: Address,
+    chain_id: u64,
+    chain_name: &str,
+) {
+    let balance = match provider.get_balance(address).await {
+        Ok(b) => Some(b),
+        Err(e) => {
+            tracing::warn!(error = %e, %chain_name, chain_id, "failed to read wallet balance");
+            None
+        }
+    };
+
+    let nonce = match provider.get_transaction_count(address).await {
+        Ok(n) => Some(n),
+        Err(e) => {
+            tracing::warn!(error = %e, %chain_name, chain_id, "failed to read wallet nonce");
+            None
+        }
+    };
+
+    if let Some(balance) = balance {
+        relay_metrics::set_wallet_balance_wei(chain_id, f64::from(balance));
+        let balance_eth = format_ether(balance);
+        tracing::info!(
+            %chain_name,
+            chain_id,
+            wallet = %address,
+            %balance_eth,
+            nonce = ?nonce,
+            "relay wallet status"
+        );
+    } else {
+        tracing::info!(
+            %chain_name,
+            chain_id,
+            wallet = %address,
+            nonce = ?nonce,
+            "relay wallet status (balance unavailable)"
+        );
+    }
+
+    if let Some(nonce) = nonce {
+        relay_metrics::set_wallet_nonce(chain_id, nonce);
+    }
+}
+
+/// Spawns a fire-and-forget background task that periodically refreshes the
+/// per-chain wallet `balance_wei` and `nonce` gauges. Intentionally NOT added
+/// to `tokio::select!` / `JoinSet`: this is observability, not business logic,
+/// and a panicking metrics task must never bring down the engine.
+fn spawn_wallet_metrics_task(provider: Arc<DynProvider>, chain_id: u64, wallet_address: Address) {
+    tokio::spawn(async move {
+        relay_metrics::run_wallet_metrics_task(
+            provider,
+            chain_id,
+            wallet_address,
+            relay_metrics::WALLET_METRICS_INTERVAL,
+        )
+        .await
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Health / readiness handlers
+// ---------------------------------------------------------------------------
+
+/// Liveness probe — always returns 200.
+///
+/// Indicates only that the process is up and the async runtime is healthy.
+/// k8s should NEVER restart the relay mid-backfill (it would just discard
+/// progress and retry), so this endpoint deliberately ignores backfill state.
+async fn livez() -> StatusCode {
+    StatusCode::OK
+}
+
+/// Readiness probe — 200 once backfill has completed, 503 before that.
+///
+/// During a rolling update this keeps the new pod out of service until its
+/// in-memory commitment log has caught up, so the old pod continues to
+/// serve satellite traffic until the replacement is genuinely ready.
+async fn readyz(State(log): State<Arc<CommitmentLog>>) -> StatusCode {
+    if log.is_ready() {
+        StatusCode::OK
+    } else {
+        StatusCode::SERVICE_UNAVAILABLE
+    }
+}
+
+// ---------------------------------------------------------------------------
 // CLI run
 // ---------------------------------------------------------------------------
 
 impl Cli {
     pub async fn run(self) -> eyre::Result<()> {
         let shutdown = tokio::signal::ctrl_c();
-
-        let health_app = axum::Router::new().route(
-            "/health",
-            axum::routing::get(|| async { axum::http::StatusCode::OK }),
-        );
-        let health_listener = tokio::net::TcpListener::bind(self.health_bind_addr).await?;
-        tracing::info!(addr = %self.health_bind_addr, "starting health check server");
-        let health_server = axum::serve(health_listener, health_app);
 
         let config = parse_config(&self.config)?;
 
@@ -344,16 +436,59 @@ impl Cli {
         let signer: PrivateKeySigner = wallet_key
             .parse()
             .map_err(|e| eyre::eyre!("failed to parse WALLET_PRIVATE_KEY: {e}"))?;
+        let wallet_address = signer.address();
         let wallet = EthereumWallet::from(signer);
 
         // Build the World Chain (source) provider from WORLDCHAIN_RPC_URL.
+        //
+        // NOTE: this await is the one slow operation that happens BEFORE the
+        // health/readiness server is up. We accept this tradeoff so that
+        // `/readyz` can read directly from `Engine`'s own `Arc<CommitmentLog>`
+        // — i.e. there is exactly one log instance in the process, shared
+        // between the engine and the readiness handler. The alternative
+        // (construct the log outside `Engine` and pass it in) would let us
+        // spawn axum first, but at the cost of an extra public seam on
+        // `Engine` purely for probe wiring. The WC provider build is
+        // typically <1s on a healthy RPC, well inside k8s probe grace.
         let wc_rpc_url = rpc_url_from_env(SOURCE_RPC_ENV)?;
         let wc_provider = Arc::new(build_provider(&wc_rpc_url, &wallet).await?);
 
         let wc_config = WorldChainConfig::from(&config.source);
+
+        // Best-effort startup wallet snapshot — surfaces low-balance / stuck-tx
+        // problems before backfill even starts. Failures are non-fatal.
+        log_wallet_status(
+            wc_provider.as_ref(),
+            wallet_address,
+            wc_config.chain_id,
+            "world_chain",
+        )
+        .await;
+
+        // Spawn a fire-and-forget background task that periodically refreshes
+        // the World Chain wallet `balance_wei` / `nonce` gauges. This MUST
+        // live off the propagate hot path — observability code can never pay
+        // network-latency tax on the critical path.
+        spawn_wallet_metrics_task(wc_provider.clone(), wc_config.chain_id, wallet_address);
+
         let world_chain = chain::WorldChain::new(&wc_config, wc_provider.clone());
 
         let mut engine = Engine::new(world_chain);
+
+        // Spawn the health/readiness server BEFORE registering satellites
+        // (which involves further `.await`s on per-satellite RPC builds).
+        // While the engine backfills, `/livez` reports 200 and `/readyz`
+        // reports 503, keeping the pod in service for liveness but
+        // NotReady for traffic until `CommitmentLog::mark_ready()` fires.
+        let health_app = Router::new()
+            .route("/livez", get(livez))
+            .route("/readyz", get(readyz))
+            .with_state(engine.log().clone());
+        let health_listener = tokio::net::TcpListener::bind(self.health_bind_addr).await?;
+        tracing::info!(addr = %self.health_bind_addr, "starting health check server");
+        let mut health_task =
+            tokio::spawn(async move { axum::serve(health_listener, health_app).await });
+
         let mut satellite_count = 0usize;
 
         // Spawn permissioned gateway satellites.
@@ -361,6 +496,20 @@ impl Cli {
             match sat_config.chain_type {
                 ChainType::Default => {
                     let provider = Arc::new(satellite_provider(&sat_config.name, &wallet).await?);
+
+                    log_wallet_status(
+                        provider.as_ref(),
+                        wallet_address,
+                        sat_config.destination_chain_id,
+                        &sat_config.name,
+                    )
+                    .await;
+
+                    spawn_wallet_metrics_task(
+                        provider.clone(),
+                        sat_config.destination_chain_id,
+                        wallet_address,
+                    );
 
                     let satellite = PermissionedSatellite::new(
                         &sat_config.name,
@@ -376,6 +525,20 @@ impl Cli {
                     // Standard Ethereum provider for contract reads (sol! bindings).
                     let read_provider =
                         Arc::new(satellite_provider(&sat_config.name, &wallet).await?);
+
+                    log_wallet_status(
+                        read_provider.as_ref(),
+                        wallet_address,
+                        sat_config.destination_chain_id,
+                        &sat_config.name,
+                    )
+                    .await;
+
+                    spawn_wallet_metrics_task(
+                        read_provider.clone(),
+                        sat_config.destination_chain_id,
+                        wallet_address,
+                    );
 
                     // Tempo-typed provider for sending transactions with 2D nonces.
                     let tempo_provider = ProviderBuilder::new_with_network::<TempoNetwork>()
@@ -410,6 +573,20 @@ impl Cli {
         for sat_config in config.ethereum_mpt_gateways.iter().flatten() {
             let provider = Arc::new(satellite_provider(&sat_config.name, &wallet).await?);
 
+            log_wallet_status(
+                provider.as_ref(),
+                wallet_address,
+                sat_config.destination_chain_id,
+                &sat_config.name,
+            )
+            .await;
+
+            spawn_wallet_metrics_task(
+                provider.clone(),
+                sat_config.destination_chain_id,
+                wallet_address,
+            );
+
             let satellite = EthereumMptSatellite::from_config(
                 &wc_config,
                 sat_config,
@@ -434,10 +611,19 @@ impl Cli {
         }
 
         tokio::select! {
-            result = engine.run() => result,
-            result = health_server => result.map_err(eyre::Report::from),
+            result = engine.run() => {
+                health_task.abort();
+                result
+            }
+            result = &mut health_task => match result {
+                Ok(Ok(())) => Err(eyre::eyre!("health server exited unexpectedly")),
+                Ok(Err(e)) => Err(eyre::Report::from(e)),
+                Err(e) if e.is_cancelled() => Ok(()),
+                Err(e) => Err(eyre::Report::from(e)),
+            },
             _ = shutdown => {
                 tracing::info!("received shutdown signal");
+                health_task.abort();
                 Ok(())
             }
         }

--- a/services/relay/src/cli/mod.rs
+++ b/services/relay/src/cli/mod.rs
@@ -327,8 +327,12 @@ impl From<&SourceConfig> for WorldChainConfig {
 // ---------------------------------------------------------------------------
 
 /// Logs the relay wallet's address, balance, and nonce on the given chain,
-/// and publishes the corresponding metrics. Errors are demoted to `warn!` —
+/// and publishes the balance gauge. Errors are demoted to `warn!` —
 /// a wallet snapshot must never fail process startup.
+///
+/// Nonce is reported as a structured log field only; we do not expose it as a
+/// metric because a healthy `propagate_state.attempts{outcome="success"}` rate
+/// already implies the wallet is signing and broadcasting correctly.
 async fn log_wallet_status<P: Provider>(
     provider: &P,
     address: Address,
@@ -370,10 +374,6 @@ async fn log_wallet_status<P: Provider>(
             nonce = ?nonce,
             "relay wallet status (balance unavailable)"
         );
-    }
-
-    if let Some(nonce) = nonce {
-        relay_metrics::set_wallet_nonce(chain_id, nonce);
     }
 }
 

--- a/services/relay/src/cli/mod.rs
+++ b/services/relay/src/cli/mod.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use eyre::Result;
 use serde::Deserialize;
 
 use alloy::{
@@ -328,43 +329,26 @@ async fn log_wallet_status<P: Provider>(
     address: Address,
     chain_id: u64,
     chain_name: &str,
-) {
-    let balance = match provider.get_balance(address).await {
-        Ok(b) => Some(b),
-        Err(e) => {
-            tracing::warn!(error = %e, %chain_name, chain_id, "failed to read wallet balance");
-            None
-        }
-    };
+) -> Result<()> {
+    let (balance, nonce) = tokio::try_join!(
+        provider.get_balance(address),
+        provider.get_transaction_count(address)
+    )?;
 
-    let nonce = match provider.get_transaction_count(address).await {
-        Ok(n) => Some(n),
-        Err(e) => {
-            tracing::warn!(error = %e, %chain_name, chain_id, "failed to read wallet nonce");
-            None
-        }
-    };
+    relay_metrics::set_wallet_balance_wei(chain_id, f64::from(balance));
+    
+    let balance_eth = format_ether(balance);
 
-    if let Some(balance) = balance {
-        relay_metrics::set_wallet_balance_wei(chain_id, f64::from(balance));
-        let balance_eth = format_ether(balance);
-        tracing::info!(
-            %chain_name,
-            chain_id,
-            wallet = %address,
-            %balance_eth,
-            nonce = ?nonce,
-            "relay wallet status"
-        );
-    } else {
-        tracing::info!(
-            %chain_name,
-            chain_id,
-            wallet = %address,
-            nonce = ?nonce,
-            "relay wallet status (balance unavailable)"
-        );
-    }
+    tracing::info!(
+        %chain_name,
+        chain_id,
+        wallet = %address,
+        %balance_eth,
+        nonce = ?nonce,
+        "relay wallet status"
+    );
+
+    Ok(())
 }
 
 /// Fire-and-forget so a panicking metrics task can't bring down the engine.

--- a/services/relay/src/cli/mod.rs
+++ b/services/relay/src/cli/mod.rs
@@ -422,8 +422,6 @@ impl Cli {
 
         let wc_config = WorldChainConfig::from(&config.source);
 
-        // Best-effort startup wallet snapshot — surfaces low-balance / stuck-tx
-        // problems before backfill even starts. Failures are non-fatal.
         log_wallet_status(
             wc_provider.as_ref(),
             wallet_address,
@@ -432,21 +430,14 @@ impl Cli {
         )
         .await;
 
-        // Spawn a fire-and-forget background task that periodically refreshes
-        // the World Chain wallet `balance_wei` gauge. This MUST live off the
-        // propagate hot path — observability code can never pay
-        // network-latency tax on the critical path.
         spawn_wallet_metrics_task(wc_provider.clone(), wc_config.chain_id, wallet_address);
 
         let world_chain = chain::WorldChain::new(&wc_config, wc_provider.clone());
 
         let mut engine = Engine::new(world_chain);
 
-        // Spawn the health/readiness server BEFORE registering satellites
-        // (which involves further `.await`s on per-satellite RPC builds).
-        // While the engine backfills, `/livez` reports 200 and `/readyz`
-        // reports 503, keeping the pod in service for liveness but
-        // NotReady for traffic until `CommitmentLog::mark_ready()` fires.
+        // Spawn the health server before per-satellite RPC builds so `/readyz`
+        // can return 503 while the engine backfills.
         let health_app = Router::new()
             .route("/livez", get(livez))
             .route("/readyz", get(readyz))

--- a/services/relay/src/cli/mod.rs
+++ b/services/relay/src/cli/mod.rs
@@ -322,17 +322,7 @@ impl From<&SourceConfig> for WorldChainConfig {
     }
 }
 
-// ---------------------------------------------------------------------------
-// Startup wallet snapshot
-// ---------------------------------------------------------------------------
-
-/// Logs the relay wallet's address, balance, and nonce on the given chain,
-/// and publishes the balance gauge. Errors are demoted to `warn!` —
-/// a wallet snapshot must never fail process startup.
-///
-/// Nonce is reported as a structured log field only; we do not expose it as a
-/// metric because a healthy `propagate_state.attempts{outcome="success"}` rate
-/// already implies the wallet is signing and broadcasting correctly.
+/// Best-effort wallet snapshot: failures are warned, never fatal.
 async fn log_wallet_status<P: Provider>(
     provider: &P,
     address: Address,
@@ -377,10 +367,7 @@ async fn log_wallet_status<P: Provider>(
     }
 }
 
-/// Spawns a fire-and-forget background task that periodically refreshes the
-/// per-chain wallet `balance_wei` gauge. Intentionally NOT added to
-/// `tokio::select!` / `JoinSet`: this is observability, not business logic,
-/// and a panicking metrics task must never bring down the engine.
+/// Fire-and-forget so a panicking metrics task can't bring down the engine.
 fn spawn_wallet_metrics_task(provider: Arc<DynProvider>, chain_id: u64, wallet_address: Address) {
     tokio::spawn(async move {
         relay_metrics::run_wallet_metrics_task(
@@ -393,24 +380,12 @@ fn spawn_wallet_metrics_task(provider: Arc<DynProvider>, chain_id: u64, wallet_a
     });
 }
 
-// ---------------------------------------------------------------------------
-// Health / readiness handlers
-// ---------------------------------------------------------------------------
-
-/// Liveness probe — always returns 200.
-///
-/// Indicates only that the process is up and the async runtime is healthy.
-/// k8s should NEVER restart the relay mid-backfill (it would just discard
-/// progress and retry), so this endpoint deliberately ignores backfill state.
 async fn livez() -> StatusCode {
     StatusCode::OK
 }
 
-/// Readiness probe — 200 once backfill has completed, 503 before that.
-///
-/// During a rolling update this keeps the new pod out of service until its
-/// in-memory commitment log has caught up, so the old pod continues to
-/// serve satellite traffic until the replacement is genuinely ready.
+/// 503 until backfill completes, so a fresh pod stays out of service during
+/// rolling updates until its commitment log has caught up.
 async fn readyz(State(log): State<Arc<CommitmentLog>>) -> StatusCode {
     if log.is_ready() {
         StatusCode::OK
@@ -440,16 +415,8 @@ impl Cli {
         let wallet = EthereumWallet::from(signer);
 
         // Build the World Chain (source) provider from WORLDCHAIN_RPC_URL.
-        //
-        // NOTE: this await is the one slow operation that happens BEFORE the
-        // health/readiness server is up. We accept this tradeoff so that
-        // `/readyz` can read directly from `Engine`'s own `Arc<CommitmentLog>`
-        // — i.e. there is exactly one log instance in the process, shared
-        // between the engine and the readiness handler. The alternative
-        // (construct the log outside `Engine` and pass it in) would let us
-        // spawn axum first, but at the cost of an extra public seam on
-        // `Engine` purely for probe wiring. The WC provider build is
-        // typically <1s on a healthy RPC, well inside k8s probe grace.
+        // NOTE: blocks the health server briefly so `Engine` can own the single
+        // `Arc<CommitmentLog>` shared with `/readyz`.
         let wc_rpc_url = rpc_url_from_env(SOURCE_RPC_ENV)?;
         let wc_provider = Arc::new(build_provider(&wc_rpc_url, &wallet).await?);
 

--- a/services/relay/src/cli/mod.rs
+++ b/services/relay/src/cli/mod.rs
@@ -29,6 +29,10 @@ pub struct Cli {
     /// Relay config as a JSON string.
     #[arg(long, env = "RELAY_CONFIG")]
     pub config: String,
+
+    /// Address the health-check HTTP server binds to.
+    #[arg(long, env = "HEALTH_BIND_ADDR", default_value = "0.0.0.0:8081")]
+    pub health_bind_addr: std::net::SocketAddr,
 }
 
 // ---------------------------------------------------------------------------
@@ -323,6 +327,14 @@ impl Cli {
     pub async fn run(self) -> eyre::Result<()> {
         let shutdown = tokio::signal::ctrl_c();
 
+        let health_app = axum::Router::new().route(
+            "/health",
+            axum::routing::get(|| async { axum::http::StatusCode::OK }),
+        );
+        let health_listener = tokio::net::TcpListener::bind(self.health_bind_addr).await?;
+        tracing::info!(addr = %self.health_bind_addr, "starting health check server");
+        let health_server = axum::serve(health_listener, health_app);
+
         let config = parse_config(&self.config)?;
 
         // Build a wallet for relay transactions.
@@ -423,6 +435,7 @@ impl Cli {
 
         tokio::select! {
             result = engine.run() => result,
+            result = health_server => result.map_err(eyre::Report::from),
             _ = shutdown => {
                 tracing::info!("received shutdown signal");
                 Ok(())

--- a/services/relay/src/engine.rs
+++ b/services/relay/src/engine.rs
@@ -1,4 +1,4 @@
-use std::{sync::Arc, time::Instant};
+use std::sync::Arc;
 
 use eyre::Result;
 use futures_util::StreamExt;
@@ -6,9 +6,26 @@ use tokio::task::JoinSet;
 use tracing::{debug, error, info, warn};
 
 use crate::{
-    bindings::NothingChanged, cli::WorldChain, log::CommitmentLog, metrics as relay_metrics,
-    satellite::Satellite, stream,
+    bindings::NothingChanged,
+    cli::WorldChain,
+    log::CommitmentLog,
+    metrics as relay_metrics,
+    primitives::StateCommitment,
+    satellite::Satellite,
+    stream,
 };
+
+/// Returns the static label value for a [`StateCommitment`] variant, used as
+/// a `event_kind` structured-log field. Kept narrow on purpose: this is a
+/// tracing aid, not a metric label.
+fn event_kind(commitment: &StateCommitment) -> &'static str {
+    match commitment {
+        StateCommitment::ChainCommitted(_) => "chain_committed",
+        StateCommitment::RootCommitment(_) => "root_commitment",
+        StateCommitment::IssuerPubKey(_) => "issuer_pub_key",
+        StateCommitment::OprfPubKey(_) => "oprf_pub_key",
+    }
+}
 
 /// The core relay engine.
 ///
@@ -54,8 +71,6 @@ impl Engine {
     /// succeeds. Propagation failures are logged but never fatal -- the engine
     /// will retry on the next tick.
     async fn propagate(&self) -> Result<()> {
-        let start = Instant::now();
-
         let source_root = match self
             .world_chain
             .world_id_source()
@@ -67,7 +82,6 @@ impl Engine {
             Err(e) => {
                 warn!(error = %e, "failed to read source root");
                 relay_metrics::inc_propagate_outcome(relay_metrics::outcome::RPC_ERROR);
-                relay_metrics::record_propagate_duration(start.elapsed().as_secs_f64());
                 return Ok(());
             }
         };
@@ -82,7 +96,6 @@ impl Engine {
             Err(e) => {
                 warn!(error = %e, "failed to read registry root");
                 relay_metrics::inc_propagate_outcome(relay_metrics::outcome::RPC_ERROR);
-                relay_metrics::record_propagate_duration(start.elapsed().as_secs_f64());
                 return Ok(());
             }
         };
@@ -97,7 +110,6 @@ impl Engine {
         if !root_changed && snapshot.is_empty() {
             debug!("propagation tick: nothing to propagate");
             relay_metrics::inc_propagate_outcome(relay_metrics::outcome::NOOP);
-            relay_metrics::record_propagate_duration(start.elapsed().as_secs_f64());
             return Ok(());
         }
 
@@ -158,7 +170,6 @@ impl Engine {
                 relay_metrics::inc_propagate_outcome(relay_metrics::outcome::SIMULATION_REVERT);
             }
         }
-        relay_metrics::record_propagate_duration(start.elapsed().as_secs_f64());
         Ok(())
     }
 
@@ -174,9 +185,7 @@ impl Engine {
         // Satellites query the destination chain's head and use log.since()
         // to send any commits the destination hasn't received yet.
         info!("backfilling historical ChainCommitted events");
-        let backfill_start = Instant::now();
         stream::backfill_commitments(&self.world_chain, &self.log).await?;
-        relay_metrics::record_backfill_duration(backfill_start.elapsed().as_secs_f64());
 
         info!("backfill complete, starting satellite relay loop");
 
@@ -197,13 +206,11 @@ impl Engine {
                 Some(result) = events.next() => {
                     match result {
                         Ok(commitment) => {
-                            let event_kind = relay_metrics::event_kind(&commitment);
                             info!(
                                 event = %commitment,
-                                event_kind,
+                                event_kind = event_kind(&commitment),
                                 "received event from World Chain"
                             );
-                            relay_metrics::inc_event_received(&commitment);
                             self.log.insert(commitment);
                             relay_metrics::record_pending_counts(&self.log);
                         }

--- a/services/relay/src/engine.rs
+++ b/services/relay/src/engine.rs
@@ -6,13 +6,8 @@ use tokio::task::JoinSet;
 use tracing::{debug, error, info, warn};
 
 use crate::{
-    bindings::NothingChanged,
-    cli::WorldChain,
-    log::CommitmentLog,
-    metrics as relay_metrics,
-    primitives::StateCommitment,
-    satellite::Satellite,
-    stream,
+    bindings::NothingChanged, cli::WorldChain, log::CommitmentLog, metrics as relay_metrics,
+    primitives::StateCommitment, satellite::Satellite, stream,
 };
 
 /// Returns the static label value for a [`StateCommitment`] variant, used as

--- a/services/relay/src/engine.rs
+++ b/services/relay/src/engine.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{sync::Arc, time::Instant};
 
 use eyre::Result;
 use futures_util::StreamExt;
@@ -6,7 +6,8 @@ use tokio::task::JoinSet;
 use tracing::{debug, error, info, warn};
 
 use crate::{
-    bindings::NothingChanged, cli::WorldChain, log::CommitmentLog, satellite::Satellite, stream,
+    bindings::NothingChanged, cli::WorldChain, log::CommitmentLog, metrics as relay_metrics,
+    satellite::Satellite, stream,
 };
 
 /// The core relay engine.
@@ -53,6 +54,8 @@ impl Engine {
     /// succeeds. Propagation failures are logged but never fatal -- the engine
     /// will retry on the next tick.
     async fn propagate(&self) -> Result<()> {
+        let start = Instant::now();
+
         let source_root = match self
             .world_chain
             .world_id_source()
@@ -63,6 +66,8 @@ impl Engine {
             Ok(root) => root,
             Err(e) => {
                 warn!(error = %e, "failed to read source root");
+                relay_metrics::inc_propagate_outcome(relay_metrics::outcome::RPC_ERROR);
+                relay_metrics::record_propagate_duration(start.elapsed().as_secs_f64());
                 return Ok(());
             }
         };
@@ -76,6 +81,8 @@ impl Engine {
             Ok(root) => root,
             Err(e) => {
                 warn!(error = %e, "failed to read registry root");
+                relay_metrics::inc_propagate_outcome(relay_metrics::outcome::RPC_ERROR);
+                relay_metrics::record_propagate_duration(start.elapsed().as_secs_f64());
                 return Ok(());
             }
         };
@@ -83,16 +90,21 @@ impl Engine {
         // Drain pending entries — removed from the map now so concurrent
         // inserts during the await are not lost.
         let snapshot = self.log.take_pending();
+        relay_metrics::record_pending_counts(&self.log);
 
         let root_changed = source_root != registry_root;
 
         if !root_changed && snapshot.is_empty() {
             debug!("propagation tick: nothing to propagate");
+            relay_metrics::inc_propagate_outcome(relay_metrics::outcome::NOOP);
+            relay_metrics::record_propagate_duration(start.elapsed().as_secs_f64());
             return Ok(());
         }
 
         let issuers = snapshot.issuer_ids();
         let oprfs = snapshot.oprf_ids();
+        let issuers_attempted = issuers.len();
+        let oprfs_attempted = oprfs.len();
 
         info!(
             root_changed,
@@ -114,25 +126,39 @@ impl Engine {
             Ok(pending) => match pending.get_receipt().await {
                 Ok(receipt) if receipt.status() => {
                     info!(hash = %receipt.transaction_hash, "propagateState succeeded");
+                    relay_metrics::inc_propagate_outcome(relay_metrics::outcome::SUCCESS);
                 }
                 Ok(receipt) => {
-                    warn!(hash = %receipt.transaction_hash, "propagateState reverted on-chain");
+                    warn!(
+                        hash = %receipt.transaction_hash,
+                        issuers_attempted,
+                        oprfs_attempted,
+                        "propagateState reverted on-chain"
+                    );
                     self.log.restore_pending(snapshot);
+                    relay_metrics::record_pending_counts(&self.log);
+                    relay_metrics::inc_propagate_outcome(relay_metrics::outcome::REVERT_ON_CHAIN);
                 }
                 Err(e) => {
                     warn!(error = %e, "failed to get propagateState receipt");
                     self.log.restore_pending(snapshot);
+                    relay_metrics::record_pending_counts(&self.log);
+                    relay_metrics::inc_propagate_outcome(relay_metrics::outcome::RPC_ERROR);
                 }
             },
             Err(e) if e.as_decoded_error::<NothingChanged>().is_some() => {
                 debug!(error = %e, "propagateState reverted with NothingChanged");
                 // State is already on-chain — no need to restore.
+                relay_metrics::inc_propagate_outcome(relay_metrics::outcome::NOTHING_CHANGED);
             }
             Err(e) => {
                 warn!(error = %e, "propagateState simulation reverted");
                 self.log.restore_pending(snapshot);
+                relay_metrics::record_pending_counts(&self.log);
+                relay_metrics::inc_propagate_outcome(relay_metrics::outcome::SIMULATION_REVERT);
             }
         }
+        relay_metrics::record_propagate_duration(start.elapsed().as_secs_f64());
         Ok(())
     }
 
@@ -148,7 +174,9 @@ impl Engine {
         // Satellites query the destination chain's head and use log.since()
         // to send any commits the destination hasn't received yet.
         info!("backfilling historical ChainCommitted events");
+        let backfill_start = Instant::now();
         stream::backfill_commitments(&self.world_chain, &self.log).await?;
+        relay_metrics::record_backfill_duration(backfill_start.elapsed().as_secs_f64());
 
         info!("backfill complete, starting satellite relay loop");
 
@@ -169,8 +197,15 @@ impl Engine {
                 Some(result) = events.next() => {
                     match result {
                         Ok(commitment) => {
-                            info!(event = %commitment, "received event from World Chain");
+                            let event_kind = relay_metrics::event_kind(&commitment);
+                            info!(
+                                event = %commitment,
+                                event_kind,
+                                "received event from World Chain"
+                            );
+                            relay_metrics::inc_event_received(&commitment);
                             self.log.insert(commitment);
+                            relay_metrics::record_pending_counts(&self.log);
                         }
                         Err(e) => warn!(error = %e, "failed to decode event"),
                     }

--- a/services/relay/src/engine.rs
+++ b/services/relay/src/engine.rs
@@ -10,9 +10,6 @@ use crate::{
     primitives::StateCommitment, satellite::Satellite, stream,
 };
 
-/// Returns the static label value for a [`StateCommitment`] variant, used as
-/// a `event_kind` structured-log field. Kept narrow on purpose: this is a
-/// tracing aid, not a metric label.
 fn event_kind(commitment: &StateCommitment) -> &'static str {
     match commitment {
         StateCommitment::ChainCommitted(_) => "chain_committed",

--- a/services/relay/src/lib.rs
+++ b/services/relay/src/lib.rs
@@ -96,7 +96,6 @@ mod engine;
 /// Append-only, hash-chain-verified commitment log with watch-based fan-out.
 mod log;
 
-/// Service-level metric definitions and helpers.
 pub mod metrics;
 
 /// Core domain types: commitments, keccak chain, key identifiers.

--- a/services/relay/src/lib.rs
+++ b/services/relay/src/lib.rs
@@ -96,6 +96,9 @@ mod engine;
 /// Append-only, hash-chain-verified commitment log with watch-based fan-out.
 mod log;
 
+/// Service-level metric definitions and helpers.
+pub mod metrics;
+
 /// Core domain types: commitments, keccak chain, key identifiers.
 pub mod primitives;
 

--- a/services/relay/src/log.rs
+++ b/services/relay/src/log.rs
@@ -23,18 +23,11 @@ use crate::{
     },
 };
 
-// ── PendingCounts ───────────────────────────────────────────────────────────
-
-/// Snapshot of the pending-queue depths in the [`CommitmentLog`].
-///
-/// Roots are propagated automatically via `ChainCommitted` events and are not
-/// tracked in a pending map (see `CommitmentLog::insert`), so they are
-/// intentionally absent here.
+/// Pending-queue depths in the [`CommitmentLog`]. Roots aren't tracked here
+/// because they propagate via `ChainCommitted` rather than a pending map.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct PendingCounts {
-    /// Number of pending credential-issuer key updates.
     pub issuers: usize,
-    /// Number of pending OPRF key updates.
     pub oprfs: usize,
 }
 
@@ -125,10 +118,7 @@ impl CommitmentLog {
         self.ready_notify.notify_waiters();
     }
 
-    /// Returns `true` once [`mark_ready`](Self::mark_ready) has fired
-    /// (i.e. backfill is complete and the log is ready for satellite use).
-    ///
-    /// Cheap, non-blocking — safe to call from request handlers.
+    /// Non-blocking check that backfill is complete.
     pub fn is_ready(&self) -> bool {
         self.ready_flag.load(Ordering::Acquire)
     }
@@ -188,10 +178,7 @@ impl CommitmentLog {
         }
     }
 
-    /// Returns the current pending-queue depths without draining them.
-    ///
-    /// Acquires the pending-map mutexes briefly; safe to call from any
-    /// thread but should not be invoked in tight loops.
+    /// Current pending-queue depths without draining them.
     pub fn pending_counts(&self) -> PendingCounts {
         let issuers = self.pending_issuers.lock().len();
         let oprfs = self.pending_oprfs.lock().len();

--- a/services/relay/src/log.rs
+++ b/services/relay/src/log.rs
@@ -23,6 +23,24 @@ use crate::{
     },
 };
 
+// ── PendingCounts ───────────────────────────────────────────────────────────
+
+/// Snapshot of the pending-queue depths in the [`CommitmentLog`].
+///
+/// Roots are propagated automatically via `ChainCommitted` events and are not
+/// tracked in a pending map (see `CommitmentLog::insert`), so `roots` is
+/// always `0` today — the field is reported for consistency with the metrics
+/// label set and to make future bookkeeping cheap to wire up.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct PendingCounts {
+    /// Number of pending credential-issuer key updates.
+    pub issuers: usize,
+    /// Number of pending OPRF key updates.
+    pub oprfs: usize,
+    /// Number of pending root commitments tracked separately from the chain log.
+    pub roots: usize,
+}
+
 // ── PendingSnapshot ─────────────────────────────────────────────────────────
 
 /// A snapshot of pending issuer/OPRF key updates drained from the log.
@@ -110,6 +128,14 @@ impl CommitmentLog {
         self.ready_notify.notify_waiters();
     }
 
+    /// Returns `true` once [`mark_ready`](Self::mark_ready) has fired
+    /// (i.e. backfill is complete and the log is ready for satellite use).
+    ///
+    /// Cheap, non-blocking — safe to call from request handlers.
+    pub fn is_ready(&self) -> bool {
+        self.ready_flag.load(Ordering::Acquire)
+    }
+
     /// Waits until the log is ready (backfill complete).
     ///
     /// # Race-free design
@@ -162,6 +188,20 @@ impl CommitmentLog {
                 // Roots are propagated automatically via ChainCommitted — no
                 // pending state needed. We just log the event.
             }
+        }
+    }
+
+    /// Returns the current pending-queue depths without draining them.
+    ///
+    /// Acquires the pending-map mutexes briefly; safe to call from any
+    /// thread but should not be invoked in tight loops.
+    pub fn pending_counts(&self) -> PendingCounts {
+        let issuers = self.pending_issuers.lock().len();
+        let oprfs = self.pending_oprfs.lock().len();
+        PendingCounts {
+            issuers,
+            oprfs,
+            roots: 0,
         }
     }
 

--- a/services/relay/src/log.rs
+++ b/services/relay/src/log.rs
@@ -28,17 +28,14 @@ use crate::{
 /// Snapshot of the pending-queue depths in the [`CommitmentLog`].
 ///
 /// Roots are propagated automatically via `ChainCommitted` events and are not
-/// tracked in a pending map (see `CommitmentLog::insert`), so `roots` is
-/// always `0` today — the field is reported for consistency with the metrics
-/// label set and to make future bookkeeping cheap to wire up.
+/// tracked in a pending map (see `CommitmentLog::insert`), so they are
+/// intentionally absent here.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct PendingCounts {
     /// Number of pending credential-issuer key updates.
     pub issuers: usize,
     /// Number of pending OPRF key updates.
     pub oprfs: usize,
-    /// Number of pending root commitments tracked separately from the chain log.
-    pub roots: usize,
 }
 
 // ── PendingSnapshot ─────────────────────────────────────────────────────────
@@ -198,11 +195,7 @@ impl CommitmentLog {
     pub fn pending_counts(&self) -> PendingCounts {
         let issuers = self.pending_issuers.lock().len();
         let oprfs = self.pending_oprfs.lock().len();
-        PendingCounts {
-            issuers,
-            oprfs,
-            roots: 0,
-        }
+        PendingCounts { issuers, oprfs }
     }
 
     /// Atomically drains all pending entries.

--- a/services/relay/src/metrics.rs
+++ b/services/relay/src/metrics.rs
@@ -1,12 +1,4 @@
-//! Metrics definitions and helpers for the world-id-relay.
-//!
-//! All metric names are declared as `pub const` so call sites are typo-proof
-//! and the dashboard/alert spec lives in one place. Convenience setter/recorder
-//! functions wrap the `metrics::` macros so business modules never import the
-//! `metrics` crate directly.
-//!
-//! Only metrics whose alert would justify paging an on-call engineer live
-//! here. Latency/timing signals belong in traces, not metrics.
+//! Service-level metrics for the world-id-relay.
 
 use std::{sync::Arc, time::Duration};
 
@@ -15,36 +7,19 @@ use alloy_primitives::Address;
 
 use crate::log::CommitmentLog;
 
-/// Cadence at which the background wallet metrics task refreshes the per-chain
-/// `balance_wei` gauge. Chosen to be fast enough for low-balance alerting
-/// while staying well below provider rate limits across all chains.
 pub const WALLET_METRICS_INTERVAL: Duration = Duration::from_secs(30);
 
-// ── Metric name constants ───────────────────────────────────────────────────
-
-/// Wallet native-token balance, in wei (`f64`-encoded for OTLP / Datadog).
 pub const METRICS_WALLET_BALANCE_WEI: &str = "relay.wallet.balance_wei";
-
-/// `propagateState` attempt outcomes from the World Chain source contract.
 pub const METRICS_PROPAGATE_STATE_ATTEMPTS: &str = "relay.propagate_state.attempts";
-
-/// Per-satellite relay attempt outcomes.
 pub const METRICS_SATELLITE_RELAY_ATTEMPTS: &str = "relay.satellite.relay.attempts";
-
-/// Pending update queue depth in [`CommitmentLog`], split by kind.
 pub const METRICS_LOG_PENDING_COUNT: &str = "relay.log.pending_count";
-
-// ── Label keys ──────────────────────────────────────────────────────────────
 
 const LABEL_CHAIN_ID: &str = "chain_id";
 const LABEL_OUTCOME: &str = "outcome";
 const LABEL_SATELLITE: &str = "satellite";
 const LABEL_KIND: &str = "kind";
 
-// ── Outcome constants ───────────────────────────────────────────────────────
-
-/// Outcomes for `propagateState` and satellite relay counters. Using shared
-/// string constants keeps cardinality fixed and the dashboard query stable.
+/// Shared outcome labels — kept in one place so cardinality stays bounded.
 pub mod outcome {
     pub const SUCCESS: &str = "success";
     pub const NOTHING_CHANGED: &str = "nothing_changed";
@@ -56,16 +31,12 @@ pub mod outcome {
     pub const TIMEOUT: &str = "timeout";
 }
 
-/// Kinds for the pending-count gauge.
 pub mod pending_kind {
     pub const ISSUER: &str = "issuer";
     pub const OPRF: &str = "oprf";
 }
 
-// ── Describe ────────────────────────────────────────────────────────────────
-
-/// Register metadata for all relay metrics. Call once after
-/// `telemetry_batteries::init()`.
+/// Register metadata; call once after `telemetry_batteries::init()`.
 pub fn describe_metrics() {
     ::metrics::describe_gauge!(
         METRICS_WALLET_BALANCE_WEI,
@@ -92,9 +63,6 @@ pub fn describe_metrics() {
     );
 }
 
-// ── Setters / recorders ─────────────────────────────────────────────────────
-
-/// Records the wallet's native-token balance (in wei) for the given chain.
 pub fn set_wallet_balance_wei(chain_id: u64, balance_wei: f64) {
     ::metrics::gauge!(
         METRICS_WALLET_BALANCE_WEI,
@@ -103,16 +71,8 @@ pub fn set_wallet_balance_wei(chain_id: u64, balance_wei: f64) {
     .set(balance_wei);
 }
 
-/// Runs a background task that periodically refreshes the `balance_wei`
-/// wallet gauge for a single chain. Intended to be `tokio::spawn`ed once per
-/// chain at startup and then dropped — the task is fire-and-forget.
-///
-/// This MUST stay off the propagate/relay hot paths: observability code must
-/// never pay network-latency tax on the critical path. Errors are demoted to
-/// `warn!`; the task never returns and never panics.
-///
-/// The first tick fires immediately so dashboards aren't blank during the
-/// first interval after process start.
+/// Periodically refreshes the `balance_wei` gauge; kept off the relay hot
+/// path. Errors are warned; the task never returns.
 pub async fn run_wallet_metrics_task(
     provider: Arc<DynProvider>,
     chain_id: u64,
@@ -120,9 +80,7 @@ pub async fn run_wallet_metrics_task(
     interval: Duration,
 ) {
     let mut ticker = tokio::time::interval(interval);
-    // Skip missed ticks rather than burst — if the provider stalls for a
-    // minute we don't want to fire several back-to-back refreshes when it
-    // recovers.
+    // Skip missed ticks so a stalled provider doesn't cause a burst on recovery.
     ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
     loop {
         ticker.tick().await;
@@ -133,7 +91,6 @@ pub async fn run_wallet_metrics_task(
     }
 }
 
-/// Increments the `propagateState` attempt counter with the given outcome.
 pub fn inc_propagate_outcome(outcome: &'static str) {
     ::metrics::counter!(
         METRICS_PROPAGATE_STATE_ATTEMPTS,
@@ -142,7 +99,6 @@ pub fn inc_propagate_outcome(outcome: &'static str) {
     .increment(1);
 }
 
-/// Increments a satellite relay attempt counter with the given outcome.
 pub fn inc_satellite_relay_outcome(satellite: &str, outcome: &'static str) {
     ::metrics::counter!(
         METRICS_SATELLITE_RELAY_ATTEMPTS,
@@ -152,10 +108,6 @@ pub fn inc_satellite_relay_outcome(satellite: &str, outcome: &'static str) {
     .increment(1);
 }
 
-/// Snapshots the log's pending queue depths and publishes them as gauges.
-///
-/// Cheap: each call acquires the log's internal locks briefly. Intended to be
-/// called from `Engine` after every state-changing log operation.
 pub fn record_pending_counts(log: &CommitmentLog) {
     let counts = log.pending_counts();
     ::metrics::gauge!(

--- a/services/relay/src/metrics.rs
+++ b/services/relay/src/metrics.rs
@@ -4,17 +4,20 @@
 //! and the dashboard/alert spec lives in one place. Convenience setter/recorder
 //! functions wrap the `metrics::` macros so business modules never import the
 //! `metrics` crate directly.
+//!
+//! Only metrics whose alert would justify paging an on-call engineer live
+//! here. Latency/timing signals belong in traces, not metrics.
 
 use std::{sync::Arc, time::Duration};
 
 use alloy::providers::{DynProvider, Provider};
 use alloy_primitives::Address;
 
-use crate::{log::CommitmentLog, primitives::StateCommitment};
+use crate::log::CommitmentLog;
 
 /// Cadence at which the background wallet metrics task refreshes the per-chain
-/// `balance_wei` and `nonce` gauges. Chosen to be fast enough for low-balance
-/// alerting while staying well below provider rate limits across all chains.
+/// `balance_wei` gauge. Chosen to be fast enough for low-balance alerting
+/// while staying well below provider rate limits across all chains.
 pub const WALLET_METRICS_INTERVAL: Duration = Duration::from_secs(30);
 
 // ── Metric name constants ───────────────────────────────────────────────────
@@ -22,29 +25,14 @@ pub const WALLET_METRICS_INTERVAL: Duration = Duration::from_secs(30);
 /// Wallet native-token balance, in wei (`f64`-encoded for OTLP / Datadog).
 pub const METRICS_WALLET_BALANCE_WEI: &str = "relay.wallet.balance_wei";
 
-/// Latest read transaction count (nonce) for the relay wallet.
-pub const METRICS_WALLET_NONCE: &str = "relay.wallet.nonce";
-
 /// `propagateState` attempt outcomes from the World Chain source contract.
 pub const METRICS_PROPAGATE_STATE_ATTEMPTS: &str = "relay.propagate_state.attempts";
-
-/// End-to-end latency of a single `Engine::propagate` tick.
-pub const METRICS_PROPAGATE_STATE_DURATION: &str = "relay.propagate_state.duration_seconds";
 
 /// Per-satellite relay attempt outcomes.
 pub const METRICS_SATELLITE_RELAY_ATTEMPTS: &str = "relay.satellite.relay.attempts";
 
-/// Per-satellite relay attempt duration, including proof construction.
-pub const METRICS_SATELLITE_RELAY_DURATION: &str = "relay.satellite.relay.duration_seconds";
-
 /// Pending update queue depth in [`CommitmentLog`], split by kind.
 pub const METRICS_LOG_PENDING_COUNT: &str = "relay.log.pending_count";
-
-/// Latency of the one-shot historical `ChainCommitted` backfill at startup.
-pub const METRICS_BACKFILL_DURATION: &str = "relay.backfill.duration_seconds";
-
-/// Number of registry events received from World Chain, by event kind.
-pub const METRICS_EVENTS_RECEIVED: &str = "relay.events.received";
 
 // ── Label keys ──────────────────────────────────────────────────────────────
 
@@ -52,7 +40,6 @@ const LABEL_CHAIN_ID: &str = "chain_id";
 const LABEL_OUTCOME: &str = "outcome";
 const LABEL_SATELLITE: &str = "satellite";
 const LABEL_KIND: &str = "kind";
-const LABEL_EVENT_KIND: &str = "event_kind";
 
 // ── Outcome constants ───────────────────────────────────────────────────────
 
@@ -86,21 +73,11 @@ pub fn describe_metrics() {
         ::metrics::Unit::Count,
         "Relay wallet native-token balance, in wei."
     );
-    ::metrics::describe_gauge!(
-        METRICS_WALLET_NONCE,
-        ::metrics::Unit::Count,
-        "Latest observed transaction count (nonce) for the relay wallet."
-    );
 
     ::metrics::describe_counter!(
         METRICS_PROPAGATE_STATE_ATTEMPTS,
         ::metrics::Unit::Count,
         "World Chain `propagateState` attempts, labelled by outcome."
-    );
-    ::metrics::describe_histogram!(
-        METRICS_PROPAGATE_STATE_DURATION,
-        ::metrics::Unit::Seconds,
-        "Latency of a single `Engine::propagate` tick."
     );
 
     ::metrics::describe_counter!(
@@ -108,28 +85,11 @@ pub fn describe_metrics() {
         ::metrics::Unit::Count,
         "Satellite relay attempts, labelled by satellite and outcome."
     );
-    ::metrics::describe_histogram!(
-        METRICS_SATELLITE_RELAY_DURATION,
-        ::metrics::Unit::Seconds,
-        "Latency of a single satellite relay attempt (proof build + tx submit)."
-    );
 
     ::metrics::describe_gauge!(
         METRICS_LOG_PENDING_COUNT,
         ::metrics::Unit::Count,
         "Pending update queue depth in the commitment log, by kind."
-    );
-
-    ::metrics::describe_histogram!(
-        METRICS_BACKFILL_DURATION,
-        ::metrics::Unit::Seconds,
-        "Latency of historical `ChainCommitted` backfill at startup."
-    );
-
-    ::metrics::describe_counter!(
-        METRICS_EVENTS_RECEIVED,
-        ::metrics::Unit::Count,
-        "Registry events received from World Chain, by event kind."
     );
 }
 
@@ -144,18 +104,9 @@ pub fn set_wallet_balance_wei(chain_id: u64, balance_wei: f64) {
     .set(balance_wei);
 }
 
-/// Records the wallet's transaction count (nonce) for the given chain.
-pub fn set_wallet_nonce(chain_id: u64, nonce: u64) {
-    ::metrics::gauge!(
-        METRICS_WALLET_NONCE,
-        LABEL_CHAIN_ID => chain_id.to_string(),
-    )
-    .set(nonce as f64);
-}
-
-/// Runs a background task that periodically refreshes the (`balance_wei`,
-/// `nonce`) wallet gauges for a single chain. Intended to be `tokio::spawn`ed
-/// once per chain at startup and then dropped — the task is fire-and-forget.
+/// Runs a background task that periodically refreshes the `balance_wei`
+/// wallet gauge for a single chain. Intended to be `tokio::spawn`ed once per
+/// chain at startup and then dropped — the task is fire-and-forget.
 ///
 /// This MUST stay off the propagate/relay hot paths: observability code must
 /// never pay network-latency tax on the critical path. Errors are demoted to
@@ -180,10 +131,6 @@ pub async fn run_wallet_metrics_task(
             Ok(balance) => set_wallet_balance_wei(chain_id, f64::from(balance)),
             Err(e) => tracing::warn!(error = %e, chain_id, "failed to read wallet balance"),
         }
-        match provider.get_transaction_count(wallet_address).await {
-            Ok(nonce) => set_wallet_nonce(chain_id, nonce),
-            Err(e) => tracing::warn!(error = %e, chain_id, "failed to read wallet nonce"),
-        }
     }
 }
 
@@ -196,11 +143,6 @@ pub fn inc_propagate_outcome(outcome: &'static str) {
     .increment(1);
 }
 
-/// Records the latency of a single `propagateState` tick.
-pub fn record_propagate_duration(duration_seconds: f64) {
-    ::metrics::histogram!(METRICS_PROPAGATE_STATE_DURATION).record(duration_seconds);
-}
-
 /// Increments a satellite relay attempt counter with the given outcome.
 pub fn inc_satellite_relay_outcome(satellite: &str, outcome: &'static str) {
     ::metrics::counter!(
@@ -209,41 +151,6 @@ pub fn inc_satellite_relay_outcome(satellite: &str, outcome: &'static str) {
         LABEL_OUTCOME => outcome,
     )
     .increment(1);
-}
-
-/// Records the latency of a single satellite relay attempt.
-pub fn record_satellite_relay_duration(satellite: &str, duration_seconds: f64) {
-    ::metrics::histogram!(
-        METRICS_SATELLITE_RELAY_DURATION,
-        LABEL_SATELLITE => satellite.to_owned(),
-    )
-    .record(duration_seconds);
-}
-
-/// Records the historical backfill latency. Called once per process.
-pub fn record_backfill_duration(duration_seconds: f64) {
-    ::metrics::histogram!(METRICS_BACKFILL_DURATION).record(duration_seconds);
-}
-
-/// Increments the event-received counter using the [`StateCommitment`]
-/// variant as the `event_kind` label.
-pub fn inc_event_received(commitment: &StateCommitment) {
-    let kind = event_kind(commitment);
-    ::metrics::counter!(
-        METRICS_EVENTS_RECEIVED,
-        LABEL_EVENT_KIND => kind,
-    )
-    .increment(1);
-}
-
-/// Returns the static label value for a [`StateCommitment`] variant.
-pub fn event_kind(commitment: &StateCommitment) -> &'static str {
-    match commitment {
-        StateCommitment::ChainCommitted(_) => "chain_committed",
-        StateCommitment::RootCommitment(_) => "root_commitment",
-        StateCommitment::IssuerPubKey(_) => "issuer_pub_key",
-        StateCommitment::OprfPubKey(_) => "oprf_pub_key",
-    }
 }
 
 /// Snapshots the log's pending queue depths and publishes them as gauges.

--- a/services/relay/src/metrics.rs
+++ b/services/relay/src/metrics.rs
@@ -1,0 +1,270 @@
+//! Metrics definitions and helpers for the world-id-relay.
+//!
+//! All metric names are declared as `pub const` so call sites are typo-proof
+//! and the dashboard/alert spec lives in one place. Convenience setter/recorder
+//! functions wrap the `metrics::` macros so business modules never import the
+//! `metrics` crate directly.
+
+use std::{sync::Arc, time::Duration};
+
+use alloy::providers::{DynProvider, Provider};
+use alloy_primitives::Address;
+
+use crate::{log::CommitmentLog, primitives::StateCommitment};
+
+/// Cadence at which the background wallet metrics task refreshes the per-chain
+/// `balance_wei` and `nonce` gauges. Chosen to be fast enough for low-balance
+/// alerting while staying well below provider rate limits across all chains.
+pub const WALLET_METRICS_INTERVAL: Duration = Duration::from_secs(30);
+
+// ── Metric name constants ───────────────────────────────────────────────────
+
+/// Wallet native-token balance, in wei (`f64`-encoded for OTLP / Datadog).
+pub const METRICS_WALLET_BALANCE_WEI: &str = "relay.wallet.balance_wei";
+
+/// Latest read transaction count (nonce) for the relay wallet.
+pub const METRICS_WALLET_NONCE: &str = "relay.wallet.nonce";
+
+/// `propagateState` attempt outcomes from the World Chain source contract.
+pub const METRICS_PROPAGATE_STATE_ATTEMPTS: &str = "relay.propagate_state.attempts";
+
+/// End-to-end latency of a single `Engine::propagate` tick.
+pub const METRICS_PROPAGATE_STATE_DURATION: &str = "relay.propagate_state.duration_seconds";
+
+/// Per-satellite relay attempt outcomes.
+pub const METRICS_SATELLITE_RELAY_ATTEMPTS: &str = "relay.satellite.relay.attempts";
+
+/// Per-satellite relay attempt duration, including proof construction.
+pub const METRICS_SATELLITE_RELAY_DURATION: &str = "relay.satellite.relay.duration_seconds";
+
+/// Pending update queue depth in [`CommitmentLog`], split by kind.
+pub const METRICS_LOG_PENDING_COUNT: &str = "relay.log.pending_count";
+
+/// Latency of the one-shot historical `ChainCommitted` backfill at startup.
+pub const METRICS_BACKFILL_DURATION: &str = "relay.backfill.duration_seconds";
+
+/// Number of registry events received from World Chain, by event kind.
+pub const METRICS_EVENTS_RECEIVED: &str = "relay.events.received";
+
+// ── Label keys ──────────────────────────────────────────────────────────────
+
+const LABEL_CHAIN_ID: &str = "chain_id";
+const LABEL_OUTCOME: &str = "outcome";
+const LABEL_SATELLITE: &str = "satellite";
+const LABEL_KIND: &str = "kind";
+const LABEL_EVENT_KIND: &str = "event_kind";
+
+// ── Outcome constants ───────────────────────────────────────────────────────
+
+/// Outcomes for `propagateState` and satellite relay counters. Using shared
+/// string constants keeps cardinality fixed and the dashboard query stable.
+pub mod outcome {
+    pub const SUCCESS: &str = "success";
+    pub const NOTHING_CHANGED: &str = "nothing_changed";
+    pub const REVERT_ON_CHAIN: &str = "revert_on_chain";
+    pub const SIMULATION_REVERT: &str = "simulation_revert";
+    pub const RPC_ERROR: &str = "rpc_error";
+    pub const NOOP: &str = "noop";
+    pub const RELAY_FAILED: &str = "relay_failed";
+    pub const TIMEOUT: &str = "timeout";
+}
+
+/// Kinds for the pending-count gauge.
+pub mod pending_kind {
+    pub const ISSUER: &str = "issuer";
+    pub const OPRF: &str = "oprf";
+    pub const ROOT: &str = "root";
+}
+
+// ── Describe ────────────────────────────────────────────────────────────────
+
+/// Register metadata for all relay metrics. Call once after
+/// `telemetry_batteries::init()`.
+pub fn describe_metrics() {
+    ::metrics::describe_gauge!(
+        METRICS_WALLET_BALANCE_WEI,
+        ::metrics::Unit::Count,
+        "Relay wallet native-token balance, in wei."
+    );
+    ::metrics::describe_gauge!(
+        METRICS_WALLET_NONCE,
+        ::metrics::Unit::Count,
+        "Latest observed transaction count (nonce) for the relay wallet."
+    );
+
+    ::metrics::describe_counter!(
+        METRICS_PROPAGATE_STATE_ATTEMPTS,
+        ::metrics::Unit::Count,
+        "World Chain `propagateState` attempts, labelled by outcome."
+    );
+    ::metrics::describe_histogram!(
+        METRICS_PROPAGATE_STATE_DURATION,
+        ::metrics::Unit::Seconds,
+        "Latency of a single `Engine::propagate` tick."
+    );
+
+    ::metrics::describe_counter!(
+        METRICS_SATELLITE_RELAY_ATTEMPTS,
+        ::metrics::Unit::Count,
+        "Satellite relay attempts, labelled by satellite and outcome."
+    );
+    ::metrics::describe_histogram!(
+        METRICS_SATELLITE_RELAY_DURATION,
+        ::metrics::Unit::Seconds,
+        "Latency of a single satellite relay attempt (proof build + tx submit)."
+    );
+
+    ::metrics::describe_gauge!(
+        METRICS_LOG_PENDING_COUNT,
+        ::metrics::Unit::Count,
+        "Pending update queue depth in the commitment log, by kind."
+    );
+
+    ::metrics::describe_histogram!(
+        METRICS_BACKFILL_DURATION,
+        ::metrics::Unit::Seconds,
+        "Latency of historical `ChainCommitted` backfill at startup."
+    );
+
+    ::metrics::describe_counter!(
+        METRICS_EVENTS_RECEIVED,
+        ::metrics::Unit::Count,
+        "Registry events received from World Chain, by event kind."
+    );
+}
+
+// ── Setters / recorders ─────────────────────────────────────────────────────
+
+/// Records the wallet's native-token balance (in wei) for the given chain.
+pub fn set_wallet_balance_wei(chain_id: u64, balance_wei: f64) {
+    ::metrics::gauge!(
+        METRICS_WALLET_BALANCE_WEI,
+        LABEL_CHAIN_ID => chain_id.to_string(),
+    )
+    .set(balance_wei);
+}
+
+/// Records the wallet's transaction count (nonce) for the given chain.
+pub fn set_wallet_nonce(chain_id: u64, nonce: u64) {
+    ::metrics::gauge!(
+        METRICS_WALLET_NONCE,
+        LABEL_CHAIN_ID => chain_id.to_string(),
+    )
+    .set(nonce as f64);
+}
+
+/// Runs a background task that periodically refreshes the (`balance_wei`,
+/// `nonce`) wallet gauges for a single chain. Intended to be `tokio::spawn`ed
+/// once per chain at startup and then dropped — the task is fire-and-forget.
+///
+/// This MUST stay off the propagate/relay hot paths: observability code must
+/// never pay network-latency tax on the critical path. Errors are demoted to
+/// `warn!`; the task never returns and never panics.
+///
+/// The first tick fires immediately so dashboards aren't blank during the
+/// first interval after process start.
+pub async fn run_wallet_metrics_task(
+    provider: Arc<DynProvider>,
+    chain_id: u64,
+    wallet_address: Address,
+    interval: Duration,
+) {
+    let mut ticker = tokio::time::interval(interval);
+    // Skip missed ticks rather than burst — if the provider stalls for a
+    // minute we don't want to fire several back-to-back refreshes when it
+    // recovers.
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    loop {
+        ticker.tick().await;
+        match provider.get_balance(wallet_address).await {
+            Ok(balance) => set_wallet_balance_wei(chain_id, f64::from(balance)),
+            Err(e) => tracing::warn!(error = %e, chain_id, "failed to read wallet balance"),
+        }
+        match provider.get_transaction_count(wallet_address).await {
+            Ok(nonce) => set_wallet_nonce(chain_id, nonce),
+            Err(e) => tracing::warn!(error = %e, chain_id, "failed to read wallet nonce"),
+        }
+    }
+}
+
+/// Increments the `propagateState` attempt counter with the given outcome.
+pub fn inc_propagate_outcome(outcome: &'static str) {
+    ::metrics::counter!(
+        METRICS_PROPAGATE_STATE_ATTEMPTS,
+        LABEL_OUTCOME => outcome,
+    )
+    .increment(1);
+}
+
+/// Records the latency of a single `propagateState` tick.
+pub fn record_propagate_duration(duration_seconds: f64) {
+    ::metrics::histogram!(METRICS_PROPAGATE_STATE_DURATION).record(duration_seconds);
+}
+
+/// Increments a satellite relay attempt counter with the given outcome.
+pub fn inc_satellite_relay_outcome(satellite: &str, outcome: &'static str) {
+    ::metrics::counter!(
+        METRICS_SATELLITE_RELAY_ATTEMPTS,
+        LABEL_SATELLITE => satellite.to_owned(),
+        LABEL_OUTCOME => outcome,
+    )
+    .increment(1);
+}
+
+/// Records the latency of a single satellite relay attempt.
+pub fn record_satellite_relay_duration(satellite: &str, duration_seconds: f64) {
+    ::metrics::histogram!(
+        METRICS_SATELLITE_RELAY_DURATION,
+        LABEL_SATELLITE => satellite.to_owned(),
+    )
+    .record(duration_seconds);
+}
+
+/// Records the historical backfill latency. Called once per process.
+pub fn record_backfill_duration(duration_seconds: f64) {
+    ::metrics::histogram!(METRICS_BACKFILL_DURATION).record(duration_seconds);
+}
+
+/// Increments the event-received counter using the [`StateCommitment`]
+/// variant as the `event_kind` label.
+pub fn inc_event_received(commitment: &StateCommitment) {
+    let kind = event_kind(commitment);
+    ::metrics::counter!(
+        METRICS_EVENTS_RECEIVED,
+        LABEL_EVENT_KIND => kind,
+    )
+    .increment(1);
+}
+
+/// Returns the static label value for a [`StateCommitment`] variant.
+pub fn event_kind(commitment: &StateCommitment) -> &'static str {
+    match commitment {
+        StateCommitment::ChainCommitted(_) => "chain_committed",
+        StateCommitment::RootCommitment(_) => "root_commitment",
+        StateCommitment::IssuerPubKey(_) => "issuer_pub_key",
+        StateCommitment::OprfPubKey(_) => "oprf_pub_key",
+    }
+}
+
+/// Snapshots the log's pending queue depths and publishes them as gauges.
+///
+/// Cheap: each call acquires the log's internal locks briefly. Intended to be
+/// called from `Engine` after every state-changing log operation.
+pub fn record_pending_counts(log: &CommitmentLog) {
+    let counts = log.pending_counts();
+    ::metrics::gauge!(
+        METRICS_LOG_PENDING_COUNT,
+        LABEL_KIND => pending_kind::ISSUER,
+    )
+    .set(counts.issuers as f64);
+    ::metrics::gauge!(
+        METRICS_LOG_PENDING_COUNT,
+        LABEL_KIND => pending_kind::OPRF,
+    )
+    .set(counts.oprfs as f64);
+    ::metrics::gauge!(
+        METRICS_LOG_PENDING_COUNT,
+        LABEL_KIND => pending_kind::ROOT,
+    )
+    .set(counts.roots as f64);
+}

--- a/services/relay/src/metrics.rs
+++ b/services/relay/src/metrics.rs
@@ -60,7 +60,6 @@ pub mod outcome {
 pub mod pending_kind {
     pub const ISSUER: &str = "issuer";
     pub const OPRF: &str = "oprf";
-    pub const ROOT: &str = "root";
 }
 
 // ── Describe ────────────────────────────────────────────────────────────────
@@ -169,9 +168,4 @@ pub fn record_pending_counts(log: &CommitmentLog) {
         LABEL_KIND => pending_kind::OPRF,
     )
     .set(counts.oprfs as f64);
-    ::metrics::gauge!(
-        METRICS_LOG_PENDING_COUNT,
-        LABEL_KIND => pending_kind::ROOT,
-    )
-    .set(counts.roots as f64);
 }

--- a/services/relay/src/satellite/mod.rs
+++ b/services/relay/src/satellite/mod.rs
@@ -5,12 +5,7 @@ pub use ethereum_mpt::EthereumMptSatellite;
 pub use permissioned::{PermissionedSatellite, TempoSatellite};
 use tracing::Instrument;
 
-use std::{
-    future::Future,
-    pin::Pin,
-    sync::Arc,
-    time::{Duration, Instant},
-};
+use std::{future::Future, pin::Pin, sync::Arc, time::Duration};
 
 use alloy::primitives::{B256, Bytes};
 use eyre::Result;
@@ -119,10 +114,7 @@ pub fn spawn_satellite(
                     "submitting satellite relay"
                 );
 
-                let relay_start = Instant::now();
                 let outcome = tokio::time::timeout(RELAY_TIMEOUT, satellite.relay(&merged)).await;
-                let elapsed = relay_start.elapsed().as_secs_f64();
-                relay_metrics::record_satellite_relay_duration(&satellite_name, elapsed);
 
                 match outcome {
                     Ok(Ok(tx_hash)) => {

--- a/services/relay/src/satellite/mod.rs
+++ b/services/relay/src/satellite/mod.rs
@@ -5,13 +5,19 @@ pub use ethereum_mpt::EthereumMptSatellite;
 pub use permissioned::{PermissionedSatellite, TempoSatellite};
 use tracing::Instrument;
 
-use std::{future::Future, pin::Pin, sync::Arc, time::Duration};
+use std::{
+    future::Future,
+    pin::Pin,
+    sync::Arc,
+    time::{Duration, Instant},
+};
 
 use alloy::primitives::{B256, Bytes};
 use eyre::Result;
 
 use crate::{
     log::CommitmentLog,
+    metrics as relay_metrics,
     primitives::{ChainCommitment, reduce},
 };
 
@@ -80,6 +86,8 @@ pub fn spawn_satellite(
             }
         };
 
+        let satellite_name = satellite.name().to_owned();
+
         async {
             loop {
                 chain_head.changed().await?;
@@ -105,17 +113,46 @@ pub fn spawn_satellite(
                     "relaying delta"
                 );
 
-                match tokio::time::timeout(RELAY_TIMEOUT, satellite.relay(&merged)).await {
+                tracing::info!(
+                    commitments = count,
+                    target_head = %target_head,
+                    "submitting satellite relay"
+                );
+
+                let relay_start = Instant::now();
+                let outcome = tokio::time::timeout(RELAY_TIMEOUT, satellite.relay(&merged)).await;
+                let elapsed = relay_start.elapsed().as_secs_f64();
+                relay_metrics::record_satellite_relay_duration(&satellite_name, elapsed);
+
+                match outcome {
                     Ok(Ok(tx_hash)) => {
                         local_head = target_head;
-                        tracing::info!(%tx_hash, head = %local_head, "relay succeeded");
+                        tracing::info!(
+                            %tx_hash,
+                            head = %local_head,
+                            delta_count = count,
+                            target_head = %target_head,
+                            "relay succeeded"
+                        );
+                        relay_metrics::inc_satellite_relay_outcome(
+                            &satellite_name,
+                            relay_metrics::outcome::SUCCESS,
+                        );
                     }
                     Ok(Err(e)) => {
                         tracing::warn!(error = %e, "relay failed, will retry on next head");
+                        relay_metrics::inc_satellite_relay_outcome(
+                            &satellite_name,
+                            relay_metrics::outcome::RELAY_FAILED,
+                        );
                     }
                     Err(_) => {
                         tracing::warn!(
                             "relay timed out after {RELAY_TIMEOUT:?}, will retry on next head"
+                        );
+                        relay_metrics::inc_satellite_relay_outcome(
+                            &satellite_name,
+                            relay_metrics::outcome::TIMEOUT,
                         );
                     }
                 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it changes relay startup/shutdown flow (health server lifecycle, readiness gating on backfill) and adds background RPC polling tasks, which can affect deployment behavior and provider load if misconfigured.
> 
> **Overview**
> Adds first-class observability to `world-id-relay` by introducing a dedicated `metrics` module and wiring it into startup via `describe_metrics()`.
> 
> The relay now emits counters/gauges for `propagateState` outcomes, per-satellite relay outcomes (success/failure/timeout), commitment-log pending queue depths, and per-chain wallet balance (including a periodic background balance refresher plus a startup wallet snapshot log).
> 
> Health checks are upgraded from a single `/health` endpoint to **liveness** (`/livez`) and **readiness** (`/readyz`) probes, where readiness returns 503 until backfill completes; the health server is started earlier and is explicitly aborted on engine exit/shutdown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44cd1a9e4da6b3938059f647c96ad54212b3684c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->