### PR TITLE
refactor(node): remove run_pending_tasks + eviction listener

### DIFF
--- a/services/oprf-node/src/auth/merkle_watcher.rs
+++ b/services/oprf-node/src/auth/merkle_watcher.rs
@@ -80,10 +80,7 @@ impl MerkleWatcher {
 
         let merkle_root_cache_builder = Cache::builder()
             .max_capacity(cache_config.max_cache_size.get())
-            .time_to_live(cache_config.time_to_live)
-            .eviction_listener(move |root, (), cause| {
-                tracing::trace!("removing merkle-root {root} because: {cause:?}");
-            });
+            .time_to_live(cache_config.time_to_live);
 
         let merkle_root_cache = if let Some(time_to_idle) = cache_config.time_to_idle {
             merkle_root_cache_builder.time_to_idle(time_to_idle).build()
@@ -144,7 +141,6 @@ impl MerkleWatcher {
             .or_try_insert_with(is_valid_root)
             .await?;
         if entry.is_fresh() {
-            self.merkle_root_cache.run_pending_tasks().await;
             metrics::merkle_cache::set(self.merkle_root_cache.entry_count());
             metrics::merkle_cache::miss();
             tracing::trace!("merkle root {root} loaded from chain");

--- a/services/oprf-node/src/auth/nonce_history.rs
+++ b/services/oprf-node/src/auth/nonce_history.rs
@@ -67,15 +67,8 @@ impl NonceHistory {
     /// # Arguments
     /// * `max_nonce_age` - Maximum age for nonces before they expire
     pub(crate) fn init(max_nonce_age: Duration) -> Self {
-        metrics::nonce_history::reset();
         NonceHistory {
-            nonces: Cache::builder()
-                .time_to_live(max_nonce_age)
-                .eviction_listener(move |k, (), cause| {
-                    tracing::trace!("removing nonce {k:?} because {cause:?}");
-                    metrics::nonce_history::dec();
-                })
-                .build(),
+            nonces: Cache::builder().time_to_live(max_nonce_age).build(),
         }
     }
 
@@ -105,7 +98,7 @@ impl NonceHistory {
         if !entry.is_fresh() {
             return Err(DuplicateNonce);
         }
-        metrics::nonce_history::inc();
+        metrics::nonce_history::set(self.nonces.entry_count());
         Ok(())
     }
 }

--- a/services/oprf-node/src/auth/rp_registry_watcher.rs
+++ b/services/oprf-node/src/auth/rp_registry_watcher.rs
@@ -78,10 +78,8 @@ impl RpRegistryWatcher {
     ) -> Self {
         let rp_store_builder = Cache::builder()
             .max_capacity(cache_config.max_cache_size.get())
-            .time_to_live(cache_config.time_to_live)
-            .eviction_listener(move |k, v: RelyingParty, cause| {
-                tracing::trace!("removing rp {k}/{} because: {cause:?}", v.account_type);
-            });
+            .time_to_live(cache_config.time_to_live);
+
         let rp_store = if let Some(time_to_idle) = cache_config.time_to_idle {
             rp_store_builder.time_to_idle(time_to_idle).build()
         } else {
@@ -117,7 +115,6 @@ impl RpRegistryWatcher {
             .await?;
         let rp = if entry.is_fresh() {
             let rp = entry.into_value();
-            self.rp_store.run_pending_tasks().await;
             metrics::rp_registry_cache::set(self.rp_store.entry_count());
             metrics::rp_registry_cache::miss();
             tracing::trace!("rp {rp_id}/{} loaded from chain", rp.account_type);

--- a/services/oprf-node/src/auth/schema_issuer_registry_watcher.rs
+++ b/services/oprf-node/src/auth/schema_issuer_registry_watcher.rs
@@ -64,10 +64,7 @@ impl SchemaIssuerRegistryWatcher {
     ) -> Self {
         let store_builder = Cache::builder()
             .max_capacity(cache_config.max_cache_size.get())
-            .time_to_live(cache_config.time_to_live)
-            .eviction_listener(move |k, (), cause| {
-                tracing::trace!("removing issuer {k} because: {cause:?}");
-            });
+            .time_to_live(cache_config.time_to_live);
         let issuer_schema_store = if let Some(time_to_idle) = cache_config.time_to_idle {
             store_builder.time_to_idle(time_to_idle).build()
         } else {
@@ -109,7 +106,6 @@ impl SchemaIssuerRegistryWatcher {
             .await?;
 
         if entry.is_fresh() {
-            self.issuer_schema_store.run_pending_tasks().await;
             metrics::schema_issuer_cache::set(self.issuer_schema_store.entry_count());
             metrics::schema_issuer_cache::miss();
             tracing::trace!("issuer {issuer_schema_id} loaded from chain");

--- a/services/oprf-node/src/metrics.rs
+++ b/services/oprf-node/src/metrics.rs
@@ -59,16 +59,8 @@ pub(crate) mod nonce_history {
         );
     }
 
-    pub(crate) fn reset() {
-        metrics::gauge!(METRICS_ID_NODE_NONCE_HISTORY_SIZE).set(0.0);
-    }
-
-    pub(crate) fn inc() {
-        metrics::gauge!(METRICS_ID_NODE_NONCE_HISTORY_SIZE).increment(1);
-    }
-
-    pub(crate) fn dec() {
-        metrics::gauge!(METRICS_ID_NODE_NONCE_HISTORY_SIZE).decrement(1);
+    pub(crate) fn set(val: u64) {
+        metrics::gauge!(METRICS_ID_NODE_NONCE_HISTORY_SIZE).set(val as f64);
     }
 }
 


### PR DESCRIPTION
- **build(deps): bump oprf to version 0.17.2**
- **test: use default debug builds in setup test**
- **refactor(node): remove run_pending_tasks + eviction listener**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only and cache housekeeping changes; auth and caching behavior stay the same aside from slightly less immediate gauge updates on TTL eviction.
> 
> **Overview**
> Simplifies **moka** cache setup across auth watchers by dropping **`eviction_listener`** trace hooks and **`run_pending_tasks`** calls after fresh cache inserts.
> 
> **Nonce history** metrics no longer use **`inc`/`dec`/`reset`** tied to evictions; the size gauge is set from **`entry_count()`** when a nonce is successfully added. Merkle, RP registry, and schema issuer watchers still update cache size and hit/miss metrics on fresh loads, without explicitly draining pending cache maintenance first.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa11b8070acf68b9e462d85201fbcea54be49ebe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->