### PR TITLE
fix: Audit V2: zero root validity on initialization

### DIFF
--- a/contracts/src/core/WorldIDRegistryV2Unreleased.sol
+++ b/contracts/src/core/WorldIDRegistryV2Unreleased.sol
@@ -57,7 +57,10 @@ contract WorldIDRegistryV2 is IWorldIDRegistryV2, WorldIDRegistry {
      */
     function _recordCurrentRoot() internal virtual override {
         uint256 currentRoot = _latestRoot;
-        _rootToValidityTimestamp[currentRoot] = block.timestamp;
+        // Fresh V2 deployments call inherited `initialize` before `_latestRoot` has been set.
+        if (currentRoot != 0) {
+            _rootToValidityTimestamp[currentRoot] = block.timestamp;
+        }
         super._recordCurrentRoot();
     }
 

--- a/contracts/test/core/WorldIDRegistryV2RaceCondition.t.sol
+++ b/contracts/test/core/WorldIDRegistryV2RaceCondition.t.sol
@@ -90,6 +90,25 @@ contract WorldIDRegistryV2RaceConditionTest is Test {
         assertFalse(registry.isValidRoot(rootA), "rootA expires after full window from replacement time");
     }
 
+    function test_FreshV2Deployment_DoesNotRecordZeroRoot() public {
+        vm.warp(123);
+
+        WorldIDRegistryV2 implementationV2 = new WorldIDRegistryV2();
+        ERC20Mock feeToken = new ERC20Mock();
+        bytes memory initData =
+            abi.encodeWithSelector(WorldIDRegistry.initialize.selector, 30, address(0xAAA), feeToken, 0);
+        ERC1967Proxy freshProxy = new ERC1967Proxy(address(implementationV2), initData);
+        WorldIDRegistryV2 registry = WorldIDRegistryV2(address(freshProxy));
+
+        uint256 initialRoot = registry.currentRoot();
+        assertTrue(initialRoot != 0, "initial root should be non-zero after sentinel insertion");
+        assertTrue(registry.isValidRoot(initialRoot), "latest root should be valid");
+        assertFalse(registry.isValidRoot(0), "zero root should remain unknown");
+
+        vm.expectRevert(abi.encodeWithSelector(IWorldIDRegistryV2.UnknownRoot.selector, 0));
+        registry.getRootExpiration(0);
+    }
+
     /// @notice getRootExpiration returns 0 for the latest root (not yet replaced),
     ///         the replacement timestamp for a superseded root, and reverts for unknown roots.
     function test_getRootExpiration() public {


### PR DESCRIPTION
small audit fix to avoid recording 0 root on initialization if v2 is freshly deployed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core Merkle root validity bookkeeping in `WorldIDRegistryV2`, so a mistake could incorrectly mark roots as valid/invalid, but the change is small and covered by a targeted new regression test.
> 
> **Overview**
> Prevents fresh `WorldIDRegistryV2` proxy deployments from recording a `0` root as a historical root by guarding `_recordCurrentRoot()` so it only timestamps `_latestRoot` when it is non-zero.
> 
> Adds a regression test that deploys a fresh V2 proxy and asserts the initial non-zero root is valid, while root `0` remains unknown and `getRootExpiration(0)` reverts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71210eb2f03813869b4dd02c2e5043b33e5f1b77. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->