### PR TITLE
fix: oprf release process

### DIFF
--- a/services/oprf-node/Cargo.toml
+++ b/services/oprf-node/Cargo.toml
@@ -6,7 +6,6 @@ rust-version.workspace = true
 homepage.workspace = true
 repository.workspace = true
 license.workspace = true
-publish = false
 
 [dependencies]
 alloy = { workspace = true, features = ["full", "rpc", "rpc-client-ws"] }


### PR DESCRIPTION
This was missing to create the GH release

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line packaging metadata change with no runtime or service logic impact.
> 
> **Overview**
> Fixes the **OPRF node** automated release by removing **`publish = false`** from `services/oprf-node/Cargo.toml`.
> 
> That manifest flag was preventing **release-plz** (used by `release-oprf-node` / `prepare-oprf-node-release`) from creating the expected **GitHub release** after version bumps. The crate is still not meant for **crates.io**—`services/oprf-node/release-plz.toml` keeps **`publish = false`** and **`git_only = true`** for `world-id-oprf-node`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6cf444da4f7d9ce3f3f41f514b199a1ea68095e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->