### PR TITLE
chore: clp + recursion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1673,9 +1673,9 @@ dependencies = [
 
 [[package]]
 name = "astral-tokio-tar"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c23f3af104b40a3430ccb90ed5f7bd877a8dc5c26fc92fde51a22b40890dcf9"
+checksum = "cb50a7aae84a03bf55b067832bc376f4961b790c97e64d3eacee97d389b90277"
 dependencies = [
  "filetime",
  "futures-core",
@@ -3053,7 +3053,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3952,7 +3952,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5281,7 +5281,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7795,7 +7795,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8681,7 +8681,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8761,7 +8761,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 1.0.6",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -10407,7 +10407,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -11802,7 +11802,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/services/common/tests/provider.rs
+++ b/services/common/tests/provider.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "256"]
+
 use std::sync::{
     Arc,
     atomic::{AtomicU32, Ordering},

--- a/services/gateway/src/lib.rs
+++ b/services/gateway/src/lib.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "256"]
+
 pub use crate::{
     config::{
         BatchPolicyConfig, BatcherConfig, GatewayConfig, OrphanSweeperConfig, RateLimitConfig,

--- a/services/gateway/src/main.rs
+++ b/services/gateway/src/main.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "256"]
+
 use std::path::Path;
 
 use world_id_gateway::GatewayResult;

--- a/services/indexer/src/lib.rs
+++ b/services/indexer/src/lib.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "256"]
+
 use crate::{
     blockchain::{Blockchain, BlockchainEvent, RegistryEvent},
     config::{AppState, HttpConfig, IndexerConfig, RunMode},

--- a/services/indexer/src/main.rs
+++ b/services/indexer/src/main.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "256"]
+
 use std::path::Path;
 
 use futures_util::FutureExt as _;

--- a/services/oprf-node/src/config.rs
+++ b/services/oprf-node/src/config.rs
@@ -113,7 +113,7 @@ impl Default for WatcherCacheConfig {
 impl WorldOprfNodeConfig {
     /// Default maximum allowed difference between received and node timestamp
     fn default_current_time_stamp_max_difference() -> Duration {
-        Duration::from_secs(300) // 5 minutes
+        Duration::from_mins(5) // 5 minutes
     }
 
     /// Default timeout for an `eth_call` to an unknown contract.

--- a/services/relay/src/cli/mod.rs
+++ b/services/relay/src/cli/mod.rs
@@ -1,6 +1,5 @@
 use std::sync::Arc;
 
-use eyre::Result;
 use serde::Deserialize;
 
 use alloy::{
@@ -329,14 +328,26 @@ async fn log_wallet_status<P: Provider>(
     address: Address,
     chain_id: u64,
     chain_name: &str,
-) -> Result<()> {
-    let (balance, nonce) = tokio::try_join!(
+) {
+    let (balance, nonce) = match tokio::try_join!(
         provider.get_balance(address),
         provider.get_transaction_count(address)
-    )?;
+    ) {
+        Ok(values) => values,
+        Err(err) => {
+            tracing::warn!(
+                %chain_name,
+                chain_id,
+                wallet = %address,
+                error = %err,
+                "failed to fetch relay wallet status"
+            );
+            return;
+        }
+    };
 
     relay_metrics::set_wallet_balance_wei(chain_id, f64::from(balance));
-    
+
     let balance_eth = format_ether(balance);
 
     tracing::info!(
@@ -347,8 +358,6 @@ async fn log_wallet_status<P: Provider>(
         nonce = ?nonce,
         "relay wallet status"
     );
-
-    Ok(())
 }
 
 /// Fire-and-forget so a panicking metrics task can't bring down the engine.

--- a/services/relay/src/cli/mod.rs
+++ b/services/relay/src/cli/mod.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use eyre::Result;
 use serde::Deserialize;
 
 use alloy::{
@@ -328,23 +329,11 @@ async fn log_wallet_status<P: Provider>(
     address: Address,
     chain_id: u64,
     chain_name: &str,
-) {
-    let (balance, nonce) = match tokio::try_join!(
+) -> Result<()> {
+    let (balance, nonce) = tokio::try_join!(
         provider.get_balance(address),
         provider.get_transaction_count(address)
-    ) {
-        Ok(values) => values,
-        Err(err) => {
-            tracing::warn!(
-                %chain_name,
-                chain_id,
-                wallet = %address,
-                error = %err,
-                "failed to fetch relay wallet status"
-            );
-            return;
-        }
-    };
+    )?;
 
     relay_metrics::set_wallet_balance_wei(chain_id, f64::from(balance));
 
@@ -358,6 +347,8 @@ async fn log_wallet_status<P: Provider>(
         nonce = ?nonce,
         "relay wallet status"
     );
+
+    Ok(())
 }
 
 /// Fire-and-forget so a panicking metrics task can't bring down the engine.
@@ -421,7 +412,7 @@ impl Cli {
             wc_config.chain_id,
             "world_chain",
         )
-        .await;
+        .await?;
 
         spawn_wallet_metrics_task(wc_provider.clone(), wc_config.chain_id, wallet_address);
 
@@ -454,7 +445,7 @@ impl Cli {
                         sat_config.destination_chain_id,
                         &sat_config.name,
                     )
-                    .await;
+                    .await?;
 
                     spawn_wallet_metrics_task(
                         provider.clone(),
@@ -483,7 +474,7 @@ impl Cli {
                         sat_config.destination_chain_id,
                         &sat_config.name,
                     )
-                    .await;
+                    .await?;
 
                     spawn_wallet_metrics_task(
                         read_provider.clone(),
@@ -530,7 +521,7 @@ impl Cli {
                 sat_config.destination_chain_id,
                 &sat_config.name,
             )
-            .await;
+            .await?;
 
             spawn_wallet_metrics_task(
                 provider.clone(),

--- a/tools/generate-solidity-fixtures/src/main.rs
+++ b/tools/generate-solidity-fixtures/src/main.rs
@@ -1,3 +1,4 @@
+#![recursion_limit = "256"]
 //! Generates Solidity test fixtures for `WorldIDVerifierTest.t.sol`.
 //!
 //! Spins up a local Anvil node, gateway, OPRF nodes, and indexer stub, then


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Mostly build/config tweaks plus a small behavior change to treat wallet status RPC failures as warnings instead of errors; low risk and isolated to startup/metrics logging.
> 
> **Overview**
> Adds `#![recursion_limit = "256"]` to the gateway, indexer, and `generate-solidity-fixtures` crates to avoid macro/type recursion overflows during compilation.
> 
> Updates the relay’s `log_wallet_status` to be best-effort (warn and return on RPC failures) instead of bubbling an error, and tweaks an OPRF-node default duration helper (`from_secs(300)` → `from_mins(5)`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 392201a383c8f6d2d7e498656380b0ae0acb2d45. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->