### PR TITLE
fix: batch commitments into smaller components for cold start

### DIFF
--- a/services/relay/src/satellite/mod.rs
+++ b/services/relay/src/satellite/mod.rs
@@ -25,19 +25,6 @@ const RELAY_TIMEOUT: Duration = Duration::from_secs(60);
 
 /// Maximum number of individual commitments to include in a single relay
 /// transaction.
-///
-/// A satellite that is far behind — most notably one being cold-started from a
-/// zero chain head — must replay its entire un-relayed backlog. Submitting that
-/// backlog as one transaction makes the transaction grow without bound: it can
-/// exceed the destination RPC's `eth_estimateGas` gas cap (so the relay never
-/// even gets sent) and, eventually, the destination block gas limit (so it can
-/// never be included at all). Splitting the delta into bounded chunks keeps
-/// every relay transaction cheap to estimate and includable. Each chunk still
-/// ends on a real on-chain chain head, so the satellite applies it
-/// incrementally via its keccak-chain check.
-///
-/// 64 commitments is ~4-5M gas — comfortably below typical estimateGas caps and
-/// block gas limits (e.g. Arc Mainnet's 30M) with ample margin.
 const MAX_COMMITMENTS_PER_RELAY: usize = 64;
 
 /// A destination chain that can receive bridged World ID state.
