### PR TITLE
feat: invalidate OPRF node RP signer cache on RpUpdated events

### DIFF
--- a/services/oprf-node/src/auth/rp_registry_watcher.rs
+++ b/services/oprf-node/src/auth/rp_registry_watcher.rs
@@ -8,12 +8,18 @@ use crate::{
     config::WatcherCacheConfig,
     metrics,
 };
-use alloy::{primitives::Address, providers::DynProvider};
+use alloy::{
+    primitives::Address,
+    providers::{DynProvider, Provider},
+    rpc::types::Filter,
+    sol_types::SolEvent,
+};
 use backon::Retryable as _;
 use eyre::Context;
 use moka::future::Cache;
 use taceo_nodes_common::web3;
 use taceo_oprf::types::OprfKeyId;
+use tokio_util::sync::CancellationToken;
 use tracing::instrument;
 use world_id_primitives::{oprf::WorldIdRequestAuthError, rp::RpId};
 
@@ -172,6 +178,108 @@ impl RpRegistryWatcher {
         Ok(relying_party)
     }
 
+    /// Polls the `RpRegistry` for `RpUpdated` events and invalidates the cached
+    /// entry of every RP whose record changed.
+    ///
+    /// This collapses the propagation time of an on-chain signer rotation or
+    /// deactivation from the full cache TTL down to roughly one poll interval,
+    /// which is what makes prompt revocation of a compromised signer possible.
+    ///
+    /// Design notes:
+    /// - Over-invalidation is safe: the worst case of dropping an entry we did
+    ///   not strictly need to is a single `getRp` refetch on the next request.
+    ///   We therefore ignore reorgs and simply re-fetch logs for any range that
+    ///   failed, rather than tracking chain state precisely.
+    /// - Fail-safe: any RPC error is logged and the same block range is retried
+    ///   on the next tick. The loop only terminates on cancellation. The cache
+    ///   TTL remains the backstop if this loop stalls — see [`Self`] docs.
+    /// - We start watching from the current head: on startup the cache is empty,
+    ///   so there is nothing stale to invalidate for past updates, and entries
+    ///   loaded afterwards are at most one TTL old regardless.
+    pub(crate) async fn run_invalidation_loop(
+        self,
+        poll_interval: Duration,
+        cancellation_token: CancellationToken,
+    ) {
+        let provider = self.contract.provider().clone();
+        let address = *self.contract.address();
+
+        // Establish the starting block (current head + 1), retrying on failure.
+        let mut from_block = loop {
+            tokio::select! {
+                () = cancellation_token.cancelled() => return,
+                res = provider.get_block_number() => match res {
+                    Ok(n) => break n.saturating_add(1),
+                    Err(e) => {
+                        tracing::warn!(error = %e, "rp invalidation: failed to fetch initial block number, retrying");
+                        tokio::select! {
+                            () = cancellation_token.cancelled() => return,
+                            () = tokio::time::sleep(poll_interval) => {}
+                        }
+                    }
+                }
+            }
+        };
+
+        tracing::info!(
+            from_block,
+            ?poll_interval,
+            "rp registry invalidation loop started"
+        );
+
+        loop {
+            tokio::select! {
+                () = cancellation_token.cancelled() => {
+                    tracing::info!("rp registry invalidation loop shutting down");
+                    return;
+                }
+                () = tokio::time::sleep(poll_interval) => {}
+            }
+
+            let latest = match provider.get_block_number().await {
+                Ok(n) => n,
+                Err(e) => {
+                    tracing::warn!(error = %e, "rp invalidation: failed to fetch block number, retrying");
+                    continue;
+                }
+            };
+            if latest < from_block {
+                continue;
+            }
+
+            let filter = Filter::new()
+                .address(address)
+                .event_signature(RpRegistry::RpUpdated::SIGNATURE_HASH)
+                .from_block(from_block)
+                .to_block(latest);
+
+            match provider.get_logs(&filter).await {
+                Ok(logs) => {
+                    for log in logs {
+                        match log.log_decode::<RpRegistry::RpUpdated>() {
+                            Ok(decoded) => {
+                                let rp_id = RpId::new(decoded.inner.data.rpId);
+                                self.rp_store.invalidate(&rp_id).await;
+                                metrics::rp_registry_cache::invalidation();
+                                tracing::info!(%rp_id, "invalidated cached RP after on-chain RpUpdated");
+                            }
+                            Err(e) => {
+                                tracing::warn!(error = %e, "rp invalidation: failed to decode RpUpdated log");
+                            }
+                        }
+                    }
+                    from_block = latest.saturating_add(1);
+                    // Heartbeat: alert if this stops advancing (stalled poller).
+                    metrics::rp_registry_cache::set_last_polled_block(latest);
+                }
+                Err(e) => {
+                    // Keep `from_block` to retry this range; over-invalidation is safe.
+                    tracing::warn!(error = %e, from_block, to_block = latest, "rp invalidation: get_logs failed, will retry range");
+                }
+            }
+        }
+    }
+
     #[allow(dead_code, reason = "is only used in tests")]
     #[cfg(test)]
     pub(crate) fn set_timeout_external_eth_call(&mut self, duration: Duration) {
@@ -328,6 +436,74 @@ mod tests {
         let rp2 = watcher.get_rp(&rp_fixture.world_rp_id).await?;
         assert_eq!(rp1.signer, rp2.signer);
         assert_eq!(rp1.oprf_key_id, rp2.oprf_key_id);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_event_driven_invalidation() -> eyre::Result<()> {
+        // Long TTL so that any eviction we observe is caused by the event-driven
+        // invalidation loop, not by TTL expiry.
+        let (watcher, anvil, rp_fixture, rp_registry) =
+            setup_with_rp_with_ttl(Duration::from_secs(600)).await?;
+
+        // Prime the cache.
+        watcher.get_rp(&rp_fixture.world_rp_id).await?;
+        assert!(
+            watcher.rp_store.contains_key(&rp_fixture.world_rp_id),
+            "RP should be cached after first fetch"
+        );
+
+        // Start the invalidation loop. The clone shares the same moka store, so
+        // evictions it performs are visible on `watcher`.
+        let cancel = CancellationToken::new();
+        let handle = tokio::spawn(
+            watcher
+                .clone()
+                .run_invalidation_loop(Duration::from_millis(200), cancel.clone()),
+        );
+
+        // Trigger an on-chain RpUpdated by rotating the signer to a fresh key.
+        let deployer = anvil.signer(0)?;
+        let manager = LocalSigner::from_signing_key(rp_fixture.signing_key.clone());
+        let new_signer = LocalSigner::random().address();
+        anvil
+            .update_rp(
+                rp_registry,
+                deployer,
+                manager.clone(),
+                rp_fixture.world_rp_id,
+                false, // keep active
+                manager.address(),
+                new_signer,
+                "test.domain".to_string(),
+            )
+            .await?;
+
+        // The loop should evict the stale entry within a few poll intervals.
+        let mut invalidated = false;
+        for _ in 0..50 {
+            if !watcher.rp_store.contains_key(&rp_fixture.world_rp_id) {
+                invalidated = true;
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+        cancel.cancel();
+        handle
+            .await
+            .expect("invalidation loop task should not panic");
+
+        assert!(
+            invalidated,
+            "cache entry should be invalidated after the RpUpdated event"
+        );
+
+        // A subsequent fetch reflects the rotated signer.
+        let rp = watcher.get_rp(&rp_fixture.world_rp_id).await?;
+        assert_eq!(
+            rp.signer, new_signer,
+            "refetched RP should carry the rotated signer"
+        );
         Ok(())
     }
 

--- a/services/oprf-node/src/config.rs
+++ b/services/oprf-node/src/config.rs
@@ -58,6 +58,18 @@ pub struct WorldOprfNodeConfig {
         with = "humantime_serde"
     )]
     pub timeout_external_eth_call: Duration,
+
+    /// Poll interval for the `RpRegistry` `RpUpdated` cache-invalidation loop.
+    ///
+    /// On each tick the node scans for `RpUpdated` events and evicts the cached
+    /// signer of any updated RP, so an on-chain signer rotation or deactivation
+    /// takes effect within roughly this interval instead of waiting out the
+    /// cache TTL. The TTL remains the backstop if the loop stalls.
+    #[serde(
+        default = "WorldOprfNodeConfig::default_rp_registry_poll_interval",
+        with = "humantime_serde"
+    )]
+    pub rp_registry_poll_interval: Duration,
 }
 
 /// Cache configuration for a registry watcher.
