### PR TITLE
fix(node): fixes a test-cases

### DIFF
--- a/services/oprf-node/src/auth/rp_registry_watcher.rs
+++ b/services/oprf-node/src/auth/rp_registry_watcher.rs
@@ -223,8 +223,11 @@ mod tests {
         let watcher = RpRegistryWatcher::init(
             rp_registry,
             http_rpc_provider,
-            ttl,
-            WatcherCacheConfig::default(),
+            Duration::from_secs(10),
+            WatcherCacheConfig {
+                time_to_live: ttl,
+                ..Default::default()
+            },
         );
 
         Ok((watcher, anvil, rp_fixture, rp_registry))
@@ -319,7 +322,7 @@ mod tests {
         );
         tokio::time::sleep(Duration::from_secs(2)).await;
         assert!(
-            watcher.rp_store.contains_key(&rp_fixture.world_rp_id),
+            !watcher.rp_store.contains_key(&rp_fixture.world_rp_id),
             "RP should NOT be in cache anymore"
         );
         let rp2 = watcher.get_rp(&rp_fixture.world_rp_id).await?;


### PR DESCRIPTION
NOTE: this is actually not a fix, but needed to
create a release PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes in rp_registry_watcher.rs; no production init or runtime behavior is modified.
> 
> **Overview**
> Adjusts **`RpRegistryWatcher` unit test setup** so cache TTL and eth-call timeout are passed to `init` the same way as production: a fixed **10s** external call timeout and the test’s `ttl` on **`WatcherCacheConfig.time_to_live`**, instead of using `ttl` as the timeout argument.
> 
> Updates **`test_cache_ttl_expiry`** to expect the RP entry to be **evicted** from `rp_store` after sleeping past the 1s TTL (assertion flipped to `!contains_key`), matching the test’s intent that cached RPs expire and can be refetched.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 208ab9857a2f38097486b5670b30c939f0668680. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->