@@ -342,5 +329,143 @@ mod tests {
         let delta = vec![commitment_with(1)];
         let chunks = chunk_by_commitments(&delta, MAX_COMMITMENTS_PER_RELAY);
         assert_eq!(chunks.len(), 1);
+    }
+
+    /// End-to-end: fork Arc Mainnet, impersonate the relay operator, and drive
+    /// the **real** chunked relay path (`chunk_by_commitments` + `reduce` +
+    /// `sendMessage`) chunk-by-chunk through the *currently deployed* gateway
+    /// and satellite. Asserts the satellite's keccak chain advances from a zero
+    /// head all the way to the live source tip.
+    ///
+    /// Needs `WORLDCHAIN_RPC_URL` + `ARC_RPC_URL` and a local `anvil`.
+    #[tokio::test]
+    #[ignore = "forks Arc Mainnet; needs WORLDCHAIN_RPC_URL + ARC_RPC_URL + anvil"]
+    async fn cold_start_chunked_catch_up_reaches_source_tip_on_fork() -> eyre::Result<()> {
+        use crate::{
+            bindings::{IGateway, IWorldIDSatellite},
+            relay::encode_evm_v1_address,
+            satellite::permissioned::build_chain_head_attribute,
+        };
+        use alloy::{
+            node_bindings::Anvil,
+            primitives::{Address, U256, address},
+            providers::{Provider, ProviderBuilder, ext::AnvilApi},
+            rpc::types::{Filter, TransactionRequest},
+            sol_types::SolEvent,
+        };
+
+        const SOURCE: Address = address!("12E8f92fE5901c17341E4A445F6CF991fFc2909E");
+        const ARC_GATEWAY: Address = address!("2940Ce2f0f852230Cde632e203D327513b090206");
+        const ARC_SATELLITE: Address = address!("304E14e4dC0508C0927e3b307a2C18422C07E394");
+        const RELAYER: Address = address!("6348A4a4dF173F68eB28A452Ca6c13493e447aF1");
+        const ANCHOR_CHAIN_ID: u64 = 480;
+        const DEPLOYMENT_BLOCK: u64 = 29_732_292;
+
+        let (Ok(wc_url), Ok(arc_url)) = (
+            std::env::var("WORLDCHAIN_RPC_URL"),
+            std::env::var("ARC_RPC_URL"),
+        ) else {
+            eprintln!("skipping: set WORLDCHAIN_RPC_URL and ARC_RPC_URL");
+            return Ok(());
+        };
+
+        // ── Reconstruct the full backlog (the cold-start delta from head 0x0). ──
+        let wc = ProviderBuilder::new().connect_http(wc_url.parse()?);
+        let topic = IWorldIDSource::ChainCommitted::SIGNATURE_HASH;
+        let latest = wc.get_block_number().await?;
+        let mut delta: Vec<Arc<ChainCommitment>> = Vec::new();
+        let (mut from, chunk) = (DEPLOYMENT_BLOCK, 50_000u64);
+        while from <= latest {
+            let to = (from + chunk - 1).min(latest);
+            let filter = Filter::new()
+                .address(SOURCE)
+                .event_signature(topic)
+                .from_block(from)
+                .to_block(to);
+            for log in wc.get_logs(&filter).await? {
+                let ev = IWorldIDSource::ChainCommitted::decode_log(&log.inner)?;
+                delta.push(Arc::new(ChainCommitment {
+                    chain_head: ev.keccakChain,
+                    block_number: ev.blockNumber.to::<u64>(),
+                    chain_id: ev.chainId.to::<u64>(),
+                    commitment_payload: ev.commitment.clone(),
+                    timestamp: 0,
+                }));
+            }
+            from = to + 1;
+        }
+        let target_head = delta.last().expect("backlog non-empty").chain_head;
+        let target_len: usize = delta.iter().map(|c| commitment_count(c)).sum();
+        println!(
+            "backlog: {} events / {} commitments → tip {target_head}",
+            delta.len(),
+            target_len
+        );
+
+        // ── Fork Arc and impersonate the relay operator (gateway owner). ────────
+        let anvil = Anvil::new().fork(arc_url).spawn();
+        let fork = ProviderBuilder::new().connect_http(anvil.endpoint_url());
+        fork.anvil_impersonate_account(RELAYER).await?;
+        fork.anvil_set_balance(RELAYER, U256::from(10u128.pow(20)))
+            .await?;
+
+        let satellite = IWorldIDSatellite::new(ARC_SATELLITE, &fork);
+        let start = satellite.KECCAK_CHAIN().call().await?;
+        assert_eq!(start.head, B256::ZERO, "satellite must start cold");
+        assert_eq!(start.length, 0);
+
+        // ── Drive the production chunking path chunk-by-chunk. ──────────────────
+        let recipient = encode_evm_v1_address(ANCHOR_CHAIN_ID, ARC_SATELLITE);
+        let chunks = chunk_by_commitments(&delta, MAX_COMMITMENTS_PER_RELAY);
+        let n_chunks = chunks.len();
+        for (i, chunk) in chunks.into_iter().enumerate() {
+            let merged = reduce(chunk)?;
+            let calldata = IGateway::sendMessageCall {
+                recipient: recipient.clone().into(),
+                payload: merged.commitment_payload.clone(),
+                attributes: vec![build_chain_head_attribute(merged.chain_head)],
+            }
+            .abi_encode();
+            let tx = TransactionRequest::default()
+                .from(RELAYER)
+                .to(ARC_GATEWAY)
+                .input(calldata.into());
+            let receipt = fork.send_transaction(tx).await?.get_receipt().await?;
+            assert!(
+                receipt.status(),
+                "chunk {} of {n_chunks} reverted on-chain",
+                i + 1
+            );
+            let now = satellite.KECCAK_CHAIN().call().await?;
+            println!(
+                "  chunk {:>2}/{n_chunks}: {:>2} events, gas {:>8} → head {} (len {})",
+                i + 1,
+                chunk.len(),
+                receipt.gas_used,
+                now.head,
+                now.length
+            );
+        }
+
+        // ── The satellite must now sit at the live source tip. ──────────────────
+        let end = satellite.KECCAK_CHAIN().call().await?;
+        assert_eq!(
+            end.head, target_head,
+            "satellite head must reach source tip"
+        );
+        assert_eq!(
+            end.length as usize, target_len,
+            "all commitments must apply"
+        );
+
+        let sat_root = satellite.LATEST_ROOT().call().await?;
+        let src_root = IWorldIDSource::new(SOURCE, &wc)
+            .LATEST_ROOT()
+            .call()
+            .await?;
+        assert_eq!(sat_root, src_root, "satellite root must equal source root");
+        println!("caught up to tip: head {} root {sat_root}", end.head);
+
+        Ok(())
     }
 }