@@ -176,6 +188,11 @@ impl WorldOprfNodeConfig {
         Duration::from_secs(10)
     }
 
+    /// Default poll interval for the `RpRegistry` invalidation loop.
+    fn default_rp_registry_poll_interval() -> Duration {
+        Duration::from_secs(2)
+    }
+
     /// Initialize with default values for all optional fields.
     #[must_use]
     #[allow(
@@ -200,6 +217,7 @@ impl WorldOprfNodeConfig {
             rpc_provider_config,
             current_time_stamp_max_difference: Self::default_current_time_stamp_max_difference(),
             timeout_external_eth_call: Self::default_timeout_external_eth_call(),
+            rp_registry_poll_interval: Self::default_rp_registry_poll_interval(),
             node_config: OprfNodeServiceConfig::with_default_values(environment, version_req),
             rp_cache_config: WatcherCacheConfig::default(),
             issuer_cache_config: WatcherCacheConfig::default(),

--- a/services/oprf-node/src/lib.rs
+++ b/services/oprf-node/src/lib.rs
@@ -122,6 +122,13 @@ pub fn start(
         config.rp_cache_config,
     );
 
+    tracing::info!("spawning RpRegistry invalidation loop..");
+    tokio::spawn(
+        rp_registry_watcher
+            .clone()
+            .run_invalidation_loop(config.rp_registry_poll_interval, cancellation_token.clone()),
+    );
+
     let query_vk = serde_json::from_str::<VerificationKey<Bn254>>(QUERY_VERIFICATION_KEY)
         .expect("can deserialize embedded vk");
     let query_vk = Arc::new(ark_groth16::prepare_verifying_key(&query_vk.into()));

--- a/services/oprf-node/src/metrics.rs
+++ b/services/oprf-node/src/metrics.rs
@@ -128,6 +128,12 @@ pub(crate) mod rp_registry_cache {
     /// Number of hits in the `rp_registry_watcher` cache.
     const METRICS_ID_NODE_RP_REGISTRY_WATCHER_CACHE_HITS: &str =
         "taceo.oprf.node.rp_registry_watcher_cache.hits";
+    /// Number of event-driven invalidations of the `rp_registry_watcher` cache.
+    const METRICS_ID_NODE_RP_REGISTRY_WATCHER_CACHE_INVALIDATIONS: &str =
+        "taceo.oprf.node.rp_registry_watcher_cache.invalidations";
+    /// Highest block scanned by the `RpUpdated` invalidation poller.
+    const METRICS_ID_NODE_RP_REGISTRY_WATCHER_LAST_POLLED_BLOCK: &str =
+        "taceo.oprf.node.rp_registry_watcher_cache.last_polled_block";
 
     pub(super) fn describe_metrics() {
         metrics::describe_gauge!(
@@ -147,6 +153,18 @@ pub(crate) mod rp_registry_cache {
             metrics::Unit::Count,
             "Number of hits in the rp_registry_watcher cache."
         );
+
+        metrics::describe_counter!(
+            METRICS_ID_NODE_RP_REGISTRY_WATCHER_CACHE_INVALIDATIONS,
+            metrics::Unit::Count,
+            "Number of cache entries invalidated in response to on-chain RpUpdated events."
+        );
+
+        metrics::describe_gauge!(
+            METRICS_ID_NODE_RP_REGISTRY_WATCHER_LAST_POLLED_BLOCK,
+            metrics::Unit::Count,
+            "Highest block scanned by the RpUpdated invalidation poller. Alert if this stops advancing."
+        );
     }
 
     pub(crate) fn set(val: u64) {
@@ -159,6 +177,14 @@ pub(crate) mod rp_registry_cache {
 
     pub(crate) fn miss() {
         metrics::counter!(METRICS_ID_NODE_RP_REGISTRY_WATCHER_CACHE_MISSES).increment(1);
+    }
+
+    pub(crate) fn invalidation() {
+        metrics::counter!(METRICS_ID_NODE_RP_REGISTRY_WATCHER_CACHE_INVALIDATIONS).increment(1);
+    }
+
+    pub(crate) fn set_last_polled_block(block: u64) {
+        metrics::gauge!(METRICS_ID_NODE_RP_REGISTRY_WATCHER_LAST_POLLED_BLOCK).set(block as f64);
     }
 }
 


### PR DESCRIPTION
## Summary

The `RpRegistryWatcher` in the OPRF node caches each RP's signer purely by TTL (default 10m) with **no event-driven invalidation**, diverging from WIP-101 §8 — *"OPRF Nodes MUST invalidate the `signer` cache on any `RpUpdated` event emission from the `RpRegistry`."*

For **EOA signers** (the common case), rotation is an atomic swap of the single registered `signer` address in `RpRegistry`. With TTL-only caching, a rotation — including **revoking a compromised signer** via `updateRp` (rotate) or `toggleActive=false` (kill switch) — only takes effect once the cached entry expires. That leaves up to a full TTL window where the stale/stolen signer is still accepted, and during a planned rotation a window where *neither* key is accepted fleet-wide.

This PR adds a background loop that polls `RpRegistry` for `RpUpdated` logs over HTTP (`eth_getLogs`) and invalidates the cached entry of each updated RP, collapsing the propagation delay from the TTL to roughly **one poll interval** (default 2s). The TTL stays as the backstop.

## Changes

- **`rp_registry_watcher.rs`**: `run_invalidation_loop()` — polls `RpUpdated`, calls `rp_store.invalidate(rpId)`. Cancellation-aware, fail-safe.
- **`lib.rs`**: spawn the loop at startup, wired to the existing cancellation token.
- **`config.rs`**: new `rp_registry_poll_interval` (default 2s).
- **`metrics.rs`**: `…cache.invalidations` counter + `…cache.last_polled_block` heartbeat gauge.

## Reliability notes

- **No request-path impact**: detached task; if polling breaks, requests still serve off the cache/TTL as before.
- **TTL remains the backstop** — events make revocation *fast*; TTL guarantees it *eventually* even if the loop stalls.
- **Fail-safe loop**: RPC errors are logged and the same block range is retried next tick; the loop only exits on cancellation.
- **Over-invalidation is safe** (worst case: one extra `getRp`), so reorgs are ignored rather than precisely tracked.
- **Observability**: `last_polled_block` lets us alert when the poller stops advancing (a stalled poller silently degrades back to TTL-only — security-relevant).

## Test plan

- [x] `cargo check` / `cargo clippy` (crate denies `clippy::all` + `pedantic` + `unwrap_used`) clean
- [x] New `test_event_driven_invalidation` (anvil): prime cache → on-chain signer rotation → loop evicts entry → refetch returns rotated signer
- [x] Existing `rp_registry_watcher` tests pass

## Follow-ups (not in this PR)

- Datadog monitor on `last_polled_block` not advancing.
- Staged rollout across operators (poll interval is the natural throttle; set high to effectively disable per-operator).

🤖 Generated with [Claude Code](https://claude.com/claude-code)