### PR TITLE
chore: handle panics gracefully

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2630,7 +2630,7 @@ version = "3.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d314cc62af2b6b0c65780555abb4d02a03dd3b799cd42419044f0c38d99738c0"
 dependencies = [
- "darling 0.23.0",
+ "darling 0.21.3",
  "ident_case",
  "prettyplease",
  "proc-macro2",
@@ -7102,7 +7102,7 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -10390,14 +10390,13 @@ dependencies = [
 
 [[package]]
 name = "telemetry-batteries"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87b9214761fa0b4c2879a491aa4109a4036dc3c1ac9f47ba42ae15916fba7b23"
+checksum = "f47bb4a5d51f7c46f394e1853046a9aceec3ba64156a3ac0017ad691b259d98e"
 dependencies = [
  "backtrace",
  "bon",
  "chrono",
- "color-eyre",
  "dirs",
  "eyre",
  "http 1.4.0",

--- a/services/gateway/src/main.rs
+++ b/services/gateway/src/main.rs
@@ -4,6 +4,8 @@ use std::path::Path;
 
 use world_id_gateway::GatewayResult;
 
+use telemetry_batteries::TopLevelResultExt;
+
 #[tokio::main]
 async fn main() -> GatewayResult<()> {
     let env_path = Path::new(env!("CARGO_MANIFEST_DIR")).join(".env"); // load env vars in the root of this service
@@ -14,10 +16,7 @@ async fn main() -> GatewayResult<()> {
     let _ = dotenvy::dotenv();
     tracing::info!("Starting world-id-gateway");
 
-    if let Err(error) = world_id_gateway::run().await {
-        tracing::error!(error = ?error, "gateway terminated with error");
-        return Err(error);
-    }
+    world_id_gateway::run().await.panic_on_top_level_error();
 
     Ok(())
 }

--- a/services/indexer/src/main.rs
+++ b/services/indexer/src/main.rs
@@ -5,6 +5,8 @@ use std::path::Path;
 use futures_util::FutureExt as _;
 use world_id_indexer::GlobalConfig;
 
+use telemetry_batteries::TopLevelResultExt;
+
 #[tokio::main]
 async fn main() -> eyre::Result<()> {
     let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
@@ -18,10 +20,7 @@ async fn main() -> eyre::Result<()> {
 
     let config = GlobalConfig::from_env()?;
     let indexer_run = unsafe { world_id_indexer::run_indexer(config) }.boxed();
-    if let Err(error) = indexer_run.await {
-        tracing::error!(error = ?error, "indexer terminated with error");
-        return Err(error);
-    }
+    indexer_run.await.panic_on_top_level_error();
 
     tracing::info!("⚠️ Exiting world-id-indexer...");
 

--- a/services/relay/src/bin/main.rs
+++ b/services/relay/src/bin/main.rs
@@ -17,7 +17,7 @@ async fn main() -> Result<()> {
     let cli = Cli::parse();
     let cli_run = cli.run().boxed();
 
-    cli_run.wait.panic_on_top_level_error();
+    cli_run.await.panic_on_top_level_error();
 
     Ok(())
 }

--- a/services/relay/src/bin/main.rs
+++ b/services/relay/src/bin/main.rs
@@ -3,6 +3,8 @@ use eyre::Result;
 use futures_util::FutureExt as _;
 use world_id_relay::cli::Cli;
 
+use telemetry_batteries::TopLevelResultExt;
+
 #[tokio::main]
 async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
@@ -15,10 +17,7 @@ async fn main() -> Result<()> {
     let cli = Cli::parse();
     let cli_run = cli.run().boxed();
 
-    if let Err(e) = cli_run.await {
-        tracing::error!(error = ?e, "relay terminated with error");
-        std::process::exit(1);
-    }
+    cli_run.wait.panic_on_top_level_error();
 
     Ok(())
 }


### PR DESCRIPTION
- **chore: bump telemetry-batteries**
- **chore: use panic_on_top_level_error**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how all three services exit on run failure (relay no longer exits with code 1 explicitly), which can affect orchestration and crash reporting behavior.
> 
> **Overview**
> Bumps **`telemetry-batteries`** to **0.3.2** (lockfile only; drops its **`color-eyre`** dependency and adjusts transitive crate versions).
> 
> Gateway, indexer, and relay **main** binaries no longer hand-roll top-level failure handling (`tracing::error` + `return Err` / `process::exit(1)`). Each service now awaits its run future and calls **`panic_on_top_level_error()`** from **`TopLevelResultExt`**, centralizing how fatal startup/run errors are reported and terminated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 957c127375f314d89b6c4540eb23ab972d1fa586. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->