### PR TITLE
chore: read tempo wallet balance from TIP-20 fee token

### DIFF
--- a/services/relay/src/bindings.rs
+++ b/services/relay/src/bindings.rs
@@ -263,6 +263,13 @@ sol! {
 // ── Sol interfaces ──────────────────────────────────────────────────────────
 
 sol! {
+    #[sol(rpc)]
+    interface IERC20 {
+        function balanceOf(address account) external view returns (uint256);
+    }
+}
+
+sol! {
     interface ICommitment {
         function updateRoot(uint256,uint256,bytes32);
         function setIssuerPubkey(uint64,uint256,uint256,bytes32);

--- a/services/relay/src/cli/mod.rs
+++ b/services/relay/src/cli/mod.rs
@@ -369,7 +369,13 @@ async fn log_tempo_wallet_status<P: Provider>(
 ) -> Result<()> {
     let erc20 = IERC20::new(TEMPO_FEE_TOKEN, provider);
     let (balance_call, nonce) = tokio::try_join!(
-        async { erc20.balanceOf(address).call().await.map_err(eyre::Error::from) },
+        async {
+            erc20
+                .balanceOf(address)
+                .call()
+                .await
+                .map_err(eyre::Error::from)
+        },
         async {
             provider
                 .get_transaction_count(address)
@@ -379,8 +385,7 @@ async fn log_tempo_wallet_status<P: Provider>(
     )?;
 
     let balance = balance_call;
-    let balance_usdc = format_units(balance, 6)
-        .unwrap_or_else(|_| balance.to_string());
+    let balance_usdc = format_units(balance, 6).unwrap_or_else(|_| balance.to_string());
 
     relay_metrics::set_wallet_balance_wei(chain_id, f64::from(balance));
 

--- a/services/relay/src/cli/mod.rs
+++ b/services/relay/src/cli/mod.rs
@@ -8,15 +8,22 @@ use alloy::{
     providers::{DynProvider, Provider, ProviderBuilder},
     signers::local::PrivateKeySigner,
 };
-use alloy_primitives::{Address, utils::format_ether};
+use alloy_primitives::{
+    Address,
+    utils::{format_ether, format_units},
+};
 use axum::{Router, extract::State, http::StatusCode, routing::get};
 use tempo_alloy::{TempoNetwork, provider::TempoProviderBuilderExt};
 
 use crate::{
+    bindings::IERC20,
     engine::Engine,
     log::CommitmentLog,
     metrics as relay_metrics,
-    satellite::{EthereumMptSatellite, PermissionedSatellite, TempoSatellite},
+    satellite::{
+        EthereumMptSatellite, PermissionedSatellite, TempoSatellite,
+        permissioned::tempo::FEE_TOKEN as TEMPO_FEE_TOKEN,
+    },
 };
 
 pub mod chain;
@@ -351,6 +358,45 @@ async fn log_wallet_status<P: Provider>(
     Ok(())
 }
 
+/// Tempo-specific wallet status: native `eth_getBalance` returns a placeholder
+/// (~4.24e75) on Tempo, so balance is read from the TIP-20 fee token contract
+/// directly via `balanceOf`. Logs in USDC.e units (6 decimals).
+async fn log_tempo_wallet_status<P: Provider>(
+    provider: &P,
+    address: Address,
+    chain_id: u64,
+    chain_name: &str,
+) -> Result<()> {
+    let erc20 = IERC20::new(TEMPO_FEE_TOKEN, provider);
+    let (balance_call, nonce) = tokio::try_join!(
+        async { erc20.balanceOf(address).call().await.map_err(eyre::Error::from) },
+        async {
+            provider
+                .get_transaction_count(address)
+                .await
+                .map_err(eyre::Error::from)
+        }
+    )?;
+
+    let balance = balance_call;
+    let balance_usdc = format_units(balance, 6)
+        .unwrap_or_else(|_| balance.to_string());
+
+    relay_metrics::set_wallet_balance_wei(chain_id, f64::from(balance));
+
+    tracing::info!(
+        %chain_name,
+        chain_id,
+        wallet = %address,
+        fee_token = %TEMPO_FEE_TOKEN,
+        %balance_usdc,
+        nonce = ?nonce,
+        "relay wallet status (tempo TIP-20 fee token)"
+    );
+
+    Ok(())
+}
+
 /// Fire-and-forget so a panicking metrics task can't bring down the engine.
 fn spawn_wallet_metrics_task(provider: Arc<DynProvider>, chain_id: u64, wallet_address: Address) {
     tokio::spawn(async move {
@@ -361,6 +407,36 @@ fn spawn_wallet_metrics_task(provider: Arc<DynProvider>, chain_id: u64, wallet_a
             relay_metrics::WALLET_METRICS_INTERVAL,
         )
         .await
+    });
+}
+
+/// Tempo variant: polls the TIP-20 fee token's `balanceOf` instead of
+/// native `eth_getBalance` (which returns a placeholder on Tempo).
+/// The value written to `relay.wallet.balance_wei{chain_id:4217}` is in
+/// USDC.e base units (6 decimals) — i.e. `106041276` = $106.04.
+fn spawn_tempo_wallet_metrics_task(
+    provider: Arc<DynProvider>,
+    chain_id: u64,
+    wallet_address: Address,
+) {
+    tokio::spawn(async move {
+        let mut ticker = tokio::time::interval(relay_metrics::WALLET_METRICS_INTERVAL);
+        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        let erc20 = IERC20::new(TEMPO_FEE_TOKEN, provider);
+        loop {
+            ticker.tick().await;
+            match erc20.balanceOf(wallet_address).call().await {
+                Ok(balance) => {
+                    relay_metrics::set_wallet_balance_wei(chain_id, f64::from(balance));
+                }
+                Err(e) => tracing::warn!(
+                    error = %e,
+                    chain_id,
+                    fee_token = %TEMPO_FEE_TOKEN,
+                    "failed to read tempo fee token balance"
+                ),
+            }
+        }
     });
 }
 
@@ -468,7 +544,7 @@ impl Cli {
                     let read_provider =
                         Arc::new(satellite_provider(&sat_config.name, &wallet).await?);
 
-                    log_wallet_status(
+                    log_tempo_wallet_status(
                         read_provider.as_ref(),
                         wallet_address,
                         sat_config.destination_chain_id,
@@ -476,7 +552,7 @@ impl Cli {
                     )
                     .await?;
 
-                    spawn_wallet_metrics_task(
+                    spawn_tempo_wallet_metrics_task(
                         read_provider.clone(),
                         sat_config.destination_chain_id,
                         wallet_address,

--- a/services/relay/src/satellite/mod.rs
+++ b/services/relay/src/satellite/mod.rs
@@ -1,5 +1,5 @@
 mod ethereum_mpt;
-mod permissioned;
+pub mod permissioned;
 
 pub use ethereum_mpt::EthereumMptSatellite;
 pub use permissioned::{PermissionedSatellite, TempoSatellite};

--- a/services/relay/src/satellite/permissioned/tempo.rs
+++ b/services/relay/src/satellite/permissioned/tempo.rs
@@ -20,8 +20,10 @@ use crate::{
 
 use super::build_chain_head_attribute;
 
-/// USDC.e (TIP-20) fee token on Tempo.
-const FEE_TOKEN: Address = address!("0x20c000000000000000000000b9537d11c60e8b50");
+/// USDC.e (TIP-20) fee token on Tempo. Gas on Tempo is paid in this token,
+/// not native ETH — `eth_getBalance` returns a placeholder value on Tempo,
+/// so wallet-balance checks must query `balanceOf` on this contract instead.
+pub const FEE_TOKEN: Address = address!("0x20c000000000000000000000b9537d11c60e8b50");
 
 /// A permissioned satellite targeting a Tempo blockchain destination.
 ///


### PR DESCRIPTION
## Summary
Tempo has no native gas token — `eth_getBalance` returns a placeholder value (~4.24e75) for any address. The relay's wallet-balance startup check and periodic metrics task both used `get_balance` for Tempo, so the gauge `world_id_relay.relay_wallet_balance_wei{chain_id:4217}` reported nonsense (and the existing balance monitor couldn't possibly be useful for Tempo).

Gas on Tempo is paid in the USDC.e TIP-20 token at `0x20c000000000000000000000b9537d11c60e8b50`. This PR reads `balanceOf(wallet)` on that contract instead, for both startup logging and the periodic gauge refresh.

Verified locally with the prod signer: startup log reports `balance_usdc=106.041276` matching the on-chain USDC.e balance.

## Changes
- `bindings.rs` — add `IERC20::balanceOf` sol binding.
- `satellite/permissioned/tempo.rs` — promote `FEE_TOKEN` to `pub` with explanatory comment.
- `satellite/mod.rs` — `pub mod permissioned` so the CLI can reach `FEE_TOKEN`.
- `cli/mod.rs` — new `log_tempo_wallet_status` and `spawn_tempo_wallet_metrics_task`; wire both into `ChainType::Tempo` startup in place of the native equivalents.

## Caveats
- The gauge `relay.wallet.balance_wei` keeps its name for the Tempo `chain_id` tag, but the unit is now USDC.e base units (6 decimals), not wei. Balance monitors must use different thresholds per chain — e.g. `chain_id:4217 < 50_000_000` for $50, `chain_id:480 < 5e16` for 0.05 ETH.
- No new metric / dashboard work in this PR.

## Test plan
- [x] `cargo check -p world-id-relay` passes
- [x] Local run with TEMPO-only prod config logged `balance_usdc=106.041276` at startup
- [ ] CI passes
- [ ] After deploy, confirm `world_id_relay.relay_wallet_balance_wei{chain_id:4217}` in Datadog reports a sane value (~1e8 for $100)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only change for Tempo startup logs and balance gauges; relay transaction paths are unchanged aside from reusing the existing fee token address.
> 
> **Overview**
> On **Tempo** satellites, wallet balance reporting no longer uses native `eth_getBalance` (which returns a meaningless placeholder). Startup logging and the periodic metrics loop now read **`IERC20::balanceOf`** on the public **USDC.e TIP-20 fee token** (`FEE_TOKEN`), with USDC-style logging at 6 decimals.
> 
> The relay adds a minimal **`IERC20`** binding, exports **`FEE_TOKEN`** from the Tempo satellite module, and wires **`log_tempo_wallet_status`** / **`spawn_tempo_wallet_metrics_task`** for `ChainType::Tempo` instead of the standard ETH paths.
> 
> **Operational note:** the existing `relay.wallet.balance_wei` gauge name is unchanged, but for Tempo `chain_id` the value is **USDC.e base units**, not wei—alert thresholds must differ per chain.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ddea9e5789a503c9b954ef447994b37fd9001ac4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->