### PR TITLE
refactor: granular embed features, no-embed defaults

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,7 @@ This project MAY have a knowledge graph at `graph/`. If it does, look at the `gr
 - `crates/core/`: Top-level integration layer that exposes full protocol functionality.
 - `crates/issuer/`: Issuer functionality for World ID.
 - `crates/primitives/`: Foundational raw types with minimal dependencies.
-- `crates/proof/`: Proof generation/verification; optional `embed-zkeys`/`compress-zkeys` features.
+- `crates/proof/`: Proof generation/verification; ZK artifacts provided at runtime via `ZkArtifactSource`, with opt-in embed features (`embed-zkeys`, `embed-ownership-prover`/`-verifier`, umbrella `embed-zk-artifacts`); nothing is embedded by default.
 - `crates/test-utils/`: Shared test helpers for integration/e2e tests across crates and services.
 - `crates/zk-mobile-bench/`: Mobile benchmarks for World ID ZK proof generation, used by CI via mobench.
 

--- a/crates/authenticator/Cargo.toml
+++ b/crates/authenticator/Cargo.toml
@@ -17,14 +17,20 @@ include = [
 ]
 
 [features]
-default = ["embed-zkeys"]
+# By default nothing is embedded: ZK artifacts are provided at runtime
+# through a `ZkArtifactSource`. Embedding is an explicit opt-in.
+default = []
 embed-zkeys = ["world-id-proof/embed-zkeys"]
-# Embed Noir ownership proof artifacts into binary
-embed-noir-artifacts = ["world-id-proof/embed-noir-artifacts"]
 # Compress the embedded zkeys to reduce binary size (ARK point compression)
 compress-zkeys = ["embed-zkeys", "world-id-proof/compress-zkeys"]
 # Compress the tar archive with zstd
 zstd-compress-zkeys = ["embed-zkeys", "world-id-proof/zstd-compress-zkeys"]
+# Embed the Noir ownership prover/verifier (built ad-hoc with nargo)
+embed-ownership-prover = ["world-id-proof/embed-ownership-prover"]
+embed-ownership-verifier = ["world-id-proof/embed-ownership-verifier"]
+embed-noir-artifacts = ["embed-ownership-prover", "embed-ownership-verifier"]
+# Embed everything
+embed-zk-artifacts = ["embed-zkeys", "embed-noir-artifacts"]
 
 [dependencies]
 # Use WASM-safe base features only

--- a/crates/authenticator/Cargo.toml
+++ b/crates/authenticator/Cargo.toml
@@ -17,8 +17,6 @@ include = [
 ]
 
 [features]
-# By default nothing is embedded: ZK artifacts are provided at runtime
-# through a `ZkArtifactSource`. Embedding is an explicit opt-in.
 default = []
 embed-zkeys = ["world-id-proof/embed-zkeys"]
 # Compress the embedded zkeys to reduce binary size (ARK point compression)

--- a/crates/authenticator/src/prove.rs
+++ b/crates/authenticator/src/prove.rs
@@ -619,7 +619,7 @@ mod tests {
     #[cfg(all(
         not(target_arch = "wasm32"),
         feature = "embed-zkeys",
-        feature = "embed-noir-artifacts"
+        feature = "embed-ownership-prover"
     ))]
     async fn test_prove_credential_sub_succeeds_with_correct_sub() {
         use world_id_primitives::Credential;

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -12,7 +12,7 @@ repository.workspace = true
 include = ["src/**/*", "bin/**/*", "tests/**/*", "Cargo.toml", "README.md"]
 
 [features]
-default = ["authenticator", "embed-zkeys"]
+default = ["authenticator"]
 
 authenticator = [
     "dep:world-id-proof",
@@ -25,6 +25,12 @@ embed-zkeys = ["authenticator", "world-id-proof/embed-zkeys"]
 compress-zkeys = ["authenticator", "embed-zkeys", "world-id-proof/compress-zkeys"]
 # Compress the tar archive with zstd
 zstd-compress-zkeys = ["authenticator", "embed-zkeys", "world-id-proof/zstd-compress-zkeys"]
+# Embed the Noir ownership prover/verifier (built ad-hoc with nargo)
+embed-ownership-prover = ["authenticator", "world-id-proof/embed-ownership-prover"]
+embed-ownership-verifier = ["authenticator", "world-id-proof/embed-ownership-verifier"]
+embed-noir-artifacts = ["embed-ownership-prover", "embed-ownership-verifier"]
+# Embed everything
+embed-zk-artifacts = ["embed-zkeys", "embed-noir-artifacts"]
 
 issuer = [
     "dep:world-id-issuer",
@@ -41,6 +47,11 @@ world-id-proof = { workspace = true, optional = true }
 world-id-authenticator = { workspace = true, optional = true }
 world-id-primitives = { workspace = true }
 world-id-registries = { workspace = true }
+
+# Integration tests that generate real proofs need embedded artifacts.
+[[test]]
+name = "generate_proof"
+required-features = ["embed-zkeys"]
 
 [dev-dependencies]
 alloy = { workspace = true }

--- a/crates/proof/Cargo.toml
+++ b/crates/proof/Cargo.toml
@@ -19,17 +19,27 @@ include = [
 ]
 
 [features]
-default = ["embed-zkeys"]
-# Embed Circom zkeys into binary
+# By default nothing is embedded: artifacts are provided at runtime through a
+# `ZkArtifactSource`. Embedding is an explicit opt-in per artifact.
+default = []
+
+# Embed Circom zkeys (query + nullifier proof material) into the binary
 embed-zkeys = ["dep:tar"]
 # Compress the embedded zkeys to reduce binary size (ARK point compression)
 compress-zkeys = ["embed-zkeys", "dep:ark-serialize", "dep:circom-types"]
 # Compress the tar archive with zstd
 zstd-compress-zkeys = ["embed-zkeys", "dep:zstd"]
 
-# Embed Noir ownership proof artifacts into binary. The artifacts are built
-# ad-hoc in build.rs with `nargo` (see the pinned version in `flake.nix`).
-embed-noir-artifacts = ["dep:provekit-r1cs-compiler"]
+# Embed the Noir ownership proof prover/verifier into the binary. The
+# artifacts are built ad-hoc in build.rs with `nargo` (see the pinned version
+# in `flake.nix`). The prover is multi-MB; verifying-only consumers should
+# enable just the verifier.
+embed-ownership-prover = ["dep:provekit-r1cs-compiler"]
+embed-ownership-verifier = ["dep:provekit-r1cs-compiler"]
+embed-noir-artifacts = ["embed-ownership-prover", "embed-ownership-verifier"]
+
+# Embed everything
+embed-zk-artifacts = ["embed-zkeys", "embed-noir-artifacts"]
 
 [dependencies]
 ark-babyjubjub = { workspace = true }

--- a/crates/proof/Cargo.toml
+++ b/crates/proof/Cargo.toml
@@ -19,8 +19,6 @@ include = [
 ]
 
 [features]
-# By default nothing is embedded: artifacts are provided at runtime through a
-# `ZkArtifactSource`. Embedding is an explicit opt-in per artifact.
 default = []
 
 # Embed Circom zkeys (query + nullifier proof material) into the binary
@@ -30,10 +28,6 @@ compress-zkeys = ["embed-zkeys", "dep:ark-serialize", "dep:circom-types"]
 # Compress the tar archive with zstd
 zstd-compress-zkeys = ["embed-zkeys", "dep:zstd"]
 
-# Embed the Noir ownership proof prover/verifier into the binary. The
-# artifacts are built ad-hoc in build.rs with `nargo` (see the pinned version
-# in `flake.nix`). The prover is multi-MB; verifying-only consumers should
-# enable just the verifier.
 embed-ownership-prover = ["dep:provekit-r1cs-compiler"]
 embed-ownership-verifier = ["dep:provekit-r1cs-compiler"]
 embed-noir-artifacts = ["embed-ownership-prover", "embed-ownership-verifier"]

--- a/crates/proof/README.md
+++ b/crates/proof/README.md
@@ -78,5 +78,5 @@ fingerprints in `src/proof.rs`.
 ## Noir ownership proof
 
 The Noir ownership proof APIs are available on native targets. They can either use explicit
-prover/verifier material loaded from readers or paths, or embedded artifacts when
-`embed-noir-artifacts` is enabled.
+prover/verifier material loaded from readers or paths, or embedded artifacts when the
+corresponding `embed-ownership-prover` / `embed-ownership-verifier` feature is enabled.

--- a/crates/proof/README.md
+++ b/crates/proof/README.md
@@ -22,10 +22,15 @@ Each ZK artifact type has exactly one way of being obtained:
 
 ### Features
 
+By default **nothing is embedded**: ZK artifacts are provided at runtime through a
+`ZkArtifactSource` (embedded, filesystem, or a client-provided implementation).
+Embedding artifacts into the binary is an explicit opt-in per artifact:
+
 ##### `embed-zkeys`
 
-build.rs will include the Circom zkey files into the binary (committed files when building
-in-repo, otherwise downloaded from the pinned GitHub release).
+build.rs will include the Circom zkey files (query + nullifier proof material) into the
+binary (committed files when building in-repo, otherwise downloaded from the pinned GitHub
+release).
 
 Download from github is done as a workaround to circumvent the max crates.io hosting limit.
 
@@ -34,18 +39,20 @@ Download from github is done as a workaround to circumvent the max crates.io hos
 build.rs will additionally compress the zkey files before embedding them.
 At runtime, zkeys are decompressed in memory during initialization.
 
-##### `embed-noir-artifacts`
+##### `embed-ownership-prover` / `embed-ownership-verifier`
 
-build.rs will build the Noir ownership proof artifacts with `nargo` and include them into
-the binary. Requires `nargo` on PATH at the pinned version — use `nix develop` or:
+build.rs will build the Noir ownership proof artifacts with `nargo` and embed the selected
+one(s) into the binary. The prover is multi-MB; verifying-only consumers should enable just
+the verifier. Requires `nargo` on PATH at the pinned version — use `nix develop` or:
 
 ```sh
 noirup --version v1.0.0-beta.11
 ```
 
-##### neither `compress-zkeys` or `embed-zkeys`
+##### Umbrellas
 
-zkey files are not included in the bin.
+- `embed-noir-artifacts` = ownership prover + verifier
+- `embed-zk-artifacts` = everything
 
 ## Circom circuit artifacts
 

--- a/crates/proof/build.rs
+++ b/crates/proof/build.rs
@@ -31,7 +31,10 @@ fn main() -> eyre::Result<()> {
 
     let out_dir = PathBuf::from(env::var("OUT_DIR")?);
 
-    #[cfg(feature = "embed-noir-artifacts")]
+    #[cfg(any(
+        feature = "embed-ownership-prover",
+        feature = "embed-ownership-verifier"
+    ))]
     if noir_artifacts::should_embed() {
         noir_artifacts::setup(&out_dir)?;
     }
@@ -223,7 +226,10 @@ fn ark_compress_zkeys(out_dir: &Path) -> eyre::Result<()> {
     Ok(())
 }
 
-#[cfg(feature = "embed-noir-artifacts")]
+#[cfg(any(
+    feature = "embed-ownership-prover",
+    feature = "embed-ownership-verifier"
+))]
 mod noir_artifacts {
     use std::process::Command;
 
@@ -239,7 +245,8 @@ mod noir_artifacts {
     pub(super) fn should_embed() -> bool {
         let target_arch = env::var("CARGO_CFG_TARGET_ARCH").ok();
         target_arch.as_deref() != Some("wasm32")
-            && env::var_os("CARGO_FEATURE_EMBED_NOIR_ARTIFACTS").is_some()
+            && (env::var_os("CARGO_FEATURE_EMBED_OWNERSHIP_PROVER").is_some()
+                || env::var_os("CARGO_FEATURE_EMBED_OWNERSHIP_VERIFIER").is_some())
     }
 
     /// Checks that `nargo` is on PATH and is exactly [`REQUIRED_NARGO_VERSION`].

--- a/crates/proof/src/artifacts/embedded.rs
+++ b/crates/proof/src/artifacts/embedded.rs
@@ -46,45 +46,33 @@ impl ZkArtifactSource for EmbeddedZkArtifacts {
     }
 
     fn ownership_prover(&self) -> Result<OwnershipProver, ZkArtifactError> {
-        // NOTE: Relying on wasm32 as a gate might seem weird here
-        //       but it's because the relevant code from provekit that allows
-        //       deserializing ProveKit artifacts has io/fs dependencies (and some C-based
-        //       libraries) - once that's resolved we should only rely on the embed-noir-artifacts
-        //       feature gate only
-
-        #[cfg(all(not(target_arch = "wasm32"), feature = "embed-noir-artifacts"))]
+        #[cfg(all(not(target_arch = "wasm32"), feature = "embed-ownership-prover"))]
         {
             noir::load_embedded_ownership_prover()
                 .map_err(|e| ZkArtifactError::load(ZkArtifactKind::OwnershipProver, e))
         }
 
-        #[cfg(any(target_arch = "wasm32", not(feature = "embed-noir-artifacts")))]
+        #[cfg(any(target_arch = "wasm32", not(feature = "embed-ownership-prover")))]
         {
             Err(ZkArtifactError::Unavailable {
                 kind: ZkArtifactKind::OwnershipProver,
-                reason: "enable `embed-noir-artifacts` on a native target",
+                reason: "enable `embed-ownership-prover` on a native target",
             })
         }
     }
 
     fn ownership_verifier(&self) -> Result<OwnershipVerifier, ZkArtifactError> {
-        // NOTE: Relying on wasm32 as a gate might seem weird here
-        //       but it's because the relevant code from provekit that allows
-        //       deserializing ProveKit artifacts has io/fs dependencies (and some C-based
-        //       libraries) - once that's resolved we should only rely on the embed-noir-artifacts
-        //       feature gate only
-
-        #[cfg(all(not(target_arch = "wasm32"), feature = "embed-noir-artifacts"))]
+        #[cfg(all(not(target_arch = "wasm32"), feature = "embed-ownership-verifier"))]
         {
             noir::load_embedded_ownership_verifier()
                 .map_err(|e| ZkArtifactError::load(ZkArtifactKind::OwnershipVerifier, e))
         }
 
-        #[cfg(any(target_arch = "wasm32", not(feature = "embed-noir-artifacts")))]
+        #[cfg(any(target_arch = "wasm32", not(feature = "embed-ownership-verifier")))]
         {
             Err(ZkArtifactError::Unavailable {
                 kind: ZkArtifactKind::OwnershipVerifier,
-                reason: "enable `embed-noir-artifacts` on a native target",
+                reason: "enable `embed-ownership-verifier` on a native target",
             })
         }
     }
@@ -249,35 +237,41 @@ pub mod zkeys {
     }
 }
 
-#[cfg(all(feature = "embed-noir-artifacts", not(target_arch = "wasm32")))]
+#[cfg(all(
+    not(target_arch = "wasm32"),
+    any(
+        feature = "embed-ownership-prover",
+        feature = "embed-ownership-verifier"
+    )
+))]
 pub mod noir {
-    use crate::{OwnershipProver, OwnershipVerifier};
-
-    #[cfg(not(docsrs))]
+    #[cfg(all(feature = "embed-ownership-prover", not(docsrs)))]
     const PKP_BYTES: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/ownership_proof.pkp"));
 
-    #[cfg(docsrs)]
+    #[cfg(all(feature = "embed-ownership-prover", docsrs))]
     const PKP_BYTES: &[u8] = &[];
 
     /// Loads the embedded ownership proof prover.
     ///
     /// # Errors
     /// Returns an error if embedded Noir artifacts are missing or invalid.
-    pub fn load_embedded_ownership_prover() -> eyre::Result<OwnershipProver> {
+    #[cfg(feature = "embed-ownership-prover")]
+    pub fn load_embedded_ownership_prover() -> eyre::Result<crate::OwnershipProver> {
         crate::ownership_proof::load_ownership_prover_from_reader(PKP_BYTES)
     }
 
-    #[cfg(not(docsrs))]
+    #[cfg(all(feature = "embed-ownership-verifier", not(docsrs)))]
     const PKV_BYTES: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/ownership_proof.pkv"));
 
-    #[cfg(docsrs)]
+    #[cfg(all(feature = "embed-ownership-verifier", docsrs))]
     const PKV_BYTES: &[u8] = &[];
 
     /// Loads the embedded ownership proof verifier.
     ///
     /// # Errors
     /// Returns an error if embedded Noir artifacts are missing or invalid.
-    pub fn load_embedded_ownership_verifier() -> eyre::Result<OwnershipVerifier> {
+    #[cfg(feature = "embed-ownership-verifier")]
+    pub fn load_embedded_ownership_verifier() -> eyre::Result<crate::OwnershipVerifier> {
         crate::ownership_proof::load_ownership_verifier_from_reader(PKV_BYTES)
     }
 }

--- a/crates/proof/src/artifacts/embedded.rs
+++ b/crates/proof/src/artifacts/embedded.rs
@@ -46,6 +46,12 @@ impl ZkArtifactSource for EmbeddedZkArtifacts {
     }
 
     fn ownership_prover(&self) -> Result<OwnershipProver, ZkArtifactError> {
+        // NOTE: Relying on wasm32 as a gate might seem weird here
+        //       but it's because the relevant code from provekit that allows
+        //       deserializing ProveKit artifacts has io/fs dependencies (and some C-based
+        //       libraries) - once that's resolved we should only rely on the
+        //       embed-ownership-prover feature gate.
+
         #[cfg(all(not(target_arch = "wasm32"), feature = "embed-ownership-prover"))]
         {
             noir::load_embedded_ownership_prover()
@@ -62,6 +68,12 @@ impl ZkArtifactSource for EmbeddedZkArtifacts {
     }
 
     fn ownership_verifier(&self) -> Result<OwnershipVerifier, ZkArtifactError> {
+        // NOTE: Relying on wasm32 as a gate might seem weird here
+        //       but it's because the relevant code from provekit that allows
+        //       deserializing ProveKit artifacts has io/fs dependencies (and some C-based
+        //       libraries) - once that's resolved we should only rely on the
+        //       embed-ownership-verifier feature gate.
+
         #[cfg(all(not(target_arch = "wasm32"), feature = "embed-ownership-verifier"))]
         {
             noir::load_embedded_ownership_verifier()

--- a/crates/proof/src/artifacts/mod.rs
+++ b/crates/proof/src/artifacts/mod.rs
@@ -33,7 +33,11 @@ pub trait ZkArtifactSource: Send + Sync {
 
 pub mod cached;
 pub mod dummy;
-#[cfg(any(feature = "embed-zkeys", feature = "embed-noir-artifacts"))]
+#[cfg(any(
+    feature = "embed-zkeys",
+    feature = "embed-ownership-prover",
+    feature = "embed-ownership-verifier"
+))]
 pub mod embedded;
 pub mod error;
 #[cfg(not(target_arch = "wasm32"))]

--- a/crates/proof/src/ownership_proof.rs
+++ b/crates/proof/src/ownership_proof.rs
@@ -222,7 +222,11 @@ impl NoirCircuitInput for OwnershipProofCircuitInput<TREE_DEPTH> {
     }
 }
 
-#[cfg(all(test, feature = "embed-noir-artifacts"))]
+#[cfg(all(
+    test,
+    feature = "embed-ownership-prover",
+    feature = "embed-ownership-verifier"
+))]
 mod tests {
     use crate::{
         artifacts::embedded::EmbeddedZkArtifacts, circuit_inputs::OwnershipProofCircuitInput,


### PR DESCRIPTION
Makes embedding of ZK artifacts an explicit, granular opt-in — and turns embedding **off by default** across the stack.

Feature set on `world-id-proof`:

- `embed-zkeys` — Circom query + nullifier material (kept as one feature: they always ship together, and splitting them had no consumer)
- `embed-ownership-prover` / `embed-ownership-verifier` — Noir artifacts, split so verifying-only services don't carry the multi-MB prover
- `embed-noir-artifacts` (prover+verifier) and `embed-zk-artifacts` (everything) umbrellas
- **`default = []`** — with no embed features, build.rs needs neither network nor `nargo`, so `cargo add world-id-proof` and docs.rs builds are hermetic. Artifacts are provided at runtime via `ZkArtifactSource` (#831).

`world-id-authenticator` and `world-id-core` forward the granular features and also drop embed-by-default. In-repo consumers (oprf-dev-client, oprf-node, zk-mobile-bench, fixture generator) opt in explicitly; core's `generate_proof` integration test declares `required-features`.

Verified: proof crate compiles for every individual feature and with `--no-default-features`; workspace `--all-targets` passes with and without `--all-features`; proof tests (11) and authenticator tests pass with and without embeds.

Stacked on #828 → #831.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default Cargo feature resolution for all dependents—proof generation fails at runtime unless artifacts are supplied via `ZkArtifactSource` or explicit embed features; verify downstream crates and CI opt in correctly.
> 
> **Overview**
> ZK artifact embedding is now **opt-in and split by artifact type**, with **`default = []`** on `world-id-proof`, `world-id-authenticator`, and `world-id-core` so plain `cargo add` / docs.rs builds avoid network downloads and `nargo` unless embed features are enabled.
> 
> **`world-id-proof`** adds `embed-ownership-prover` and `embed-ownership-verifier` (replacing a single `embed-noir-artifacts` gate for build/embed), keeps `embed-zkeys` for Circom material, and adds umbrellas `embed-noir-artifacts` and `embed-zk-artifacts`. `build.rs` runs Noir setup when either ownership embed feature is on; `embedded` only `include_bytes!` the prover or verifier that was requested. **`ZkArtifactSource`** error messages and docs (`README`, `AGENTS.md`) describe runtime loading via `ZkArtifactSource` when nothing is embedded.
> 
> **`world-id-authenticator`** and **`world-id-core`** forward the same feature set and drop embed-from-default; core’s `generate_proof` integration test declares `required-features = ["embed-zkeys"]`. Tests that need real proofs gate on `embed-ownership-prover` (and both prover+verifier for ownership round-trip tests) instead of the old combined flag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 263119d48ce00324204612cef49305567d3f5ab7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->