### PR TITLE
build(node): bump to latest oprf version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10123,27 +10123,9 @@ dependencies = [
 
 [[package]]
 name = "taceo-nodes-common"
-version = "0.5.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "158a4265e0eb2f65ef786ddccf870bb63829bc1e00b6d4e4a97666bdc68209ee"
-dependencies = [
- "backon",
- "git-version",
- "humantime-serde",
- "secrecy",
- "serde",
- "sqlx",
- "thiserror 2.0.18",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "taceo-nodes-common"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cb26c280819a49d38da5e896faad160b7341ae1614654d0dd0859395cfae24c"
+checksum = "f588f7f9a52606e62ec32f75d8a01f8e43b85eca0e1744303503a9dbd21e4969"
 dependencies = [
  "alloy",
  "axum",
@@ -10164,9 +10146,9 @@ dependencies = [
 
 [[package]]
 name = "taceo-oprf"
-version = "0.15.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "363805cdb094ef0d45895c616310523457e550267db0dcb3c195b3ee3ca54b71"
+checksum = "1b4f49c8462cb704e9a141490e36b9aba424e4b23524331ecd938c3451c50bd9"
 dependencies = [
  "taceo-oprf-client",
  "taceo-oprf-core",
@@ -10250,9 +10232,9 @@ dependencies = [
 
 [[package]]
 name = "taceo-oprf-service"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7544ff62e852bf4885b7a6cdef86578d4472704918250d1ee137888978a11559"
+checksum = "eca77dc6b86cff39a566ed5b83c42b7338bf8c9d62959d63c664f2246965abeb"
 dependencies = [
  "alloy",
  "ark-serialize 0.5.0",
@@ -10262,9 +10244,7 @@ dependencies = [
  "backon",
  "ciborium",
  "eyre",
- "futures",
  "http 1.4.0",
- "humantime",
  "humantime-serde",
  "metrics",
  "moka",
@@ -10276,7 +10256,7 @@ dependencies = [
  "serde_json",
  "sqlx",
  "taceo-ark-babyjubjub",
- "taceo-nodes-common 0.7.0",
+ "taceo-nodes-common",
  "taceo-oprf-core",
  "taceo-oprf-types",
  "thiserror 2.0.18",
@@ -10291,31 +10271,27 @@ dependencies = [
 
 [[package]]
 name = "taceo-oprf-test-utils"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8bb3bf80ed8dea86da3ad115870f404d685e4ca6a3f7eac43e444418f32718"
+checksum = "163a5c0190465de8f8fe7a65a0f733f3b9e96e597a740c40031e02b80c083835"
 dependencies = [
  "alloy",
  "ark-ec 0.5.0",
  "ark-ff 0.5.0",
- "async-trait",
  "eyre",
  "futures",
  "itertools 0.14.0",
- "parking_lot",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
- "reqwest 0.12.28",
  "serde_json",
  "sqlx",
  "taceo-ark-babyjubjub",
- "taceo-nodes-common 0.5.2",
+ "taceo-nodes-common",
  "taceo-oprf-core",
  "taceo-oprf-types",
  "testcontainers-modules",
  "tokio",
  "tokio-util",
- "tracing",
 ]
 
 [[package]]
@@ -12586,7 +12562,7 @@ dependencies = [
  "taceo-ark-babyjubjub",
  "taceo-circom-types",
  "taceo-eddsa-babyjubjub",
- "taceo-nodes-common 0.7.0",
+ "taceo-nodes-common",
  "taceo-oprf",
  "telemetry-batteries",
  "thiserror 2.0.18",
@@ -12755,7 +12731,7 @@ dependencies = [
  "serde_json",
  "taceo-ark-babyjubjub",
  "taceo-eddsa-babyjubjub",
- "taceo-nodes-common 0.7.0",
+ "taceo-nodes-common",
  "taceo-oprf",
  "taceo-oprf-test-utils",
  "taceo-poseidon2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,8 +74,8 @@ itertools = "0.14"
 k256 = { version = "0.13" }
 sha2 = { version = "0.11", default-features = false }
 taceo-groth16-sol = { version = "0.3.1" }
-taceo-oprf = { version = "0.15.1", default-features = false }
-taceo-oprf-test-utils = { version = "0.13", default-features = false }
+taceo-oprf = { version = "0.16", default-features = false }
+taceo-oprf-test-utils = { version = "0.14", default-features = false }
 telemetry-batteries = "0.2"
 tikv-jemallocator = "0.6"
 ruint = { version = "1.17", features = ["ark-ff-05"] }

--- a/crates/test-utils/src/stubs.rs
+++ b/crates/test-utils/src/stubs.rs
@@ -220,9 +220,17 @@ async fn spawn_orpf_node(
 
     tokio::spawn(async move {
         let cancellation_token = CancellationToken::new();
-        let router = world_id_oprf_node::start(config, secret_manager, cancellation_token.clone())
+        let node_information = secret_manager
+            .load_node_information()
             .await
-            .expect("Can start");
+            .expect("Can load node information");
+        let router = world_id_oprf_node::start(
+            config,
+            secret_manager,
+            node_information,
+            cancellation_token.clone(),
+        )
+        .expect("Can start");
         let listener = tokio::net::TcpListener::bind(bind_addr)
             .await
             .expect("Can bind listener");

--- a/services/oprf-node/src/bin/world-id-oprf-node.rs
+++ b/services/oprf-node/src/bin/world-id-oprf-node.rs
@@ -17,7 +17,7 @@ use config::{Config, Environment};
 use eyre::Context;
 use serde::Deserialize;
 use taceo_nodes_common::postgres::PostgresConfig;
-use taceo_oprf::service::secret_manager::postgres::PostgresSecretManager;
+use taceo_oprf::service::secret_manager::{SecretManager, postgres::PostgresSecretManager};
 use world_id_oprf_node::config::WorldOprfNodeConfig;
 
 #[derive(Clone, Debug, Deserialize)]
@@ -92,13 +92,18 @@ async fn run(config: FullWorldOprfNodeConfig) -> eyre::Result<()> {
     let bind_addr = config.bind_addr;
     let max_wait_time_shutdown = config.max_wait_time_shutdown;
 
+    let node_information = secret_manager
+        .load_node_information()
+        .await
+        .context("while loading node information")?;
+
     tracing::info!("starting world-node service...");
     let oprf_service_router = world_id_oprf_node::start(
         config.node_config,
         secret_manager,
+        node_information,
         cancellation_token.clone(),
-    )
-    .await?;
+    )?;
 
     let server = tokio::spawn({
         let cancellation_token = cancellation_token.clone();

--- a/services/oprf-node/src/lib.rs
+++ b/services/oprf-node/src/lib.rs
@@ -31,8 +31,9 @@ use std::sync::Arc;
 use ark_bn254::Bn254;
 use circom_types::groth16::VerificationKey;
 use eyre::Context;
-use taceo_oprf::service::{
-    OprfServiceBuilder, StartedServices, secret_manager::SecretManagerService,
+use taceo_oprf::{
+    service::{OprfServiceBuilder, StartedServices, secret_manager::SecretManagerService},
+    types::service::NodeInformation,
 };
 use tokio_util::sync::CancellationToken;
 use world_id_primitives::oprf::OprfModule;
@@ -90,9 +91,10 @@ pub mod metrics;
     clippy::missing_panics_doc,
     reason = "Can realistically not panic as we embed the key at compile time"
 )]
-pub async fn start(
+pub fn start(
     config: WorldOprfNodeConfig,
     secret_manager: SecretManagerService,
+    node_information: NodeInformation,
     cancellation_token: CancellationToken,
 ) -> eyre::Result<axum::Router> {
     let node_config = config.node_config;
@@ -171,9 +173,9 @@ pub async fn start(
         node_config,
         secret_manager,
         started_services,
-        cancellation_token.clone(),
-    )
-    .await?
+        node_information,
+        cancellation_token,
+    )?
     .module(
         &format!("/{}", OprfModule::Nullifier),
         nullifier_oprf_req_auth_service,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches OPRF node bootstrap and secret-manager integration on a critical path; scope is small but mis-loaded node metadata could break service initialization.
> 
> **Overview**
> **Bumps** `taceo-oprf` to **0.16** and `taceo-oprf-test-utils` to **0.14**, with `Cargo.lock` aligned to a single **`taceo-nodes-common` 0.7.3** dependency.
> 
> **Adapts OPRF node startup** to the new library API: callers **`load_node_information()`** on the secret manager (via the `SecretManager` trait) and pass the resulting **`NodeInformation`** into `world_id_oprf_node::start` and `OprfServiceBuilder::init`. **`start` is now synchronous** (`pub fn` / `?` instead of `.await?`), with async loading done in the binary and test stubs before invoking it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ed4797b01ba01bced7fbf34c850b991e5073694. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->