### PR TITLE
docs: Clarify WorldIDVerifier expiration check comment

### DIFF
--- a/contracts/src/core/WorldIDVerifier.sol
+++ b/contracts/src/core/WorldIDVerifier.sol
@@ -175,8 +175,9 @@ contract WorldIDVerifier is WorldIDBase, IWorldIDVerifier {
         uint160 oprfKeyId = uint160(rpId);
         BabyJubJub.Affine memory oprfPublicKey = _oprfKeyRegistry.getOprfPublicKey(oprfKeyId);
 
-        // Ensure the credential has sufficient time before expiration
-        // This prevents accepting proofs for credentials that are about to expire
+        // The proof guarantees the credential's hidden `expires_at` is greater than
+        // the public `expiresAtMin` input. Reject if that public lower bound is more
+        // than `_minExpirationThreshold` older than the current block timestamp.
         if (uint256(expiresAtMin + _minExpirationThreshold) < block.timestamp) {
             revert ExpirationTooOld();
         }

--- a/contracts/src/core/WorldIDVerifier.sol
+++ b/contracts/src/core/WorldIDVerifier.sol
@@ -176,8 +176,9 @@ contract WorldIDVerifier is WorldIDBase, IWorldIDVerifier {
         BabyJubJub.Affine memory oprfPublicKey = _oprfKeyRegistry.getOprfPublicKey(oprfKeyId);
 
         // The proof guarantees the credential's private `expires_at` is greater than
-        // the public `expiresAtMin` input. Reject if that public lower bound is more
-        // than `_minExpirationThreshold` older than the current block timestamp.
+        // the public `expiresAtMin` input. Reject if that lower bound is more than
+        // `_minExpirationThreshold` older than the current block timestamp, preventing
+        // proofs that only show the credential expires after a timestamp too far in the past.
         if (uint256(expiresAtMin + _minExpirationThreshold) < block.timestamp) {
             revert ExpirationTooOld();
         }

--- a/contracts/src/core/WorldIDVerifier.sol
+++ b/contracts/src/core/WorldIDVerifier.sol
@@ -175,7 +175,7 @@ contract WorldIDVerifier is WorldIDBase, IWorldIDVerifier {
         uint160 oprfKeyId = uint160(rpId);
         BabyJubJub.Affine memory oprfPublicKey = _oprfKeyRegistry.getOprfPublicKey(oprfKeyId);
 
-        // The proof guarantees the credential's hidden `expires_at` is greater than
+        // The proof guarantees the credential's private `expires_at` is greater than
         // the public `expiresAtMin` input. Reject if that public lower bound is more
         // than `_minExpirationThreshold` older than the current block timestamp.
         if (uint256(expiresAtMin + _minExpirationThreshold) < block.timestamp) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Comment-only change in `WorldIDVerifier` clarifying the `expiresAtMin`/`_minExpirationThreshold` semantics; no functional or security-impacting logic was modified.
> 
> **Overview**
> Clarifies the inline documentation for the expiration-threshold check in `WorldIDVerifier.verifyProofAndSignals`, explaining that the proof enforces hidden `expires_at > expiresAtMin` and the contract rejects proofs where `expiresAtMin` is too far in the past relative to `block.timestamp` and `_minExpirationThreshold`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58c0e13184691a37ed9f7d3b4d03992f4d11f2a7. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->