### PR TITLE
chore: log wallet address on sim revert

### DIFF
--- a/services/relay/src/cli/chain.rs
+++ b/services/relay/src/cli/chain.rs
@@ -1,6 +1,6 @@
 use std::{sync::Arc, time::Duration};
 
-use alloy::providers::DynProvider;
+use alloy::{providers::DynProvider, signers::local::PrivateKeySigner};
 use alloy_primitives::Address;
 
 use crate::{
@@ -51,7 +51,7 @@ impl WorldChain {
     pub fn new(
         config: &WorldChainConfig,
         provider: Arc<DynProvider>,
-        wallet_address: Address,
+        signer: &PrivateKeySigner,
     ) -> Self {
         Self {
             world_id_registry: IWorldIDRegistryInstance::new(
@@ -69,7 +69,7 @@ impl WorldChain {
             world_id_source: IWorldIDSourceInstance::new(config.world_id_source, provider.clone()),
             bridge_interval: Duration::from_secs(config.bridge_interval),
             deployment_block: config.deployment_block,
-            wallet_address,
+            wallet_address: signer.address(),
             provider,
         }
     }

--- a/services/relay/src/cli/chain.rs
+++ b/services/relay/src/cli/chain.rs
@@ -1,6 +1,7 @@
 use std::{sync::Arc, time::Duration};
 
 use alloy::providers::DynProvider;
+use alloy_primitives::Address;
 
 use crate::{
     bindings::{
@@ -36,6 +37,10 @@ pub struct WorldChain {
 
     /// Block number at which the WorldIDSource contract was deployed.
     deployment_block: u64,
+
+    /// Address of the relay signer wallet (used in diagnostic logs so
+    /// operators can identify the funded account on insufficient-funds errors).
+    wallet_address: Address,
 }
 
 impl WorldChain {
@@ -43,7 +48,11 @@ impl WorldChain {
     ///
     /// This is intentionally synchronous -- provider construction is the caller's
     /// responsibility, keeping I/O at the edges.
-    pub fn new(config: &WorldChainConfig, provider: Arc<DynProvider>) -> Self {
+    pub fn new(
+        config: &WorldChainConfig,
+        provider: Arc<DynProvider>,
+        wallet_address: Address,
+    ) -> Self {
         Self {
             world_id_registry: IWorldIDRegistryInstance::new(
                 config.world_id_registry,
@@ -60,8 +69,13 @@ impl WorldChain {
             world_id_source: IWorldIDSourceInstance::new(config.world_id_source, provider.clone()),
             bridge_interval: Duration::from_secs(config.bridge_interval),
             deployment_block: config.deployment_block,
+            wallet_address,
             provider,
         }
+    }
+
+    pub fn wallet_address(&self) -> Address {
+        self.wallet_address
     }
 
     pub fn provider(&self) -> &Arc<DynProvider> {

--- a/services/relay/src/cli/mod.rs
+++ b/services/relay/src/cli/mod.rs
@@ -396,7 +396,7 @@ impl Cli {
             .parse()
             .map_err(|e| eyre::eyre!("failed to parse WALLET_PRIVATE_KEY: {e}"))?;
         let wallet_address = signer.address();
-        let wallet = EthereumWallet::from(signer);
+        let wallet = EthereumWallet::from(signer.clone());
 
         // Build the World Chain (source) provider from WORLDCHAIN_RPC_URL.
         // NOTE: blocks the health server briefly so `Engine` can own the single
@@ -416,7 +416,7 @@ impl Cli {
 
         spawn_wallet_metrics_task(wc_provider.clone(), wc_config.chain_id, wallet_address);
 
-        let world_chain = chain::WorldChain::new(&wc_config, wc_provider.clone(), wallet_address);
+        let world_chain = chain::WorldChain::new(&wc_config, wc_provider.clone(), &signer);
 
         let mut engine = Engine::new(world_chain);
 

--- a/services/relay/src/cli/mod.rs
+++ b/services/relay/src/cli/mod.rs
@@ -416,7 +416,7 @@ impl Cli {
 
         spawn_wallet_metrics_task(wc_provider.clone(), wc_config.chain_id, wallet_address);
 
-        let world_chain = chain::WorldChain::new(&wc_config, wc_provider.clone());
+        let world_chain = chain::WorldChain::new(&wc_config, wc_provider.clone(), wallet_address);
 
         let mut engine = Engine::new(world_chain);
 

--- a/services/relay/src/engine.rs
+++ b/services/relay/src/engine.rs
@@ -156,7 +156,11 @@ impl Engine {
                 relay_metrics::inc_propagate_outcome(relay_metrics::outcome::NOTHING_CHANGED);
             }
             Err(e) => {
-                warn!(error = %e, "propagateState simulation reverted");
+                warn!(
+                    error = %e,
+                    wallet = %self.world_chain.wallet_address(),
+                    "propagateState simulation reverted"
+                );
                 self.log.restore_pending(snapshot);
                 relay_metrics::record_pending_counts(&self.log);
                 relay_metrics::inc_propagate_outcome(relay_metrics::outcome::SIMULATION_REVERT);

--- a/services/relay/tests/it/permissioned_e2e.rs
+++ b/services/relay/tests/it/permissioned_e2e.rs
@@ -415,6 +415,7 @@ async fn e2e_engine_driven_pipeline() -> Result<()> {
     // Share a single wallet-backed provider between the engine and satellite
     // so nonce management is sequential (both send txs via signer(0)).
     let shared_signer = anvil.signer(0)?;
+    let shared_wallet_address = alloy::signers::Signer::address(&shared_signer);
     let shared_provider = Arc::new(
         ProviderBuilder::new()
             .wallet(alloy::network::EthereumWallet::from(shared_signer))
@@ -432,7 +433,7 @@ async fn e2e_engine_driven_pipeline() -> Result<()> {
         deployment_block: 0,
     };
 
-    let world_chain = WorldChain::new(&wc_config, shared_provider.clone());
+    let world_chain = WorldChain::new(&wc_config, shared_provider.clone(), shared_wallet_address);
     let mut engine = Engine::new(world_chain);
     let log = engine.log().clone();
 

--- a/services/relay/tests/it/permissioned_e2e.rs
+++ b/services/relay/tests/it/permissioned_e2e.rs
@@ -415,10 +415,9 @@ async fn e2e_engine_driven_pipeline() -> Result<()> {
     // Share a single wallet-backed provider between the engine and satellite
     // so nonce management is sequential (both send txs via signer(0)).
     let shared_signer = anvil.signer(0)?;
-    let shared_wallet_address = alloy::signers::Signer::address(&shared_signer);
     let shared_provider = Arc::new(
         ProviderBuilder::new()
-            .wallet(alloy::network::EthereumWallet::from(shared_signer))
+            .wallet(alloy::network::EthereumWallet::from(shared_signer.clone()))
             .connect_http(anvil.endpoint().parse().unwrap())
             .erased(),
     );
@@ -433,7 +432,7 @@ async fn e2e_engine_driven_pipeline() -> Result<()> {
         deployment_block: 0,
     };
 
-    let world_chain = WorldChain::new(&wc_config, shared_provider.clone(), shared_wallet_address);
+    let world_chain = WorldChain::new(&wc_config, shared_provider.clone(), &shared_signer);
     let mut engine = Engine::new(world_chain);
     let log = engine.log().clone();
 


### PR DESCRIPTION
## Summary
- Lets operators identify the funded account directly from the log (e.g. for "insufficient funds for gas" errors) instead of pulling the k8s secret.

## Test plan
- [ ] CI passes (relay unit + integration tests)
- [ ] After deploy, confirm next simulation-revert log line includes `wallet=0x…`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Diagnostic logging and constructor wiring only; no change to propagation, signing, or on-chain behavior.
> 
> **Overview**
> The relay now keeps the **World Chain signer address** on `WorldChain` (via an extra `PrivateKeySigner` argument to `WorldChain::new`) and exposes it with `wallet_address()`.
> 
> When `propagateState` **simulation reverts**, the warning log includes `wallet=0x…` so operators can see which funded account failed (e.g. insufficient gas) without looking up the k8s secret.
> 
> Startup and the permissioned E2E test **clone the signer** so the same key can back both the provider wallet and `WorldChain`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e8c8a0cd8eee3eeb034f1f1ff2a480b0b0de7aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->