--- a/services/relay/src/satellite/mod.rs
+++ b/services/relay/src/satellite/mod.rs
@@ -7,10 +7,14 @@ use tracing::Instrument;
 
 use std::{future::Future, pin::Pin, sync::Arc, time::Duration};
 
-use alloy::primitives::{B256, Bytes};
+use alloy::{
+    primitives::{B256, Bytes},
+    sol_types::SolValue,
+};
 use eyre::Result;
 
 use crate::{
+    bindings::IWorldIDSource,
     log::CommitmentLog,
     metrics as relay_metrics,
     primitives::{ChainCommitment, reduce},
@@ -18,6 +22,23 @@ use crate::{
 
 /// Maximum time to wait for a single relay attempt (proof + transaction).
 const RELAY_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Maximum number of individual commitments to include in a single relay
+/// transaction.
+///
+/// A satellite that is far behind — most notably one being cold-started from a
+/// zero chain head — must replay its entire un-relayed backlog. Submitting that
+/// backlog as one transaction makes the transaction grow without bound: it can
+/// exceed the destination RPC's `eth_estimateGas` gas cap (so the relay never
+/// even gets sent) and, eventually, the destination block gas limit (so it can
+/// never be included at all). Splitting the delta into bounded chunks keeps
+/// every relay transaction cheap to estimate and includable. Each chunk still
+/// ends on a real on-chain chain head, so the satellite applies it
+/// incrementally via its keccak-chain check.
+///
+/// 64 commitments is ~4-5M gas — comfortably below typical estimateGas caps and
+/// block gas limits (e.g. Arc Mainnet's 30M) with ample margin.
+const MAX_COMMITMENTS_PER_RELAY: usize = 64;
 
 /// A destination chain that can receive bridged World ID state.
 pub trait Satellite: Send + Sync {
@@ -98,54 +119,64 @@ pub fn spawn_satellite(
                     }
                 };
 
-                let count = delta.len();
-                let merged = reduce(&delta)?;
-                let target_head = merged.chain_head;
+                // Relay the delta in bounded chunks so a large backlog (e.g. a
+                // cold-start from a zero head) is never submitted as a single
+                // oversized transaction. Each chunk ends on a real on-chain
+                // chain head, so the satellite applies them incrementally; on
+                // the first failure we stop and retry the remainder (from the
+                // now-advanced `local_head`) on the next head change.
+                let chunks = chunk_by_commitments(&delta, MAX_COMMITMENTS_PER_RELAY);
+                let chunk_total = chunks.len();
 
-                tracing::debug!(
-                    commitments = count,
-                    target = %target_head,
-                    "relaying delta"
-                );
+                for (chunk_idx, chunk) in chunks.into_iter().enumerate() {
+                    let count = chunk.len();
+                    let merged = reduce(chunk)?;
+                    let target_head = merged.chain_head;
 
-                tracing::info!(
-                    commitments = count,
-                    target_head = %target_head,
-                    "submitting satellite relay"
-                );
+                    tracing::info!(
+                        commitments = count,
+                        chunk = chunk_idx + 1,
+                        chunks = chunk_total,
+                        target_head = %target_head,
+                        "submitting satellite relay"
+                    );
 
-                let outcome = tokio::time::timeout(RELAY_TIMEOUT, satellite.relay(&merged)).await;
+                    let outcome =
+                        tokio::time::timeout(RELAY_TIMEOUT, satellite.relay(&merged)).await;
 
-                match outcome {
-                    Ok(Ok(tx_hash)) => {
-                        local_head = target_head;
-                        tracing::info!(
-                            %tx_hash,
-                            head = %local_head,
-                            delta_count = count,
-                            target_head = %target_head,
-                            "relay succeeded"
-                        );
-                        relay_metrics::inc_satellite_relay_outcome(
-                            &satellite_name,
-                            relay_metrics::outcome::SUCCESS,
-                        );
-                    }
-                    Ok(Err(e)) => {
-                        tracing::warn!(error = %e, "relay failed, will retry on next head");
-                        relay_metrics::inc_satellite_relay_outcome(
-                            &satellite_name,
-                            relay_metrics::outcome::RELAY_FAILED,
-                        );
-                    }
-                    Err(_) => {
-                        tracing::warn!(
-                            "relay timed out after {RELAY_TIMEOUT:?}, will retry on next head"
-                        );
-                        relay_metrics::inc_satellite_relay_outcome(
-                            &satellite_name,
-                            relay_metrics::outcome::TIMEOUT,
-                        );
+                    match outcome {
+                        Ok(Ok(tx_hash)) => {
+                            local_head = target_head;
+                            tracing::info!(
+                                %tx_hash,
+                                head = %local_head,
+                                delta_count = count,
+                                target_head = %target_head,
+                                "relay succeeded"
+                            );
+                            relay_metrics::inc_satellite_relay_outcome(
+                                &satellite_name,
+                                relay_metrics::outcome::SUCCESS,
+                            );
+                        }
+                        Ok(Err(e)) => {
+                            tracing::warn!(error = %e, "relay failed, will retry on next head");
+                            relay_metrics::inc_satellite_relay_outcome(
+                                &satellite_name,
+                                relay_metrics::outcome::RELAY_FAILED,
+                            );
+                            break;
+                        }
+                        Err(_) => {
+                            tracing::warn!(
+                                "relay timed out after {RELAY_TIMEOUT:?}, will retry on next head"
+                            );
+                            relay_metrics::inc_satellite_relay_outcome(
+                                &satellite_name,
+                                relay_metrics::outcome::TIMEOUT,
+                            );
+                            break;
+                        }
                     }
                 }
             }
@@ -186,4 +217,130 @@ async fn resync_head(satellite: &impl Satellite, log: &CommitmentLog, stale_head
         "destination head not found in log either, waiting"
     );
     stale_head
+}
+
+/// Number of individual commitments carried by a single `ChainCommitment`.
+///
+/// Falls back to `1` if the payload cannot be decoded (it always can in
+/// practice — the log only accepts entries whose payload decoded and
+/// hash-chained correctly), so a chunk is never sized at zero.
+fn commitment_count(commitment: &ChainCommitment) -> usize {
+    Vec::<IWorldIDSource::Commitment>::abi_decode_params(&commitment.commitment_payload)
+        .map(|c| c.len())
+        .unwrap_or(1)
+        .max(1)
+}
+
+/// Splits `delta` into contiguous chunks, each holding at most
+/// `max_commitments` individual commitments.
+///
+/// Entries are never split: a `ChainCommitment`'s proven chain head is only
+/// valid once *all* of its commitments are applied, so each entry stays whole.
+/// A single entry larger than the cap is emitted as its own chunk (we always
+/// make progress).
+fn chunk_by_commitments(
+    delta: &[Arc<ChainCommitment>],
+    max_commitments: usize,
+) -> Vec<&[Arc<ChainCommitment>]> {
+    let mut chunks = Vec::new();
+    let mut start = 0;
+    let mut acc = 0usize;
+
+    for (i, entry) in delta.iter().enumerate() {
+        let n = commitment_count(entry);
+        // Flush the in-progress chunk before adding an entry that would push it
+        // over the cap — but only if the chunk already has at least one entry.
+        if i > start && acc + n > max_commitments {
+            chunks.push(&delta[start..i]);
+            start = i;
+            acc = 0;
+        }
+        acc += n;
+    }
+    if start < delta.len() {
+        chunks.push(&delta[start..]);
+    }
+    chunks
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bindings::ICommitment;
+    use alloy::{
+        primitives::U256,
+        sol_types::{SolCall, SolValue},
+    };
+
+    /// Builds a `ChainCommitment` carrying `n` individual commitments.
+    fn commitment_with(n: usize) -> Arc<ChainCommitment> {
+        let commits: Vec<IWorldIDSource::Commitment> = (0..n)
+            .map(|i| IWorldIDSource::Commitment {
+                blockHash: B256::with_last_byte(i as u8),
+                data: ICommitment::updateRootCall {
+                    _0: U256::from(i as u64),
+                    _1: U256::from(1u64),
+                    _2: B256::ZERO,
+                }
+                .abi_encode()
+                .into(),
+            })
+            .collect();
+        Arc::new(ChainCommitment {
+            chain_head: B256::with_last_byte(n as u8),
+            block_number: 1,
+            chain_id: 480,
+            commitment_payload: commits.abi_encode_params().into(),
+            timestamp: 0,
+        })
+    }
+
+    fn total_commitments(chunk: &[Arc<ChainCommitment>]) -> usize {
+        chunk.iter().map(|c| commitment_count(c)).sum()
+    }
+
+    #[test]
+    fn commitment_count_decodes_payload() {
+        assert_eq!(commitment_count(&commitment_with(3)), 3);
+        assert_eq!(commitment_count(&commitment_with(1)), 1);
+    }
+
+    #[test]
+    fn chunks_cover_all_entries_in_order() {
+        let delta: Vec<_> = (0..10).map(|_| commitment_with(2)).collect();
+        let chunks = chunk_by_commitments(&delta, 6); // 3 entries (6 commits) per chunk
+        assert_eq!(chunks.iter().map(|c| c.len()).sum::<usize>(), delta.len());
+        // Reassembling the chunks reproduces the original sequence.
+        let flat: Vec<_> = chunks.iter().flat_map(|c| c.iter()).collect();
+        assert!(
+            flat.iter()
+                .zip(delta.iter())
+                .all(|(a, b)| Arc::ptr_eq(a, b))
+        );
+    }
+
+    #[test]
+    fn no_chunk_exceeds_cap_when_entries_fit() {
+        let delta: Vec<_> = (0..10).map(|_| commitment_with(2)).collect();
+        for chunk in chunk_by_commitments(&delta, 6) {
+            assert!(total_commitments(chunk) <= 6);
+            assert!(!chunk.is_empty());
+        }
+    }
+
+    #[test]
+    fn oversized_single_entry_becomes_its_own_chunk() {
+        // One entry alone exceeds the cap — it must still be emitted, alone.
+        let delta = vec![commitment_with(2), commitment_with(100), commitment_with(2)];
+        let chunks = chunk_by_commitments(&delta, 8);
+        assert_eq!(chunks.len(), 3);
+        assert_eq!(total_commitments(chunks[1]), 100);
+    }
+
+    #[test]
+    fn small_delta_is_a_single_chunk() {
+        let delta = vec![commitment_with(1)];
+        let chunks = chunk_by_commitments(&delta, MAX_COMMITMENTS_PER_RELAY);
+        assert_eq!(chunks.len(), 1);
+    }
 }

--- a/services/relay/tests/it/arc_cold_start_repro.rs
+++ b/services/relay/tests/it/arc_cold_start_repro.rs
@@ -1,0 +1,219 @@
+//! Live reproduction of the Arc Mainnet cold-start relay failure.
+//!
+//! Reconstructs the exact `gateway.sendMessage` transaction the relay submits
+//! when bootstrapping the Arc satellite from a zero chain head (i.e. the full
+//! historical backlog merged into a single relay), then runs `eth_estimateGas`
+//! against Arc Mainnet to determine whether the transaction is rejected for
+//! gas/size reasons or a logic revert. Also probes smaller chunks (each ending
+//! at a real intermediate chain head) to size a chunked fix.
+//!
+//! Run with:
+//!   cargo test -p world-id-relay --test it -- --ignored --nocapture arc_cold_start
+
+use alloy::{
+    primitives::{Address, B256, Bytes, address, keccak256},
+    providers::{Provider, ProviderBuilder},
+    rpc::types::{Filter, TransactionRequest},
+    sol_types::{SolCall, SolEvent, SolValue},
+};
+use world_id_relay::bindings::{IGateway, IWorldIDSource};
+
+// RPC endpoints are read from the environment so no API keys live in the repo:
+//   WORLDCHAIN_RPC_URL  — World Chain Mainnet (source, chain 480)
+//   ARC_RPC_URL         — Arc Mainnet (satellite, chain 5042)
+
+/// Chunk cap mirrored from `satellite::MAX_COMMITMENTS_PER_RELAY` to verify the
+/// fix: every chunk must be cheaply estimable.
+const MAX_COMMITMENTS_PER_RELAY: usize = 64;
+
+const SOURCE: Address = address!("12E8f92fE5901c17341E4A445F6CF991fFc2909E");
+const ARC_GATEWAY: Address = address!("2940Ce2f0f852230Cde632e203D327513b090206");
+const ARC_SATELLITE: Address = address!("304E14e4dC0508C0927e3b307a2C18422C07E394");
+const RELAYER: Address = address!("6348A4a4dF173F68eB28A452Ca6c13493e447aF1");
+const ANCHOR_CHAIN_ID: u64 = 480;
+const DEPLOYMENT_BLOCK: u64 = 29_732_292;
+const ARC_BLOCK_GAS_LIMIT: u64 = 30_000_000;
+
+/// ERC-7930 EVM v1 interoperable address (mirrors `relay::encode_evm_v1_address`).
+fn encode_evm_v1_address(chain_id: u64, addr: Address) -> Vec<u8> {
+    let chain_id_bytes = chain_id.to_be_bytes();
+    let first_nonzero = chain_id_bytes.iter().position(|&b| b != 0).unwrap_or(7);
+    let chain_ref = &chain_id_bytes[first_nonzero..];
+    let mut buf = Vec::with_capacity(2 + 2 + 1 + chain_ref.len() + 1 + 20);
+    buf.extend_from_slice(&[0x00, 0x01]);
+    buf.extend_from_slice(&[0x00, 0x00]);
+    buf.push(chain_ref.len() as u8);
+    buf.extend_from_slice(chain_ref);
+    buf.push(0x14);
+    buf.extend_from_slice(addr.as_slice());
+    buf
+}
+
+/// `chainHead(bytes32)` attribute (mirrors `permissioned::build_chain_head_attribute`).
+fn build_chain_head_attribute(chain_head: B256) -> Bytes {
+    let selector = &keccak256(b"chainHead(bytes32)")[..4];
+    let encoded_head = chain_head.abi_encode();
+    let mut attribute = Vec::with_capacity(4 + encoded_head.len());
+    attribute.extend_from_slice(selector);
+    attribute.extend_from_slice(&encoded_head);
+    attribute.into()
+}
+
+fn build_send_message_calldata(commits: &[IWorldIDSource::Commitment], head: B256) -> Bytes {
+    let recipient = encode_evm_v1_address(ANCHOR_CHAIN_ID, ARC_SATELLITE);
+    let payload: Bytes = commits.abi_encode_params().into();
+    let attribute = build_chain_head_attribute(head);
+    IGateway::sendMessageCall {
+        recipient: recipient.into(),
+        payload,
+        attributes: vec![attribute],
+    }
+    .abi_encode()
+    .into()
+}
+
+async fn estimate(arc: &impl Provider, calldata: Bytes) -> Result<u64, String> {
+    let tx = TransactionRequest::default()
+        .from(RELAYER)
+        .to(ARC_GATEWAY)
+        .input(calldata.into());
+    arc.estimate_gas(tx).await.map_err(|e| e.to_string())
+}
+
+#[tokio::test]
+#[ignore = "hits live World Chain + Arc Mainnet RPCs"]
+async fn arc_cold_start_gas_repro() -> eyre::Result<()> {
+    let (Ok(wc_url), Ok(arc_url)) = (
+        std::env::var("WORLDCHAIN_RPC_URL"),
+        std::env::var("ARC_RPC_URL"),
+    ) else {
+        eprintln!("skipping: set WORLDCHAIN_RPC_URL and ARC_RPC_URL to run this live test");
+        return Ok(());
+    };
+
+    let wc = ProviderBuilder::new().connect_http(wc_url.parse()?);
+    let arc = ProviderBuilder::new().connect_http(arc_url.parse()?);
+
+    // ── 1. Fetch every ChainCommitted event from genesis, in order. ──────────
+    // Keep per-event (head, commits) so chunk probes can use real intermediate heads.
+    let topic = IWorldIDSource::ChainCommitted::SIGNATURE_HASH;
+    let latest = wc.get_block_number().await?;
+    let mut events: Vec<(B256, Vec<IWorldIDSource::Commitment>)> = Vec::new();
+
+    let mut from = DEPLOYMENT_BLOCK;
+    const CHUNK: u64 = 50_000;
+    while from <= latest {
+        let to = (from + CHUNK - 1).min(latest);
+        let filter = Filter::new()
+            .address(SOURCE)
+            .event_signature(topic)
+            .from_block(from)
+            .to_block(to);
+        for log in wc.get_logs(&filter).await? {
+            let decoded = IWorldIDSource::ChainCommitted::decode_log(&log.inner)?;
+            let batch = Vec::<IWorldIDSource::Commitment>::abi_decode_params(&decoded.commitment)?;
+            events.push((decoded.keccakChain, batch));
+        }
+        from = to + 1;
+    }
+
+    let all_commits: Vec<IWorldIDSource::Commitment> =
+        events.iter().flat_map(|(_, c)| c.iter().cloned()).collect();
+    let last_head = events.last().map(|(h, _)| *h).unwrap_or(B256::ZERO);
+
+    println!("── Arc cold-start reconstruction ──");
+    println!("events (ChainCommitted):   {}", events.len());
+    println!("total commitments:         {}", all_commits.len());
+
+    let onchain = IWorldIDSource::new(SOURCE, &wc)
+        .KECCAK_CHAIN()
+        .call()
+        .await?;
+    println!("reconstructed head:        {last_head}");
+    println!(
+        "on-chain source head:      {} (length={})",
+        onchain.head, onchain.length
+    );
+    assert_eq!(
+        last_head, onchain.head,
+        "reconstructed head must match source"
+    );
+    assert_eq!(
+        all_commits.len() as u64,
+        onchain.length,
+        "commit count must match length"
+    );
+
+    // ── 2. Full cold-start relay (what the relay submits today). ─────────────
+    let full = build_send_message_calldata(&all_commits, last_head);
+    println!("\nFULL cold-start sendMessage:");
+    println!("calldata size:             {} bytes", full.len());
+    match estimate(&arc, full).await {
+        Ok(gas) => println!(
+            "estimate_gas:              {gas}  (arc limit {ARC_BLOCK_GAS_LIMIT}) → {}",
+            if gas > ARC_BLOCK_GAS_LIMIT {
+                "EXCEEDS LIMIT"
+            } else {
+                "fits"
+            }
+        ),
+        Err(e) => println!("estimate_gas ERROR:        {e}"),
+    }
+
+    // ── 3. The transaction itself is VALID: eth_call with explicit gas (under
+    //       Arc's 30M block limit) succeeds. The failure is purely the
+    //       eth_estimateGas gas cap, not a logic revert or the block limit.
+    println!("\nFULL tx eth_call with explicit gas (bypasses the estimate gas cap):");
+    let full = build_send_message_calldata(&all_commits, last_head);
+    for gas in [29_000_000u64, 200_000_000] {
+        let tx = TransactionRequest::default()
+            .from(RELAYER)
+            .to(ARC_GATEWAY)
+            .gas_limit(gas)
+            .input(full.clone().into());
+        println!(
+            "  gas_limit={gas:>10}  {}",
+            match arc.call(tx).await {
+                Ok(out) => format!(
+                    "OK ({} bytes returned) → tx is valid & includable",
+                    out.len()
+                ),
+                Err(e) => format!("revert: {e}"),
+            }
+        );
+    }
+
+    // ── 4. Verify the fix: chunking to MAX_COMMITMENTS_PER_RELAY makes every
+    //       relay tx cheaply estimable. The first chunk starts from the live
+    //       zero head, so we can estimate it directly against Arc.
+    println!("\nFix: chunk the backlog to <= {MAX_COMMITMENTS_PER_RELAY} commitments/tx");
+    let mut chunk_events = 0usize;
+    let mut chunk_commits: Vec<IWorldIDSource::Commitment> = Vec::new();
+    for (head, batch) in &events {
+        if !chunk_commits.is_empty()
+            && chunk_commits.len() + batch.len() > MAX_COMMITMENTS_PER_RELAY
+        {
+            break;
+        }
+        chunk_commits.extend(batch.iter().cloned());
+        chunk_events += 1;
+        let _ = head;
+    }
+    let first_chunk_head = events[chunk_events - 1].0;
+    let cd = build_send_message_calldata(&chunk_commits, first_chunk_head);
+    let n_chunks = all_commits.len().div_ceil(MAX_COMMITMENTS_PER_RELAY);
+    println!(
+        "  first chunk: {} events / {} commitments / {} bytes",
+        chunk_events,
+        chunk_commits.len(),
+        cd.len()
+    );
+    match estimate(&arc, cd).await {
+        Ok(gas) => {
+            println!("  estimate_gas: {gas}  → SUCCEEDS (cold-start completes in ~{n_chunks} txs)")
+        }
+        Err(e) => println!("  estimate_gas ERROR: {e}"),
+    }
+
+    Ok(())
+}

--- a/services/relay/tests/it/main.rs
+++ b/services/relay/tests/it/main.rs
@@ -1,3 +1,4 @@
+mod arc_cold_start_repro;
 mod permissioned_e2e;
 mod testsuite;
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes core satellite relay submission behavior for large backlogs; incorrect chunking or head advancement could stall or mis-order bridging, though logic is covered by new unit tests and matches incremental on-chain heads.
> 
> **Overview**
> Fixes satellite **cold-start** failures where the relay tried to submit the entire backlog as one `gateway.sendMessage` transaction, which could blow past destination `eth_estimateGas` caps and block gas limits (e.g. Arc Mainnet).
> 
> The relay loop now splits each delta into chunks capped at **64 individual commitments** per tx (`MAX_COMMITMENTS_PER_RELAY`). Each chunk is merged with `reduce` and relayed sequentially; `local_head` advances per successful chunk, and the loop **breaks** on relay failure or timeout so the remainder retries on the next head change. `ChainCommitment` log entries are never split—only whole entries are grouped, with oversized single entries allowed as their own chunk.
> 
> Adds unit tests for `chunk_by_commitments` and an **ignored** live integration test (`arc_cold_start_repro`) that reconstructs Arc cold-start calldata and compares full vs chunked `estimate_gas` behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b8ffb08d35c3a55f841c0016a914aed78a33a12. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->