### PR TITLE
feat: clearer OHTTP client error messages

### DIFF
--- a/crates/authenticator/src/error.rs
+++ b/crates/authenticator/src/error.rs
@@ -98,21 +98,53 @@ pub enum AuthenticatorError {
         max_supported_slot: usize,
     },
 
-    /// OHTTP encapsulation or decapsulation error.
+    /// OHTTP encapsulation error (encrypting the request, or parsing the
+    /// relay's key config list). This is a client-side crypto/encoding failure.
     #[error("OHTTP encapsulation error: {0}")]
     OhttpEncapsulationError(#[from] ohttp::Error),
+
+    /// OHTTP decapsulation error: the relay returned a `message/ohttp-res`
+    /// response that could not be decrypted. Indicates a genuine OHTTP crypto
+    /// failure (e.g. key mismatch), distinct from a non-OHTTP response body.
+    #[error("OHTTP decapsulation error: {0}")]
+    OhttpDecapsulationError(ohttp::Error),
 
     /// Binary HTTP framing error.
     #[error("Binary HTTP error: {0}")]
     BhttpError(#[from] bhttp::Error),
 
-    /// The OHTTP relay itself returned a non-success status.
-    #[error("OHTTP relay error (status {status}): {body}")]
+    /// The OHTTP request was rejected before decapsulation: the relay (or the
+    /// gateway, via an RFC 9458 §5.2 plaintext error such as a 401 key/config
+    /// mismatch) returned a non-success status. The fault is on the relay leg
+    /// or the gateway's pre-decapsulation handling, not the target service.
+    #[error(
+        "OHTTP request for {service} rejected before decapsulation (status {status}) via relay {relay_url}: {body}"
+    )]
     OhttpRelayError {
+        /// Service scope this request was for (e.g. `ohttp_gateway`).
+        service: String,
+        /// URL of the OHTTP relay the request was sent to.
+        relay_url: String,
         /// HTTP status code from the relay.
         status: StatusCode,
         /// Response body from the relay.
         body: String,
+    },
+
+    /// The OHTTP relay returned a 2xx response that is not `message/ohttp-res`,
+    /// so there is nothing to decapsulate. The gateway only sets that
+    /// content-type on a successful 2xx, so this never originates from the
+    /// gateway — it is a relay-leg condition, most commonly a captive portal or
+    /// transparent proxy on the client network intercepting the connection.
+    #[error(
+        "OHTTP relay {relay_url} returned a non-OHTTP response (content-type: {}); a captive portal or proxy may be intercepting the connection",
+        content_type.as_deref().unwrap_or("none")
+    )]
+    OhttpRelayInvalidResponse {
+        /// URL of the OHTTP relay the request was sent to.
+        relay_url: String,
+        /// The `Content-Type` of the unexpected response, if present.
+        content_type: Option<String>,
     },
 
     /// A service returned a success status but the response body could not be

--- a/crates/authenticator/src/error.rs
+++ b/crates/authenticator/src/error.rs
@@ -35,6 +35,22 @@ pub enum AuthenticatorError {
         body: String,
     },
 
+    /// A service (gateway or indexer), or an upstream target it depends on, is
+    /// temporarily unavailable (HTTP 502/503/504). Distinct from a generic 5xx
+    /// application error: these statuses specifically indicate an unreachable or
+    /// overloaded upstream. Per RFC 9458 §5.2 a gateway that cannot reach its
+    /// target returns 504, so an OHTTP inner 504 surfaces here once the gateway
+    /// emits it.
+    #[error(
+        "{service} is unavailable (status {status}); the service or an upstream target may be down or unreachable"
+    )]
+    ServiceUnavailable {
+        /// Which service was being called (e.g. `gateway`, `indexer`).
+        service: String,
+        /// The HTTP status code (502, 503, or 504).
+        status: StatusCode,
+    },
+
     /// Indexer returned an error response.
     #[error("Indexer error (status {status}): {body}")]
     IndexerError {

--- a/crates/authenticator/src/ohttp.rs
+++ b/crates/authenticator/src/ohttp.rs
@@ -28,6 +28,17 @@ impl OhttpClientConfig {
     }
 }
 
