### PR TITLE
chore: list available just commands by default

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -53,6 +53,10 @@ import 'just/cargo.just'
 import 'just/forge.just'
 import 'just/test.just'
 
+# default recipe to display help information
+default:
+    @just --list
+
 # Internal forwarding helpers used by contracts module recipes.
 _cast-dry-run *args:
     @just contracts::_cast-dry-run {{ args }}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Only adds a convenience default recipe with no build, deploy, or runtime behavior changes.
> 
> **Overview**
> Running **`just`** with no recipe name now shows available commands instead of doing nothing or erroring unclearly.
> 
> A **`default`** recipe was added to the root **`Justfile`** that runs **`just --list`**, giving newcomers and occasional users a built-in help entry point.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5877c4295831d83bd39503d69a17c9c2e46626cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->