### PR TITLE
ci: run release-please only on correct PR

### DIFF
--- a/.github/workflows/release-oprf-node.yml
+++ b/.github/workflows/release-oprf-node.yml
@@ -1,7 +1,9 @@
 name: Release OPRF Node
 
 on:
-  push:
+  pull_request:
+    types:
+      - closed
     branches:
       - main
 
@@ -11,6 +13,9 @@ permissions:
 jobs:
   release:
     name: Release OPRF Node
+    if: >-
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.head.ref == 'release-please--branches--main--components--world-id-oprf-node'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -26,6 +31,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+          target-branch: main
 
   build-docker:
     name: Build Docker

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,3 +1,0 @@
-{
-  "services/oprf-node": "1.2.1"
-}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,5 +8,10 @@
     }
   },
   "include-component-in-tag": true,
-  "separate-pull-requests": true
+  "separate-pull-requests": true,
+  "plugins": [
+        {
+            "type": "cargo-workspace"
+        }
+    ]
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,10 +8,5 @@
     }
   },
   "include-component-in-tag": true,
-  "separate-pull-requests": true,
-  "plugins": [
-        {
-            "type": "cargo-workspace"
-        }
-    ]
+  "separate-pull-requests": true
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> CI/release automation changes can block or misfire releases; deleting the manifest while workflows still reference it may break prepare/release version tracking until the manifest is restored or managed elsewhere.
> 
> **Overview**
> **Release OPRF Node** no longer runs **release-please** on every push to `main`. It now triggers on **closed pull requests** to `main` and only runs the release job when the PR was **merged** and the head branch is **`release-please--branches--main--components--world-id-oprf-node`**.
> 
> The **release-please** step now sets **`target-branch: main`** explicitly. **Docker build** behavior is unchanged: it still depends on the release job and runs only when `released` is true.
> 
> This PR also **removes** `.release-please-manifest.json` from the repo (previously pinned `services/oprf-node` at `1.2.1`). Both **prepare** and **release** workflows still reference that manifest path, so version state may now depend on release-please branches or follow-up changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e87c2e1b40420173032514b37758b1914cbc1bc6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->