+/// Returns `true` if `content_type` is the OHTTP response media type
+/// `message/ohttp-res`, matched loosely: case-insensitive and ignoring any
+/// parameters (e.g. `message/ohttp-res; charset=utf-8`).
+fn is_ohttp_res_content_type(content_type: &str) -> bool {
+    content_type
+        .split(';')
+        .next()
+        .map(str::trim)
+        .is_some_and(|media_type| media_type.eq_ignore_ascii_case("message/ohttp-res"))
+}
+
 /// Parsed response from an OHTTP-decapsulated Binary HTTP message.
 #[derive(Debug)]
 pub struct OhttpResponse {
@@ -42,6 +53,7 @@ pub struct OhttpResponse {
 #[derive(Clone, Debug)]
 pub struct OhttpClient {
     client: Client,
+    config_scope: String,
     relay_url: String,
     target_scheme: String,
     target_authority: String,
@@ -97,6 +109,7 @@ impl OhttpClient {
 
         Ok(Self {
             client,
+            config_scope: config_scope.to_owned(),
             relay_url: config.relay_url,
             target_scheme,
             target_authority,
@@ -160,13 +173,36 @@ impl OhttpClient {
 
         if !resp.status().is_success() {
             return Err(AuthenticatorError::OhttpRelayError {
+                service: self.config_scope.clone(),
+                relay_url: self.relay_url.clone(),
                 status: resp.status(),
                 body: resp.text().await.unwrap_or_default(),
             });
         }
 
+        // RFC 9458: a successful OHTTP exchange is returned as `message/ohttp-res`.
+        // The gateway sets this content-type only on a 2xx success; any other 2xx
+        // body (e.g. a captive portal or proxy HTML page) is not decryptable, so
+        // reject it with a clear error instead of a cryptic decapsulation failure.
+        let content_type = resp
+            .headers()
+            .get(reqwest::header::CONTENT_TYPE)
+            .and_then(|value| value.to_str().ok())
+            .map(str::to_owned);
+        if !content_type
+            .as_deref()
+            .is_some_and(is_ohttp_res_content_type)
+        {
+            return Err(AuthenticatorError::OhttpRelayInvalidResponse {
+                relay_url: self.relay_url.clone(),
+                content_type,
+            });
+        }
+
         let enc_response = resp.bytes().await?;
-        let response_buf = ohttp_resp_ctx.decapsulate(&enc_response)?;
+        let response_buf = ohttp_resp_ctx
+            .decapsulate(&enc_response)
+            .map_err(AuthenticatorError::OhttpDecapsulationError)?;
 
         let response_msg = Message::read_bhttp(&mut std::io::Cursor::new(&response_buf))?;
         let status_code = response_msg

--- a/crates/authenticator/src/ohttp.rs
+++ b/crates/authenticator/src/ohttp.rs
@@ -339,4 +339,134 @@ mod tests {
             "expected InvalidConfig for empty key config, got: {result:?}"
         );
     }
+
+    #[test]
+    fn ohttp_res_content_type_matches_loosely() {
+        // Exact, parameterised, and differently-cased variants all match.
+        assert!(is_ohttp_res_content_type("message/ohttp-res"));
+        assert!(is_ohttp_res_content_type(
+            "message/ohttp-res; charset=utf-8"
+        ));
+        assert!(is_ohttp_res_content_type("Message/OHTTP-Res"));
+        assert!(is_ohttp_res_content_type("message/ohttp-res ; foo=bar"));
+
+        // Anything else (including the request media type) is rejected.
+        assert!(!is_ohttp_res_content_type("message/ohttp-req"));
+        assert!(!is_ohttp_res_content_type("text/html"));
+        assert!(!is_ohttp_res_content_type("application/json"));
+        assert!(!is_ohttp_res_content_type(""));
+    }
+
+    /// Builds a valid base64 `application/ohttp-keys` config list so that
+    /// [`OhttpClient::new`] succeeds and the request path can encapsulate.
+    fn test_key_config_base64() -> String {
+        ohttp::init();
+        let config = ohttp::KeyConfig::new(
+            1,
+            ohttp::hpke::Kem::X25519Sha256,
+            vec![ohttp::SymmetricSuite::new(
+                ohttp::hpke::Kdf::HkdfSha256,
+                ohttp::hpke::Aead::Aes128Gcm,
+            )],
+        )
+        .expect("failed to build test key config");
+        let encoded =
+            ohttp::KeyConfig::encode_list(&[config]).expect("failed to encode test key config");
+        base64::engine::general_purpose::STANDARD.encode(encoded)
+    }
+
+    fn test_client(relay_url: String) -> OhttpClient {
+        OhttpClient::new(
+            reqwest::Client::new(),
+            "ohttp_gateway",
+            "https://target.example",
+            OhttpClientConfig::new(relay_url, test_key_config_base64()),
+        )
+        .expect("failed to construct test OhttpClient")
+    }
+
+    #[tokio::test]
+    async fn relay_non_success_status_yields_relay_error_with_scope_and_url() {
+        let mut server = mockito::Server::new_async().await;
+        let relay_url = server.url();
+        let mock = server
+            .mock("POST", "/")
+            .with_status(502)
+            .with_body("upstream boom")
+            .create_async()
+            .await;
+
+        let client = test_client(relay_url.clone());
+        let result = client.get("/account").await;
+
+        match result {
+            Err(AuthenticatorError::OhttpRelayError {
+                service,
+                relay_url: err_relay_url,
+                status,
+                body,
+            }) => {
+                assert_eq!(service, "ohttp_gateway");
+                assert_eq!(err_relay_url, relay_url);
+                assert_eq!(status, StatusCode::BAD_GATEWAY);
+                assert_eq!(body, "upstream boom");
+            }
+            other => panic!("expected OhttpRelayError, got: {other:?}"),
+        }
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn relay_2xx_non_ohttp_content_type_yields_invalid_response() {
+        let mut server = mockito::Server::new_async().await;
+        let relay_url = server.url();
+        // A captive portal / proxy intercepting the connection returns 200 HTML.
+        let mock = server
+            .mock("POST", "/")
+            .with_status(200)
+            .with_header("content-type", "text/html")
+            .with_body("<html>captive portal</html>")
+            .create_async()
+            .await;
+
+        let client = test_client(relay_url.clone());
+        let result = client.get("/account").await;
+
+        match result {
+            Err(AuthenticatorError::OhttpRelayInvalidResponse {
+                relay_url: err_relay_url,
+                content_type,
+            }) => {
+                assert_eq!(err_relay_url, relay_url);
+                assert_eq!(content_type.as_deref(), Some("text/html"));
+            }
+            other => panic!("expected OhttpRelayInvalidResponse, got: {other:?}"),
+        }
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn ohttp_res_with_undecryptable_body_yields_decapsulation_error() {
+        let mut server = mockito::Server::new_async().await;
+        let relay_url = server.url();
+        // Correct content-type but a body that is not a valid encapsulated
+        // response: this must surface as a *decapsulation* error, never as the
+        // encapsulation error the two used to share.
+        let mock = server
+            .mock("POST", "/")
+            .with_status(200)
+            .with_header("content-type", "message/ohttp-res")
+            .with_body("not a valid encapsulated response")
+            .create_async()
+            .await;
+
+        let client = test_client(relay_url);
+        let result = client.get("/account").await;
+
+        match result {
+            Err(AuthenticatorError::OhttpDecapsulationError(_)) => {}
+            other => panic!("expected OhttpDecapsulationError, got: {other:?}"),
+        }
+        mock.assert_async().await;
+    }
 }

--- a/crates/authenticator/src/service_client.rs
+++ b/crates/authenticator/src/service_client.rs
@@ -95,6 +95,25 @@ impl ServiceClient {
     }
 
     fn error_from_response(&self, resp: &TransportResponse) -> AuthenticatorError {
+        let service = match self.service_kind {
+            ServiceKind::Gateway => "gateway",
+            ServiceKind::Indexer => "indexer",
+        };
+
+        // 502/503/504 specifically signal an unreachable or overloaded upstream
+        // (RFC 9458 §5.2 uses 504 for a gateway that cannot reach its target).
+        // Surface them as a clear "service unavailable" error rather than a raw
+        // 5xx body, which is typically an opaque infra error page.
+        if matches!(
+            resp.status,
+            StatusCode::BAD_GATEWAY | StatusCode::SERVICE_UNAVAILABLE | StatusCode::GATEWAY_TIMEOUT
+        ) {
+            return AuthenticatorError::ServiceUnavailable {
+                service: service.to_owned(),
+                status: resp.status,
+            };
+        }
+
         let body = String::from_utf8_lossy(&resp.body).into_owned();
         match self.service_kind {
             ServiceKind::Gateway => AuthenticatorError::GatewayError {


### PR DESCRIPTION
## Summary

Improves the accuracy of error messages surfaced on the OHTTP request path in the authenticator. Today, non-crypto failures are misattributed to OHTTP crypto — e.g. a target service being unreachable surfaces as a cryptic "decapsulation" error, and a captive portal returning a 200 HTML page also fails as an opaque decapsulation error.

All changes are server-agnostic and do **not** depend on matching the server's error body (so they remain portable across any RFC 9458 gateway). No server change is required.

## Changes

- **Split decapsulation from encapsulation errors** — `OhttpEncapsulationError` previously printed "encapsulation error" for *both* encrypt and decrypt failures. Added a dedicated `OhttpDecapsulationError` so a failed decrypt is labelled accurately.
- **Content-type guard before decapsulation** — a 2xx relay response that is not `message/ohttp-res` (loose, case-insensitive match) now returns `OhttpRelayInvalidResponse` instead of a cryptic decap failure. The gateway only sets that content-type on success, so this is provably a relay-leg condition — most commonly a captive portal / transparent proxy intercepting the client network.
- **Relay errors carry scope + relay URL** — `OhttpRelayError` now includes the `service` scope and `relay_url`, and its message reflects that a non-2xx outer response means the request was rejected *before* decapsulation (relay leg, or the gateway's RFC 9458 §5.2 pre-decap plaintext rejections such as a 401 key/config mismatch).
- **Inner 502/503/504 → service unavailable** — inner statuses that signal an unreachable/overloaded upstream now map to a clear `ServiceUnavailable` error rather than a raw 5xx body. RFC 9458 §5.2 uses 504 for a gateway that cannot reach its target; this installs the correct client behaviour now (no effect on the current gateway, which returns 500, until a server follow-up lands).

## Out of scope

The headline "target-unreachable shows as decapsulation" symptom is **not** client-fixable: RFC 9458 §5.2 mandates that post-decapsulation and target errors be encapsulated (inner response, outer 200), so there is no outer-layer signal. The portable fix is server-side — emit a distinct inner status (504, not 500) for target-unreachable — and is recommended as a follow-up on the gateway.

## Tests

- Pure unit test for the loose `message/ohttp-res` matcher.
- mockito-based request-path tests: relay non-2xx → `OhttpRelayError` (scope + URL populated); 2xx non-OHTTP content-type → `OhttpRelayInvalidResponse`; correct content-type with an undecryptable body → `OhttpDecapsulationError`.
