### PR TITLE
refactor(node): small logging/metrics cleanup

### DIFF
--- a/services/oprf-node/src/auth.rs
+++ b/services/oprf-node/src/auth.rs
@@ -35,7 +35,7 @@ pub(crate) fn log_auth_module_error(
     if matches!(mapped, WorldIdRequestAuthError::Internal) {
         tracing::error!(?err, "Internal error in {module}");
     } else {
-        tracing::warn!(auth_error = true, %err, ?err, "Error in {module}: {err}");
+        tracing::warn!(auth_error = true, ?err, "Error in {module}: {err}");
     }
 }
 

--- a/services/oprf-node/src/auth/merkle_watcher.rs
+++ b/services/oprf-node/src/auth/merkle_watcher.rs
@@ -76,16 +76,13 @@ impl MerkleWatcher {
         http_rpc_provider: &web3::HttpRpcProvider,
         cache_config: WatcherCacheConfig,
     ) -> Self {
-        metrics::merkle_cache::reset();
-
         let contract = WorldIdRegistry::new(contract_address, http_rpc_provider.inner());
 
         let merkle_root_cache_builder = Cache::builder()
             .max_capacity(cache_config.max_cache_size.get())
             .time_to_live(cache_config.time_to_live)
             .eviction_listener(move |root, (), cause| {
-                tracing::debug!("removing merkle-root {root} because: {cause:?}");
-                metrics::merkle_cache::dec();
+                tracing::trace!("removing merkle-root {root} because: {cause:?}");
             });
 
         let merkle_root_cache = if let Some(time_to_idle) = cache_config.time_to_idle {
@@ -147,8 +144,10 @@ impl MerkleWatcher {
             .or_try_insert_with(is_valid_root)
             .await?;
         if entry.is_fresh() {
-            metrics::merkle_cache::inc();
+            self.merkle_root_cache.run_pending_tasks().await;
+            metrics::merkle_cache::set(self.merkle_root_cache.entry_count());
             metrics::merkle_cache::miss();
+            tracing::trace!("merkle root {root} loaded from chain");
         } else {
             metrics::merkle_cache::hit();
         }

--- a/services/oprf-node/src/auth/rp_registry_watcher.rs
+++ b/services/oprf-node/src/auth/rp_registry_watcher.rs
@@ -76,14 +76,11 @@ impl RpRegistryWatcher {
         timeout_external_eth_call: Duration,
         cache_config: WatcherCacheConfig,
     ) -> Self {
-        metrics::rp_registry_cache::reset();
-
         let rp_store_builder = Cache::builder()
             .max_capacity(cache_config.max_cache_size.get())
             .time_to_live(cache_config.time_to_live)
             .eviction_listener(move |k, v: RelyingParty, cause| {
-                tracing::debug!("removing rp {k}/{} because: {cause:?}", v.account_type);
-                metrics::rp_registry_cache::dec(v.account_type);
+                tracing::trace!("removing rp {k}/{} because: {cause:?}", v.account_type);
             });
         let rp_store = if let Some(time_to_idle) = cache_config.time_to_idle {
             rp_store_builder.time_to_idle(time_to_idle).build()
@@ -120,9 +117,10 @@ impl RpRegistryWatcher {
             .await?;
         let rp = if entry.is_fresh() {
             let rp = entry.into_value();
-            metrics::rp_registry_cache::inc(rp.account_type);
+            self.rp_store.run_pending_tasks().await;
+            metrics::rp_registry_cache::set(self.rp_store.entry_count());
             metrics::rp_registry_cache::miss();
-            tracing::debug!("rp {rp_id}/{} loaded from chain", rp.account_type);
+            tracing::trace!("rp {rp_id}/{} loaded from chain", rp.account_type);
             rp
         } else {
             metrics::rp_registry_cache::hit();

--- a/services/oprf-node/src/auth/schema_issuer_registry_watcher.rs
+++ b/services/oprf-node/src/auth/schema_issuer_registry_watcher.rs
@@ -62,14 +62,11 @@ impl SchemaIssuerRegistryWatcher {
         http_rpc_provider: &web3::HttpRpcProvider,
         cache_config: WatcherCacheConfig,
     ) -> Self {
-        metrics::schema_issuer_cache::reset();
-
         let store_builder = Cache::builder()
             .max_capacity(cache_config.max_cache_size.get())
             .time_to_live(cache_config.time_to_live)
             .eviction_listener(move |k, (), cause| {
-                tracing::debug!("removing issuer {k} because: {cause:?}");
-                metrics::schema_issuer_cache::dec();
+                tracing::trace!("removing issuer {k} because: {cause:?}");
             });
         let issuer_schema_store = if let Some(time_to_idle) = cache_config.time_to_idle {
             store_builder.time_to_idle(time_to_idle).build()
@@ -112,9 +109,10 @@ impl SchemaIssuerRegistryWatcher {
             .await?;
 
         if entry.is_fresh() {
-            metrics::schema_issuer_cache::inc();
+            self.issuer_schema_store.run_pending_tasks().await;
+            metrics::schema_issuer_cache::set(self.issuer_schema_store.entry_count());
             metrics::schema_issuer_cache::miss();
-            tracing::debug!("issuer {issuer_schema_id} loaded from chain");
+            tracing::trace!("issuer {issuer_schema_id} loaded from chain");
         } else {
             metrics::schema_issuer_cache::hit();
         }

--- a/services/oprf-node/src/metrics.rs
+++ b/services/oprf-node/src/metrics.rs
@@ -104,16 +104,8 @@ pub(crate) mod merkle_cache {
         );
     }
 
-    pub(crate) fn reset() {
-        metrics::gauge!(METRICS_ID_NODE_MERKLE_WATCHER_CACHE_SIZE).set(0.0);
-    }
-
-    pub(crate) fn inc() {
-        metrics::gauge!(METRICS_ID_NODE_MERKLE_WATCHER_CACHE_SIZE).increment(1);
-    }
-
-    pub(crate) fn dec() {
-        metrics::gauge!(METRICS_ID_NODE_MERKLE_WATCHER_CACHE_SIZE).decrement(1);
+    pub(crate) fn set(val: u64) {
+        metrics::gauge!(METRICS_ID_NODE_MERKLE_WATCHER_CACHE_SIZE).set(val as f64);
     }
 
     pub(crate) fn hit() {
@@ -126,10 +118,6 @@ pub(crate) mod merkle_cache {
 }
 
 pub(crate) mod rp_registry_cache {
-    use crate::auth::rp_module::RpAccountType;
-
-    /// Attribute ID attached to size metrics distinguishing the RP signer type.
-    const METRICS_ATTRID_RP_TYPE: &str = "type";
 
     /// Number of stored RPs in the `rp_registry_watcher` cache.
     const METRICS_ID_NODE_RP_REGISTRY_WATCHER_CACHE_SIZE: &str =
@@ -140,14 +128,6 @@ pub(crate) mod rp_registry_cache {
     /// Number of hits in the `rp_registry_watcher` cache.
     const METRICS_ID_NODE_RP_REGISTRY_WATCHER_CACHE_HITS: &str =
         "taceo.oprf.node.rp_registry_watcher_cache.hits";
-
-    fn label(ty: RpAccountType) -> &'static str {
-        match ty {
-            RpAccountType::Eoa => "eoa",
-            RpAccountType::Contract => "contract",
-            RpAccountType::IncompatibleWip101 => "incompatible_wip101",
-        }
-    }
 
     pub(super) fn describe_metrics() {
         metrics::describe_gauge!(
@@ -169,34 +149,8 @@ pub(crate) mod rp_registry_cache {
         );
     }
 
-    pub(crate) fn reset() {
-        for ty in [
-            RpAccountType::Eoa,
-            RpAccountType::Contract,
-            RpAccountType::IncompatibleWip101,
-        ] {
-            metrics::gauge!(
-                METRICS_ID_NODE_RP_REGISTRY_WATCHER_CACHE_SIZE,
-                METRICS_ATTRID_RP_TYPE => label(ty),
-            )
-            .set(0.0);
-        }
-    }
-
-    pub(crate) fn inc(ty: RpAccountType) {
-        metrics::gauge!(
-            METRICS_ID_NODE_RP_REGISTRY_WATCHER_CACHE_SIZE,
-            METRICS_ATTRID_RP_TYPE => label(ty),
-        )
-        .increment(1);
-    }
-
-    pub(crate) fn dec(ty: RpAccountType) {
-        metrics::gauge!(
-            METRICS_ID_NODE_RP_REGISTRY_WATCHER_CACHE_SIZE,
-            METRICS_ATTRID_RP_TYPE => label(ty),
-        )
-        .decrement(1);
+    pub(crate) fn set(val: u64) {
+        metrics::gauge!(METRICS_ID_NODE_RP_REGISTRY_WATCHER_CACHE_SIZE).set(val as f64);
     }
 
     pub(crate) fn hit() {
@@ -241,16 +195,8 @@ pub(crate) mod schema_issuer_cache {
         );
     }
 
-    pub(crate) fn reset() {
-        metrics::gauge!(METRICS_ID_NODE_SCHEMA_ISSUER_REGISTRY_WATCHER_CACHE_SIZE).set(0.0);
-    }
-
-    pub(crate) fn inc() {
-        metrics::gauge!(METRICS_ID_NODE_SCHEMA_ISSUER_REGISTRY_WATCHER_CACHE_SIZE).increment(1);
-    }
-
-    pub(crate) fn dec() {
-        metrics::gauge!(METRICS_ID_NODE_SCHEMA_ISSUER_REGISTRY_WATCHER_CACHE_SIZE).decrement(1);
+    pub(crate) fn set(val: u64) {
+        metrics::gauge!(METRICS_ID_NODE_SCHEMA_ISSUER_REGISTRY_WATCHER_CACHE_SIZE).set(val as f64);
     }
 
     pub(crate) fn hit() {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes are limited to tracing and Prometheus gauge updates; auth and on-chain validation paths are unchanged.
> 
> **Overview**
> Tightens **auth logging and cache observability** in `oprf-node` without changing validation behavior.
> 
> Client-attributable auth failures no longer log the same error twice in `log_auth_module_error` (drops redundant `%err` while keeping `?err`). Merkle, RP registry, and schema-issuer watchers stop maintaining cache size via `reset`/`inc`/`dec` on init and eviction; on a **fresh** cache insert they call `run_pending_tasks()` and publish **`entry_count()`** through new `metrics::*_cache::set` helpers. RP registry **cache size** is no longer split by account `type` label. Cache eviction and “loaded from chain” messages move from **debug** to **trace**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ea9d973239216684f9e6f931631cde036a5994f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->