### PR TITLE
chore: update telemetry batteries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10390,9 +10390,9 @@ dependencies = [
 
 [[package]]
 name = "telemetry-batteries"
-version = "0.2.1"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389eb13150fdfb5c2a79f333a8d71808cd024e1335d73d184590e2a02e0dd53a"
+checksum = "87b9214761fa0b4c2879a491aa4109a4036dc3c1ac9f47ba42ae15916fba7b23"
 dependencies = [
  "backtrace",
  "bon",
@@ -10418,8 +10418,8 @@ dependencies = [
  "tower",
  "tracing",
  "tracing-appender",
- "tracing-error",
  "tracing-opentelemetry",
+ "tracing-opentelemetry-instrumentation-sdk",
  "tracing-serde 0.1.3",
  "tracing-subscriber 0.3.22",
 ]
@@ -11100,6 +11100,19 @@ dependencies = [
  "tracing-log",
  "tracing-subscriber 0.3.22",
  "web-time",
+]
+
+[[package]]
+name = "tracing-opentelemetry-instrumentation-sdk"
+version = "0.32.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8f2540011f6d5ac30e1fc9ff169573b4559406498ac27e0242549d9bf527ed1"
+dependencies = [
+ "http 1.4.0",
+ "opentelemetry",
+ "opentelemetry-semantic-conventions",
+ "tracing",
+ "tracing-opentelemetry",
 ]
 
 [[package]]
@@ -12565,7 +12578,7 @@ dependencies = [
 
 [[package]]
 name = "world-id-oprf-node"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "alloy",
  "ark-bn254 0.5.0",
@@ -12733,6 +12746,7 @@ dependencies = [
  "metrics",
  "metrics-util",
  "serde",
+ "telemetry-batteries",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ sha2 = { version = "0.11", default-features = false }
 taceo-groth16-sol = { version = "0.3.1" }
 taceo-oprf = { version = "0.16", default-features = false }
 taceo-oprf-test-utils = { version = "0.14", default-features = false }
-telemetry-batteries = "0.2"
+telemetry-batteries = "0.3"
 tikv-jemallocator = "0.6"
 ruint = { version = "1.17", features = ["ark-ff-05"] }
 poseidon2 = { package = "taceo-poseidon2", version = "0.2" }

--- a/services/common/Cargo.toml
+++ b/services/common/Cargo.toml
@@ -31,6 +31,7 @@ serde = { workspace = true }
 thiserror = { workspace = true }
 url = { workspace = true }
 tracing = { workspace = true }
+telemetry-batteries = { workspace = true }
 
 backon = { workspace = true }
 config = { workspace = true }

--- a/services/common/src/server_layers.rs
+++ b/services/common/src/server_layers.rs
@@ -6,86 +6,13 @@ use std::{
 };
 
 use axum::response::IntoResponse;
-use http::{Request, StatusCode};
+use http::Request;
+use telemetry_batteries::tracing::middleware::TraceLayer;
 use tower::Layer;
-use tower_http::trace::{DefaultOnRequest, MakeSpan, OnResponse, TraceLayer};
-use tracing::Span;
-
-/// Custom span maker that includes HTTP method and path in every request
-/// span.
-#[derive(Clone, Debug)]
-pub struct MakeRequestSpan;
-
-impl<B> MakeSpan<B> for MakeRequestSpan {
-    fn make_span(&mut self, request: &Request<B>) -> Span {
-        // don't create a span for /health endpoint
-        if request.uri().path() == "/health" {
-            return Span::none();
-        }
-
-        tracing::debug_span!(
-            "request",
-            method = %request.method(),
-            path = %request.uri(),
-        )
-    }
-}
-
-/// Custom response handler that only logs when there's an active span
-#[derive(Clone)]
-pub struct ConditionalOnResponse;
-
-impl<B> OnResponse<B> for ConditionalOnResponse {
-    fn on_response(
-        self,
-        response: &axum::http::Response<B>,
-        latency: std::time::Duration,
-        span: &Span,
-    ) {
-        let message = format!(
-            "{}Request completed with status {} in {}ms",
-            if response.status() == StatusCode::BAD_REQUEST {
-                "🟡 Bad "
-            } else {
-                ""
-            },
-            response.status(),
-            latency.as_millis()
-        );
-
-        let error_status = [
-            StatusCode::INTERNAL_SERVER_ERROR,
-            StatusCode::BAD_GATEWAY,
-            StatusCode::SERVICE_UNAVAILABLE,
-            StatusCode::GATEWAY_TIMEOUT,
-        ];
-
-        if error_status.contains(&response.status()) {
-            tracing::error!(
-                message,
-                status = %response.status(),
-                latency = ?latency,
-            );
-        } else if !span.is_disabled() && response.status() != StatusCode::NOT_FOUND {
-            tracing::debug!(
-                message,
-                status = %response.status(),
-                latency = ?latency,
-            );
-        }
-    }
-}
 
 /// Creates a [`TraceLayer`] with method and path on every request span.
-pub fn trace_layer() -> TraceLayer<
-    tower_http::classify::SharedClassifier<tower_http::classify::ServerErrorsAsFailures>,
-    MakeRequestSpan,
-    DefaultOnRequest,
-    ConditionalOnResponse,
-> {
-    TraceLayer::new_for_http()
-        .make_span_with(MakeRequestSpan)
-        .on_response(ConditionalOnResponse)
+pub fn trace_layer() -> TraceLayer {
+    TraceLayer::default()
 }
 
 /// Tower layer that responds with a caller-supplied structured error when a


### PR DESCRIPTION
Updates telemetry-batteries to 0.3.1 use the new & improved trace layer

The new version has:

1. Fixed tracing context extraction from request headers
2. Improved trace span creation modeled after will-bank/datadog-tracing which includes a lot of useful properties & fields understood by DD
3. Disables env filtering on traces, now it only applies to logs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Request tracing and log output for services using `trace_layer()` will change with the library swap, which affects observability but not core auth or data paths.
> 
> **Overview**
> Bumps the workspace **`telemetry-batteries`** dependency from **0.2** to **0.3** and wires it into **`world-id-services-common`**.
> 
> **`trace_layer()`** in `server_layers.rs` no longer builds a custom **`tower-http`** trace stack (`MakeRequestSpan`, conditional response logging, `/health` span suppression). It now returns **`telemetry_batteries::tracing::middleware::TraceLayer::default()`**, so HTTP request tracing follows the shared library behavior (including OpenTelemetry-related tracing deps reflected in the lockfile).
> 
> The lockfile also records **`world-id-oprf-node` 1.2.1** taking a direct **`telemetry-batteries`** dependency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5f0991085b1b561c23638eb64093dbcaa915f52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->