### PR TITLE
chore: bump indexer version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12471,7 +12471,7 @@ dependencies = [
 
 [[package]]
 name = "world-id-indexer"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "alloy",
  "ark-bn254 0.5.0",

--- a/services/indexer/Cargo.toml
+++ b/services/indexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "world-id-indexer"
-version = "0.1.4"
+version = "0.1.5"
 license.workspace = true
 edition.workspace = true
 publish = false


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Version-only metadata change with no code or dependency graph changes.
> 
> **Overview**
> Bumps the **`world-id-indexer`** crate from **0.1.4** to **0.1.5** in `services/indexer/Cargo.toml` and updates the matching **`[[package]]`** entry in **`Cargo.lock`**. No runtime or dependency changes beyond the version field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8beb628d876843844143a8d1a150664fda2979d6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->