### PR TITLE
chore: relax sanity check

### DIFF
--- a/services/indexer/src/sanity_check.rs
+++ b/services/indexer/src/sanity_check.rs
@@ -31,16 +31,16 @@ pub async fn root_sanity_check_loop(
 
         let local_root = tree_state.root().await;
 
-        // Check validity window on-chain first (covers slight lag vs current root)
-        let is_valid = match contract.isValidRoot(local_root).call().await {
+        let root_timestamp: U256 = match contract.getRootTimestamp(local_root).call().await {
             Ok(v) => v,
             Err(err) => {
-                tracing::error!(?err, "failed to call isValidRoot");
+                tracing::error!(?err, "failed to call getRootTimestamp");
                 continue;
             }
         };
 
-        if !is_valid {
+        // Root timestamp is only zero if the root was never recorded
+        if root_timestamp.is_zero() {
             // Fetch current on-chain root for diagnostics
             let current_onchain_root = match contract.currentRoot().call().await {
                 Ok(r) => r,
@@ -51,17 +51,33 @@ pub async fn root_sanity_check_loop(
             };
 
             tracing::error!(
-                local_root = %format!("0x{:x}", local_root),
-                current_onchain_root = %format!("0x{:x}", current_onchain_root),
+                local_root = %format!("0x{local_root:x}"),
+                current_onchain_root = %format!("0x{current_onchain_root:x}"),
                 "Local Merkle root is not valid on-chain"
             );
             return Err(crate::tree::TreeError::RootMismatch {
-                actual: format!("0x{:x}", local_root),
-                expected: format!("0x{:x}", current_onchain_root),
+                actual: format!("0x{local_root:x}"),
+                expected: format!("0x{current_onchain_root:x}"),
             }
             .into());
         } else {
-            tracing::debug!(local_root = %format!("0x{:x}", local_root), "Local Merkle root is valid on-chain");
+            tracing::debug!(local_root = %format!("0x{local_root:x}"), "Local Merkle root is valid on-chain");
+        }
+
+        let is_valid = match contract.isValidRoot(local_root).call().await {
+            Ok(v) => v,
+            Err(err) => {
+                tracing::error!(?err, "failed to call isValidRoot");
+                continue;
+            }
+        };
+
+        if !is_valid {
+            tracing::warn!(
+                local_root = %format!("0x{local_root:x}"),
+                root_timestamp = %root_timestamp,
+                "Local Merkle root is expired"
+            );
         }
     }
 }

--- a/services/indexer/src/sanity_check.rs
+++ b/services/indexer/src/sanity_check.rs
@@ -60,8 +60,6 @@ pub async fn root_sanity_check_loop(
                 expected: format!("0x{current_onchain_root:x}"),
             }
             .into());
-        } else {
-            tracing::debug!(local_root = %format!("0x{local_root:x}"), "Local Merkle root is valid on-chain");
         }
 
         let is_valid = match contract.isValidRoot(local_root).call().await {


### PR DESCRIPTION
Previously the sanity check would crash the indexer if the root was
expired, the this means that a crash can happen if there were no roots
recorded in a time window longer than the current root expiry (currently
set to an hour).

This relaxes the check so it only crashes if the current local root has
never been recorded and logs a warning if the local root is expired.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when the indexer exits on root drift vs continuing with an expired root, which affects liveness and how operators detect stale state.
> 
> **Overview**
> The periodic Merkle root sanity checker now **fails the indexer only when the local root was never recorded on-chain**, instead of treating any `isValidRoot` failure as fatal.
> 
> It first calls **`getRootTimestamp`**: a zero timestamp still triggers **`RootMismatch`** (with `currentRoot` for diagnostics). If the root was recorded but **`isValidRoot`** is false (expired within the on-chain window), the loop **logs a warning** with the timestamp and continues. Debug logging for valid roots was removed, and hex formatting uses inline `format!` variables.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 938310bc1779945265f426dbd183cd1e777aa160. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->