### PR TITLE
feat: credential fees

### DIFF
--- a/docs/WIPs/wip-105.md
+++ b/docs/WIPs/wip-105.md
@@ -1,0 +1,206 @@
+---
+wip: 105
+title: Credential-Based Proof Fees
+description: Allow credential issuers to configure per-proof fees enforced by OPRF-issued credential-use authorizations.
+author: Eric Woolsey
+status: Draft
+type: Standards Track
+created: 2026-05-22
+---
+
+## Abstract
+
+This WIP adds per-proof fees for World ID credentials. Fees are configured per `issuerSchemaId` and charged only when a proof actually uses a credential for that schema.
+
+OPRF Nodes enforce payment by withholding a credential-use authorization until the fee is paid. The credential proof circuit consumes that authorization and binds it to the same public `issuer_schema_id` as the credential being proven. Verifiers do not inspect fee receipts; they verify the WIP-105 proof relation.
+
+Credential issuance, credential storage, and nullifier derivation are unchanged.
+
+## Motivation
+
+Credentials are stored by the user's Authenticator, so issuers are not contacted during normal proof generation. The OPRF flow is the mandatory online step and is therefore the natural enforcement point.
+
+The nullifier OPRF output is credential-independent. Credential fees therefore use a second OPRF output: a credential-use authorization tied to one `issuerSchemaId` and one request context, but not used to derive the nullifier.
+
+Fees MUST apply to credentials actually proven, not every credential requested by the RP. A request may include alternatives, while the Authenticator proves only one.
+
+## Specification
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).
+
+### Fee Policy
+
+Each `issuerSchemaId` MAY have a fee policy controlled by the issuer schema authority or a delegated fee manager.
+
+```solidity
+struct CredentialFeePolicy {
+    address token;
+    uint256 amount;
+    address recipient;
+    uint64 effectiveAt;
+    uint32 revision;
+    bool active;
+}
+```
+
+`active == false` or `amount == 0` means no payment is required. `revision` MUST increase whenever the policy changes. OPRF Nodes MAY cache policies, but MUST invalidate cached entries after policy update events.
+
+### Selected Credentials
+
+The Authenticator resolves the `ProofRequest` before payment. The selected set MUST contain only credentials that will produce `ResponseItem`s. OPRF Nodes MUST NOT require payment for requested-but-unselected credentials.
+
+Each selected credential proof MUST include one credential-use authorization for its `issuer_schema_id`.
+
+### Fee Context
+
+A payment is bound to:
+
+```text
+WIP105FeeContextV1 {
+    chain_id
+    world_id_registry
+    rp_id
+    proof_type
+    action
+    nonce
+    request_expires_at
+    proof_request_digest
+    selected_issuer_schema_ids
+    fee_policy_revisions
+    fee_query_commitments
+}
+```
+
+`proof_request_digest` MUST commit to the complete RP-approved request, including request items and constraints. `selected_issuer_schema_ids` MUST be sorted and unique. `fee_query_commitments` bind payment to the blinded credential-use OPRF queries.
+
+The fee context MUST NOT include credential IDs, credential subjects, credential claims, credential blinding factors, account `leafIndex`, or nullifier output.
+
+### Receipt and Authorization Types
+
+`CredentialFeeReceipt` is presented to OPRF Nodes only. It is not part of the RP-facing proof response.
+
+```rust
+pub struct CredentialFeeReceipt {
+    pub fee_context_hash: [u8; 32],
+    pub expires_at: u64,
+    pub payments: Vec<CredentialFeePayment>,
+    pub proof: CredentialFeeReceiptProof,
+}
+
+pub struct CredentialFeePayment {
+    pub issuer_schema_id: u64,
+    pub policy_revision: u32,
+    pub token: Address,
+    pub amount: U256,
+    pub recipient: Address,
+}
+
+pub enum CredentialFeeReceiptProof {
+    Onchain { vault: Address, receipt_ref: [u8; 32] },
+    Signed { signer: Address, signature: Vec<u8> },
+}
+```
+
+`CredentialFeeReceiptProof` MAY be an on-chain receipt proof, a payment-processor signature, or another format accepted by OPRF Nodes. A receipt MUST cover every selected credential with an active nonzero fee.
+
+For each selected credential, the Authenticator requests a separate OPRF evaluation over:
+
+```text
+credential_use_query = H(
+    "WIP105 Credential Use",
+    leaf_index,
+    rp_id,
+    proof_type,
+    action,
+    nonce,
+    proof_request_digest,
+    issuer_schema_id,
+    fee_policy_revision
+)
+```
+
+`leaf_index` is private. The OPRF request includes a `CredentialUseQueryProof` proving that the hidden `leaf_index` is valid and that the blinded query was constructed with the public `issuer_schema_id` and request fields.
+
+```rust
+pub struct CredentialUseAuthorization {
+    pub issuer_schema_id: u64,
+    pub policy_revision: u32,
+    pub oprf_output: VerifiableOprfOutput,
+}
+
+pub struct CredentialUseQueryProof {
+    pub issuer_schema_id: u64,
+    pub policy_revision: u32,
+    pub blinded_query_commitment: [u8; 32],
+    pub proof: ZeroKnowledgeProof,
+}
+```
+
+### OPRF Authentication
+
+```rust
+pub struct NullifierOprfRequestAuthV2 {
+    pub base: NullifierOprfRequestAuthV1,
+    pub proof_request_digest: [u8; 32],
+    pub fee_context: WIP105FeeContextV1,
+    pub fee_receipts: Vec<CredentialFeeReceipt>,
+    pub credential_use_query_proofs: Vec<CredentialUseQueryProof>,
+}
+```
+
+Before returning a credential-use authorization, an OPRF Node MUST verify:
+
+1. The base nullifier OPRF authentication.
+2. Each credential-use query proof.
+3. The active fee policy for each selected `issuerSchemaId`.
+4. Receipt amounts, recipients, tokens, revisions, expiration, `fee_context_hash`, and replay protection.
+
+OPRF Nodes MAY issue credential-use authorizations without payment for zero-fee schemas.
+
+### Circuit Binding
+
+The WIP-105 credential proof circuit MUST:
+
+1. Recompute `credential_use_query` using the private `leaf_index` and public `issuer_schema_id`.
+2. Verify the credential-use OPRF output.
+3. Verify the credential signature whose signed message includes the same `issuer_schema_id`.
+4. Leave nullifier derivation unchanged.
+
+This is the direct enforcement mechanism. Paying for `issuerSchemaId = A` produces an authorization that cannot satisfy a proof whose public credential input is `issuerSchemaId = B`.
+
+### Flow
+
+1. RP signs a proof request.
+2. Authenticator selects the credentials it will prove.
+3. Payer pays active fees for those selected credentials.
+4. Authenticator sends receipts and credential-use query proofs to OPRF Nodes.
+5. OPRF Nodes return the normal nullifier OPRF output and one credential-use authorization per selected credential.
+6. Authenticator generates WIP-105 credential proofs.
+7. Verifier checks the proof using the WIP-105 verifying key.
+
+The verifier does not validate receipts or fee policies.
+
+## Rationale
+
+Credential fee data MUST NOT be added to nullifier derivation because changing fee context could produce different nullifiers for the same RP action. A separate credential-use OPRF output gives OPRF-enforced payment without weakening uniqueness.
+
+Fees are keyed by `issuerSchemaId` because it is already public in proof verification and identifies the issuer/schema pair.
+
+## Security and Privacy
+
+- WIP-105 assumes an honest threshold of OPRF Nodes enforces fee policy before issuing credential-use authorizations.
+- OPRF Nodes and the payment layer learn selected `issuerSchemaId`s.
+- Receipts MUST be bound to the fee context and credential-use query commitments.
+- Receipts bind to fee policy revisions. Fee increases SHOULD use an activation delay.
+
+## Backwards Compatibility
+
+Existing credentials remain valid. WIP-105 requires a new OPRF auth version and updated proof circuits/verifying keys for fee-enabled schemas.
+
+Schemas without active fees MAY continue using the existing proof flow during migration. Once a schema enables fees, compliant clients MUST use WIP-105 for proofs involving that schema.
+
+## Open Questions
+
+1. Should fee policies live in `CredentialSchemaIssuerRegistry` or a separate fee registry?
+2. Should WIP-105 standardize an on-chain receipt vault?
+3. Should RPs be able to set a maximum fee in the signed request?


### PR DESCRIPTION
This WIP adds per-proof fees for World ID credentials. Fees are configured per `issuerSchemaId` and charged only when a proof actually uses a credential for that schema.