### PR TITLE
feat: add flake.nix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,82 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1782918843,
+        "narHash": "sha256-ETYnV9U7Sr+A45dohzZdfCZKOss4qrTkO+wgNZNvEc0=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e8273b29fe1390ec8d4603f2477357555291432e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1783058364,
+        "narHash": "sha256-felUcVUtcdI15evRNkVfLq3opwceShhbrJt6hDlZvrk=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "e7a078c7feb51f37955a832b22a96de5fccb1f7a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -18,57 +18,7 @@
           overlays = [ (import rust-overlay) ];
         };
 
-        # Noir is not packaged in nixpkgs, so we repackage the official
-        # prebuilt release binaries. The version must match what provekit
-        # expects (see .github/workflows/noir-ci.yml and CONTRIBUTING.md).
-        noirVersion = "1.0.0-beta.11";
-        nargoArtifacts = {
-          aarch64-darwin = {
-            target = "aarch64-apple-darwin";
-            hash = "sha256-XAYTKQvnKPyzFKSAV4pg4KEc0ZLSSdCN7US+58XuoUI=";
-          };
-          x86_64-darwin = {
-            target = "x86_64-apple-darwin";
-            hash = "sha256-q/qd+hpYsQoQBt0uq/2xnrpWl99com4XB+qhsK36j/c=";
-          };
-          x86_64-linux = {
-            target = "x86_64-unknown-linux-gnu";
-            hash = "sha256-iaAU/TBYoFnRv6+ZzZiR65SKCT7DExSpzwRzSI9Ud5U=";
-          };
-          aarch64-linux = {
-            target = "aarch64-unknown-linux-gnu";
-            hash = "sha256-v25Eqc0dqMnERdIcaYtAZ4o9bveda3txjCSdZp0HCWY=";
-          };
-        };
-
-        nargo = pkgs.stdenv.mkDerivation rec {
-          pname = "nargo";
-          version = noirVersion;
-
-          src = pkgs.fetchurl {
-            url = "https://github.com/noir-lang/noir/releases/download/v${version}/nargo-${nargoArtifacts.${system}.target}.tar.gz";
-            hash = nargoArtifacts.${system}.hash;
-          };
-
-          sourceRoot = ".";
-
-          nativeBuildInputs =
-            pkgs.lib.optionals pkgs.stdenv.isLinux [ pkgs.autoPatchelfHook ];
-          buildInputs =
-            pkgs.lib.optionals pkgs.stdenv.isLinux [ pkgs.stdenv.cc.cc.lib ];
-
-          installPhase = ''
-            runHook preInstall
-            install -Dm755 nargo $out/bin/nargo
-            runHook postInstall
-          '';
-
-          meta = {
-            description = "Noir compiler and package manager";
-            homepage = "https://noir-lang.org";
-            mainProgram = "nargo";
-          };
-        };
+        nargo = pkgs.callPackage ./nix/nargo.nix { };
 
         rustToolchain =
           pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,92 @@
+{
+  description = "World ID Protocol dev environment";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = { self, nixpkgs, flake-utils, rust-overlay }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [ (import rust-overlay) ];
+        };
+
+        # Noir is not packaged in nixpkgs, so we repackage the official
+        # prebuilt release binaries. The version must match what provekit
+        # expects (see .github/workflows/noir-ci.yml and CONTRIBUTING.md).
+        noirVersion = "1.0.0-beta.11";
+        nargoArtifacts = {
+          aarch64-darwin = {
+            target = "aarch64-apple-darwin";
+            hash = "sha256-XAYTKQvnKPyzFKSAV4pg4KEc0ZLSSdCN7US+58XuoUI=";
+          };
+          x86_64-darwin = {
+            target = "x86_64-apple-darwin";
+            hash = "sha256-q/qd+hpYsQoQBt0uq/2xnrpWl99com4XB+qhsK36j/c=";
+          };
+          x86_64-linux = {
+            target = "x86_64-unknown-linux-gnu";
+            hash = "sha256-iaAU/TBYoFnRv6+ZzZiR65SKCT7DExSpzwRzSI9Ud5U=";
+          };
+          aarch64-linux = {
+            target = "aarch64-unknown-linux-gnu";
+            hash = "sha256-v25Eqc0dqMnERdIcaYtAZ4o9bveda3txjCSdZp0HCWY=";
+          };
+        };
+
+        nargo = pkgs.stdenv.mkDerivation rec {
+          pname = "nargo";
+          version = noirVersion;
+
+          src = pkgs.fetchurl {
+            url = "https://github.com/noir-lang/noir/releases/download/v${version}/nargo-${nargoArtifacts.${system}.target}.tar.gz";
+            hash = nargoArtifacts.${system}.hash;
+          };
+
+          sourceRoot = ".";
+
+          nativeBuildInputs =
+            pkgs.lib.optionals pkgs.stdenv.isLinux [ pkgs.autoPatchelfHook ];
+          buildInputs =
+            pkgs.lib.optionals pkgs.stdenv.isLinux [ pkgs.stdenv.cc.cc.lib ];
+
+          installPhase = ''
+            runHook preInstall
+            install -Dm755 nargo $out/bin/nargo
+            runHook postInstall
+          '';
+
+          meta = {
+            description = "Noir compiler and package manager";
+            homepage = "https://noir-lang.org";
+            mainProgram = "nargo";
+          };
+        };
+
+        rustToolchain =
+          pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
+      in {
+        packages = {
+          inherit nargo;
+        };
+
+        devShells.default = pkgs.mkShell {
+          packages = [
+            rustToolchain
+            nargo
+            pkgs.foundry # forge / cast / anvil
+            pkgs.circom
+            pkgs.just
+            pkgs.pkg-config
+            pkgs.openssl
+          ];
+        };
+      });
+}

