### PR TITLE
feat: distribute noir artifacts via GH release artifacts

### DIFF
--- a/.github/workflows/release-circuit-artifacts.yml
+++ b/.github/workflows/release-circuit-artifacts.yml
@@ -18,6 +18,20 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9
+        with:
+          toolchain: stable
+
+      - name: Install Noir
+        uses: noir-lang/noirup@7dbe69ccc78877f0200ffa5a40836c953d2cfd8f # v0.1.4
+        with:
+          # See https://github.com/worldfnd/provekit, a specific nargo toolchain version is required
+          toolchain: v1.0.0-beta.11
+
+      - name: Generate Noir artifacts
+        run: cargo run -p generate-noir-artifacts
+
       - name: Create release with circuit artifacts
         env:
           GH_TOKEN: ${{ github.token }}
@@ -30,6 +44,8 @@ jobs:
             circom/OPRFNullifierGraph.bin
             circom/OPRFQuery.arks.zkey
             circom/OPRFNullifier.arks.zkey
+            crates/proof/noir/ownership-proof/artifacts/ownership_proof.pkp
+            crates/proof/noir/ownership-proof/artifacts/ownership_proof.pkv
           )
 
           for file in "${files[@]}"; do

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4293,6 +4293,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "generate-noir-artifacts"
+version = "0.12.0"
+dependencies = [
+ "eyre",
+ "provekit-common",
+ "provekit-r1cs-compiler",
+]
+
+[[package]]
 name = "generate-solidity-fixtures"
 version = "0.12.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
   "services/common",
   "services/faux-issuer",
   "tools/generate-solidity-fixtures",
+  "tools/generate-noir-artifacts",
   "services/relay",
 ]
 

--- a/Justfile
+++ b/Justfile
@@ -63,5 +63,9 @@ _cast-send *args:
 _xc-rpc *args:
     @just contracts::_xc-rpc {{ args }}
 
+[group('circuits')]
+build-noir-artifacts:
+    cargo run -p generate-noir-artifacts
+
 [group('ci')]
 ci: cargo-lint fmt-check all

--- a/crates/proof/noir/ownership-proof/.gitignore
+++ b/crates/proof/noir/ownership-proof/.gitignore
@@ -1,0 +1,1 @@
+artifacts/

--- a/tools/generate-noir-artifacts/Cargo.toml
+++ b/tools/generate-noir-artifacts/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "generate-noir-artifacts"
+publish = false
+edition.workspace = true
+version.workspace = true
+license.workspace = true
+authors.workspace = true
+homepage.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+
+[[bin]]
+name = "generate-noir-artifacts"
+path = "src/main.rs"
+
+[dependencies]
+eyre = { workspace = true }
+provekit-common = { workspace = true }
+provekit-r1cs-compiler = { workspace = true }

--- a/tools/generate-noir-artifacts/src/main.rs
+++ b/tools/generate-noir-artifacts/src/main.rs
@@ -1,0 +1,46 @@
+use std::{env, fs, path::Path, process::Command};
+
+use provekit_common::{NoirProofScheme, Prover, Verifier};
+use provekit_r1cs_compiler::NoirProofSchemeBuilder as _;
+
+fn main() -> eyre::Result<()> {
+    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .ok_or_else(|| eyre::eyre!("failed to resolve workspace root"))?;
+
+    let circuit_dir = workspace_root.join("crates/proof/noir/ownership-proof");
+    let artifact_dir = circuit_dir.join("artifacts");
+
+    let nargo_output = Command::new("nargo")
+        .arg("compile")
+        .current_dir(&circuit_dir)
+        .output()
+        .map_err(|e| eyre::eyre!("failed to run nargo: {e}"))?;
+
+    if !nargo_output.status.success() {
+        let stderr = String::from_utf8_lossy(&nargo_output.stderr);
+        eyre::bail!(
+            "nargo compile failed:\n{stderr}\n\nCheck your Noir version - must be run with v1.0.0-beta.11\ninstall with noirup --version v1.0.0-beta.11"
+        );
+    }
+
+    fs::create_dir_all(&artifact_dir)?;
+
+    let scheme = NoirProofScheme::from_file(circuit_dir.join("target/ownership_proof.json"))
+        .map_err(|e| eyre::eyre!(e.to_string()))?;
+
+    provekit_common::file::write(
+        &Prover::from_noir_proof_scheme(scheme.clone()),
+        &artifact_dir.join("ownership_proof.pkp"),
+    )
+    .map_err(|e| eyre::eyre!(e.to_string()))?;
+
+    provekit_common::file::write(
+        &Verifier::from_noir_proof_scheme(scheme),
+        &artifact_dir.join("ownership_proof.pkv"),
+    )
+    .map_err(|e| eyre::eyre!(e.to_string()))?;
+
+    Ok(())
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes are limited to build tooling and release packaging; no runtime auth or on-chain logic is modified, though release correctness depends on the pinned Noir toolchain.
> 
> **Overview**
> Adds a **`generate-noir-artifacts`** workspace binary that compiles the `ownership-proof` Noir circuit with **`nargo`** (pinned to **v1.0.0-beta.11**) and writes **ProveKit** prover/verifier files **`ownership_proof.pkp`** and **`ownership_proof.pkv`** under `crates/proof/noir/ownership-proof/artifacts/`.
> 
> The **release-circuit-artifacts** workflow now installs Rust and Noir, runs that generator before creating the release, and uploads those two files alongside the existing Circom artifacts. **`just build-noir-artifacts`** mirrors the same command locally; generated **`artifacts/`** are gitignored.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9202734545792ee6192730fb7de47fe328df6f89. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->