--- a/nix/nargo.nix
+++ b/nix/nargo.nix
@@ -1,0 +1,51 @@
+# Noir is not packaged in nixpkgs, so we repackage the official prebuilt
+# release binaries. The version must match what provekit expects
+# (see .github/workflows/noir-ci.yml and CONTRIBUTING.md).
+{ stdenv, lib, fetchurl, autoPatchelfHook }:
+
+let
+  artifacts = {
+    aarch64-darwin = {
+      target = "aarch64-apple-darwin";
+      hash = "sha256-XAYTKQvnKPyzFKSAV4pg4KEc0ZLSSdCN7US+58XuoUI=";
+    };
+    x86_64-darwin = {
+      target = "x86_64-apple-darwin";
+      hash = "sha256-q/qd+hpYsQoQBt0uq/2xnrpWl99com4XB+qhsK36j/c=";
+    };
+    x86_64-linux = {
+      target = "x86_64-unknown-linux-gnu";
+      hash = "sha256-iaAU/TBYoFnRv6+ZzZiR65SKCT7DExSpzwRzSI9Ud5U=";
+    };
+    aarch64-linux = {
+      target = "aarch64-unknown-linux-gnu";
+      hash = "sha256-v25Eqc0dqMnERdIcaYtAZ4o9bveda3txjCSdZp0HCWY=";
+    };
+  };
+  artifact = artifacts.${stdenv.hostPlatform.system};
+in stdenv.mkDerivation rec {
+  pname = "nargo";
+  version = "1.0.0-beta.11";
+
+  src = fetchurl {
+    url = "https://github.com/noir-lang/noir/releases/download/v${version}/nargo-${artifact.target}.tar.gz";
+    hash = artifact.hash;
+  };
+
+  sourceRoot = ".";
+
+  nativeBuildInputs = lib.optionals stdenv.isLinux [ autoPatchelfHook ];
+  buildInputs = lib.optionals stdenv.isLinux [ stdenv.cc.cc.lib ];
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 nargo $out/bin/nargo
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Noir compiler and package manager";
+    homepage = "https://noir-lang.org";
+    mainProgram = "nargo";
+  };
+}


### PR DESCRIPTION
- **feat: add flake.nix dev environment**
- **refactor: extract nargo package to nix/nargo.nix**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to optional local dev tooling (Nix flake and lockfile); no application, CI workflow, or production runtime code is modified.
> 
> **Overview**
> Adds a **Nix flake** so contributors can enter a reproducible dev environment via `nix develop`, aligned with the repo’s existing Rust and Noir toolchain expectations.
> 
> `flake.nix` wires **nixpkgs-unstable**, **flake-utils**, and **rust-overlay** (Rust from `rust-toolchain.toml`) into a default dev shell that includes **Foundry**, **circom**, **just**, **openssl**, and **pkg-config**, plus a custom **`nargo`** package. `nix/nargo.nix` repackages Noir’s official **v1.0.0-beta.11** prebuilt binaries per platform (with Linux patchelf), matching the version used in CI. `flake.lock` pins the flake inputs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7429d5e133d64df57853617d701673e5d1b767b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->