### PR TITLE
feat(accountant): skeleton for accountant binary

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,6 @@
 * @worldcoin/protocol-contributors
 /services/oprf-node @fabian1409 @0xThemis @dkales @philsippl
 /services/oprf-dev-client @fabian1409 @0xThemis @dkales @philsippl
+/services/oprf-accountant @fabian1409 @0xThemis @dkales @philsippl
 /circom @worldcoin/protocol @fabian1409 @0xThemis @dkales
 /.github/CODEOWNERS @paolodamico @philsippl @murph

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12596,6 +12596,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "world-id-oprf-accountant"
+version = "0.1.0"
+dependencies = [
+ "ark-serialize 0.5.0",
+ "axum",
+ "backon",
+ "config",
+ "eyre",
+ "humantime-serde",
+ "metrics",
+ "rustls",
+ "serde",
+ "serde_json",
+ "sqlx",
+ "taceo-ark-babyjubjub",
+ "taceo-ark-serde-compat",
+ "taceo-nodes-common",
+ "telemetry-batteries",
+ "thiserror 2.0.18",
+ "tikv-jemallocator",
+ "tokio",
+ "tracing",
+ "world-id-primitives",
+]
+
+[[package]]
 name = "world-id-oprf-dev-client"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
   "services/indexer",
   "services/gateway",
   "services/oprf-node",
+  "services/oprf-accountant",
   "services/oprf-dev-client",
   "services/common",
   "services/faux-issuer",
@@ -158,6 +159,7 @@ world-id-registries = { version = "0.12.0", path = "crates/registries" }
 world-id-authenticator = { version = "0.12.0", path = "crates/authenticator" }
 world-id-primitives = { version = "0.12.0", path = "crates/primitives", default-features = false }
 world-id-oprf-node = { version = "1.2.0", path = "services/oprf-node" }
+world-id-oprf-accountant = { version = "0.1.0", path = "services/oprf-accountant" }
 world-id-test-utils = { path = "crates/test-utils" }
 world-id-services-common = { path = "services/common", version = "0.1.0" }
 world-id-relay = { path = "services/relay" }

--- a/services/oprf-accountant/Cargo.toml
+++ b/services/oprf-accountant/Cargo.toml
@@ -1,0 +1,39 @@
+[package]
+name = "world-id-oprf-accountant"
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+
+[dependencies]
+ark-babyjubjub = { workspace = true }
+ark-serde-compat = { workspace = true }
+ark-serialize = { workspace = true }
+axum = { workspace = true, features = ["json", "macros"] }
+backon = { workspace = true, features = ["std", "tokio-sleep"] }
+config.workspace = true
+eyre = { workspace = true }
+humantime-serde = { workspace = true }
+metrics = { workspace = true }
+rustls = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+sqlx = { workspace = true, features = ["postgres", "runtime-tokio-rustls"] }
+taceo-nodes-common = { workspace = true, features = ["api", "postgres"] }
+telemetry-batteries = { workspace = true }
+thiserror.workspace = true
+tokio = { workspace = true, features = [
+  "net",
+  "rt-multi-thread",
+  "signal",
+  "sync",
+  "time",
+  "tokio-macros",
+] }
+tracing = { workspace = true, features = ["release_max_level_debug"] }
+world-id-primitives = { workspace = true }
+
+[target.'cfg(not(target_env = "msvc"))'.dependencies]
+tikv-jemallocator = { workspace = true }

--- a/services/oprf-accountant/migrations/20260703123015_init_db.down.sql
+++ b/services/oprf-accountant/migrations/20260703123015_init_db.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS rp_signatures;

--- a/services/oprf-accountant/migrations/20260703123015_init_db.up.sql
+++ b/services/oprf-accountant/migrations/20260703123015_init_db.up.sql
@@ -1,0 +1,19 @@
+-- Stores RP (relying party) signatures over proof requests so they can be verified later.
+create table if not exists rp_signatures (
+    id BIGINT GENERATED ALWAYS AS identity PRIMARY KEY,
+    rp_id BIGINT NOT NULL,
+    epoch BIGINT NOT NULL,
+    -- version is currently always 1
+    version SMALLINT NOT NULL DEFAULT 1,
+    nonce BYTEA NOT NULL,
+    -- Signed validity window (u64 unix seconds stored as bigint)
+    signed_created_at BIGINT NOT NULL,
+    signed_expires_at BIGINT NOT NULL,
+    -- RP ECDSA (secp256k1) signature over the message (alloy Signature, 65 bytes)
+    signature BYTEA NOT NULL,
+    -- Record insertion timestamp (bookkeeping)
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    -- A given nonce should be signed at most once per RP (replay protection)
+    constraint uq_rp_signatures_rp_id_nonce unique (rp_id, nonce, epoch)
+);

--- a/services/oprf-accountant/src/config.rs
+++ b/services/oprf-accountant/src/config.rs
@@ -1,0 +1,15 @@
+//! Configuration types and environment parsing for the OPRF accountant.
+
+use serde::Deserialize;
+use taceo_nodes_common::postgres::PostgresConfig;
+
+/// The configuration for the OPRF accountant service.
+///
+/// It can be configured via environment variables.
+#[derive(Clone, Debug, Deserialize)]
+#[non_exhaustive]
+pub struct OprfAccountantConfig {
+    /// The postgres config
+    #[serde(rename = "postgres")]
+    pub postgres_config: PostgresConfig,
+}

--- a/services/oprf-accountant/src/lib.rs
+++ b/services/oprf-accountant/src/lib.rs
@@ -1,0 +1,74 @@
+// #![deny(clippy::all, clippy::pedantic)]
+// #![deny(
+//     clippy::allow_attributes_without_reason,
+//     clippy::assertions_on_result_states,
+//     clippy::dbg_macro,
+//     clippy::decimal_literal_representation,
+//     clippy::exhaustive_enums,
+//     clippy::exhaustive_structs,
+//     clippy::iter_over_hash_type,
+//     clippy::let_underscore_must_use,
+//     clippy::missing_assert_message,
+//     clippy::print_stderr,
+//     clippy::print_stdout,
+//     clippy::undocumented_unsafe_blocks,
+//     clippy::unnecessary_safety_comment,
+//     clippy::unwrap_used
+// )]
+// #![allow(missing_docs, reason = "scaffold crate, docs not written yet")]
+
+//! This crate implements the OPRF accountant for World ID.
+//!
+//! It provides an Axum based HTTP server.
+
+use axum::{
+    Json, Router,
+    extract::{FromRef, State},
+    http::StatusCode,
+    response::IntoResponse,
+    routing::post,
+};
+use serde::{Deserialize, Serialize};
+use world_id_primitives::rp::RpId;
+
+use crate::{config::OprfAccountantConfig, postgres::PostgresDb};
+
+pub mod config;
+pub mod metrics;
+pub mod postgres;
+
+#[derive(Clone)]
+struct AppState(PostgresDb);
+
+impl FromRef<AppState> for PostgresDb {
+    fn from_ref(input: &AppState) -> Self {
+        input.0.clone()
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RpVote {
+    rp_id: RpId,
+    epoch: i64,
+    #[serde(with = "ark_serde_compat::field")]
+    nonce: ark_babyjubjub::Fq,
+    created_at: u64,
+    expires_at: u64,
+    #[serde(with = "ark_serde_compat::field")]
+    action: ark_babyjubjub::Fq,
+    signature: Vec<u8>,
+}
+
+async fn post_request(
+    State(db): State<PostgresDb>,
+    Json(rp_requests): Json<Vec<RpVote>>,
+) -> impl IntoResponse {
+    let _ = db.store_request_batch(rp_requests).await;
+    StatusCode::OK
+}
+
+pub async fn start(_config: &OprfAccountantConfig, db: PostgresDb) -> Router {
+    Router::new()
+        .route("/req", post(post_request))
+        .with_state(AppState(db))
+}

--- a/services/oprf-accountant/src/main.rs
+++ b/services/oprf-accountant/src/main.rs
@@ -1,0 +1,127 @@
+//! OPRF accountant Binary
+//!
+//! This is the main entry point for the OPRF accountant.
+//! It initializes tracing, metrics, and starts the service with configuration
+//! from environment variables.
+
+use axum::Router;
+#[cfg(not(target_env = "msvc"))]
+use tikv_jemallocator::Jemalloc;
+
+#[cfg(not(target_env = "msvc"))]
+#[global_allocator]
+static GLOBAL: Jemalloc = Jemalloc;
+
+use std::{net::SocketAddr, process::ExitCode};
+
+use config::{Config, Environment};
+use eyre::Context;
+use serde::Deserialize;
+use world_id_oprf_accountant::{config::OprfAccountantConfig, postgres::PostgresDb};
+
+#[derive(Clone, Debug, Deserialize)]
+struct FullOprfAccountantConfig {
+    /// The bind addr of the AXUM server
+    #[serde(default = "default_bind_addr")]
+    pub bind_addr: SocketAddr,
+    /// The OPRF accountant service config
+    #[serde(rename = "service")]
+    pub service_config: OprfAccountantConfig,
+}
+
+// we are not allowed to build an eyre::Report yet because telemetry-batteries expects to install
+// the color-eyre hook
+fn load_oprf_accountant_config() -> Result<FullOprfAccountantConfig, config::ConfigError> {
+    let cfg = Config::builder().add_source(
+        Environment::with_prefix("TACEO_OPRF_ACCOUNTANT")
+            .separator("__")
+            .try_parsing(true),
+    );
+
+    let accountant_config = cfg.build()?.try_deserialize()?;
+
+    // Unset all env vars with our prefix to prevent leakage to subprocesses.
+    // Safety: this is called before any threads are spawned.
+    let keys_to_remove: Vec<String> = std::env::vars()
+        .filter_map(|(k, _)| k.starts_with("TACEO_OPRF_ACCOUNTANT").then_some(k))
+        .collect();
+    for key in keys_to_remove {
+        // SAFETY: no other threads are running at this point in the startup sequence.
+        unsafe {
+            std::env::remove_var(&key);
+        }
+    }
+
+    Ok(accountant_config)
+}
+
+fn default_bind_addr() -> SocketAddr {
+    "0.0.0.0:4322".parse().expect("valid SocketAddr")
+}
+
+async fn run(config: FullOprfAccountantConfig) -> eyre::Result<()> {
+    tracing::info!("{}", taceo_nodes_common::version_info!());
+    tracing::info!("starting oprf-accountant with config: {config:#?}");
+
+    let (cancellation_token, _) =
+        taceo_nodes_common::spawn_shutdown_task(taceo_nodes_common::default_shutdown_signal());
+
+    let db = PostgresDb::init(&config.service_config.postgres_config).await?;
+    // Clone the values we need afterwards
+    let bind_addr = config.bind_addr;
+
+    let accountant_router = world_id_oprf_accountant::start(&config.service_config, db).await;
+
+    let router = Router::new()
+        .merge(taceo_nodes_common::api::routes(
+            taceo_nodes_common::version_info!(),
+        ))
+        .merge(accountant_router);
+    tracing::info!("starting axum server on {bind_addr}",);
+    let listener = tokio::net::TcpListener::bind(bind_addr).await?;
+    axum::serve(listener, router)
+        .with_graceful_shutdown(async move { cancellation_token.cancelled().await })
+        .await
+        .context("while serving axum")?;
+    tracing::info!("axum server shutdown");
+    Ok(())
+}
+
+fn main() -> ExitCode {
+    // try loading config and unsetting vars before we do any potentially multithreaded work;
+    let maybe_config = load_oprf_accountant_config();
+
+    // we panic if we cannot setup tracing + TLS - if that fails we won't see anything anyways on tracing endpoint
+    rustls::crypto::aws_lc_rs::default_provider()
+        .install_default()
+        .expect("can install");
+
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .expect("Can build Tokio runtime");
+    runtime.block_on(async {
+        let _guard = telemetry_batteries::init();
+        world_id_oprf_accountant::metrics::describe_metrics();
+        // load the config
+        let config = match maybe_config {
+            Ok(config) => config,
+            Err(err) => {
+                tracing::error!(?err, "failed to load config: {err}");
+                return ExitCode::FAILURE;
+            }
+        };
+
+        match run(config).await {
+            Ok(_) => {
+                tracing::info!("good night");
+                ExitCode::SUCCESS
+            }
+            Err(err) => {
+                tracing::error!(?err, "oprf-accountant did shutdown: {err:?}");
+                tracing::error!("good night anyways");
+                ExitCode::FAILURE
+            }
+        }
+    })
+}

--- a/services/oprf-accountant/src/metrics.rs
+++ b/services/oprf-accountant/src/metrics.rs
@@ -1,0 +1,10 @@
+//! Metrics definitions for the world-id-oprf-accountant.
+//!
+//! This module defines all metrics keys used by the service and
+//! provides a helper [`describe_metrics`] to set metadata for
+//! each metric using the `metrics` crate.
+
+/// Describe all metrics used by the service.
+///
+/// This calls the `describe_*` functions from the `metrics` crate to set metadata on the different metrics.
+pub fn describe_metrics() {}

--- a/services/oprf-accountant/src/postgres.rs
+++ b/services/oprf-accountant/src/postgres.rs
@@ -1,0 +1,151 @@
+use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
+use backon::{ConstantBuilder, Retryable as _};
+use eyre::Context as _;
+use sqlx::PgPool;
+use taceo_nodes_common::postgres::{CreateSchema, PostgresConfig};
+use tracing::instrument;
+
+type Result<T> = std::result::Result<T, PostgresDbError>;
+
+/// Postgres-backed store implementing both [`SecretManager`] and [`ChainCursorStorage`] on a shared `PgPool`.
+#[derive(Clone, Debug)]
+pub struct PostgresDb {
+    pool: PgPool,
+    backoff_strategy: ConstantBuilder,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum PostgresDbError {
+    #[error("error in postgres DB: {0}")]
+    DbError(#[from] sqlx::Error),
+    #[error("internal error postgres DB: {0:?}")]
+    Internal(#[from] eyre::Report),
+}
+
+impl PostgresDb {
+    /// Initializes a [`PostgresDb`] by building the connection pool, ensuring the configured schema exists, and running all pending migrations.
+    ///
+    /// # Errors
+    /// Returns an error if creating the database pool fails, or if running the migrations fails.
+    #[instrument(level = "info", skip_all)]
+    pub async fn init(db_config: &PostgresConfig) -> eyre::Result<Self> {
+        tracing::info!("init PgPool with schema: {}", db_config.schema);
+        let pool = taceo_nodes_common::postgres::pg_pool_with_schema(db_config, CreateSchema::Yes)
+            .await
+            .context("while creating pool")?;
+        // We create the pool eagerly, so running migrations here should not hit pool-acquire retries.
+        tracing::trace!("potentially running migrations..");
+        sqlx::migrate!("./migrations")
+            .run(&pool)
+            .await
+            .context("while running migrations")?;
+
+        Ok(Self {
+            pool,
+            backoff_strategy: ConstantBuilder::new()
+                .with_max_times(db_config.max_retries.get())
+                .with_delay(db_config.retry_delay),
+        })
+    }
+
+    pub(crate) async fn store_request_batch(self, rp_requests: Vec<crate::RpVote>) -> Result<()> {
+        let rp_ids: Vec<i64> = rp_requests
+            .iter()
+            .map(|r| r.rp_id.into_inner() as i64)
+            .collect();
+        let epochs: Vec<i64> = rp_requests.iter().map(|r| r.epoch).collect();
+        let nonces: Vec<Vec<u8>> = rp_requests
+            .iter()
+            .map(|r| to_db_ark_serialize_uncompressed(&r.nonce))
+            .collect();
+        let created_ats: Vec<i64> = rp_requests.iter().map(|r| r.created_at as i64).collect();
+        let expires_ats: Vec<i64> = rp_requests.iter().map(|r| r.expires_at as i64).collect();
+        let signatures: Vec<Vec<u8>> = rp_requests.iter().map(|r| r.signature.clone()).collect();
+
+        let batch_insert = || async {
+            Ok(sqlx::query(
+                "
+                INSERT INTO rp_signatures
+                    (rp_id, epoch, nonce, signed_created_at, signed_expires_at, signature)
+                SELECT * FROM UNNEST(
+                    $1::bigint[],
+                    $2::bigint[],
+                    $3::bytea[],
+                    $4::bigint[],
+                    $5::bigint[],
+                    $6::bytea[]
+                )
+                ON CONFLICT (rp_id, nonce, epoch) DO NOTHING
+            ",
+            )
+            .bind(&rp_ids)
+            .bind(&epochs)
+            .bind(&nonces)
+            .bind(&created_ats)
+            .bind(&expires_ats)
+            .bind(&signatures)
+            .execute(&self.pool)
+            .await?
+            .rows_affected())
+        };
+
+        let _rows_affected = self.with_retry("store-request-batch", batch_insert).await?;
+
+        Ok(())
+    }
+
+    async fn with_retry<F, Fut, T>(&self, op_name: &str, f: F) -> Result<T>
+    where
+        F: Fn() -> Fut,
+        Fut: Future<Output = Result<T>>,
+    {
+        f.retry(self.backoff_strategy)
+            .sleep(tokio::time::sleep)
+            .when(is_retryable_error)
+            .notify(|err, duration| {
+                tracing::warn!(%err, "Retrying {op_name} in db after {duration:?}");
+            })
+            .await
+    }
+}
+
+#[inline]
+fn is_retryable_error(e: &PostgresDbError) -> bool {
+    match e {
+        PostgresDbError::DbError(err) => {
+            match err {
+                // structural / driver-level errors
+                sqlx::Error::PoolTimedOut
+                | sqlx::Error::Io(_)
+                | sqlx::Error::Tls(_)
+                | sqlx::Error::Protocol(_)
+                | sqlx::Error::AnyDriverError(_)
+                | sqlx::Error::WorkerCrashed
+                | sqlx::Error::BeginFailed => true,
+
+                // serialization_failure and deadlock detected for transactions
+                sqlx::Error::Database(db_err) => {
+                    matches!(db_err.code().as_deref(), Some("40001" | "40P01"))
+                }
+
+                _ => false,
+            }
+        }
+        _ => false,
+    }
+}
+
+#[inline]
+pub(crate) fn to_db_ark_serialize_uncompressed<T: CanonicalSerialize>(t: &T) -> Vec<u8> {
+    let mut bytes = Vec::with_capacity(t.uncompressed_size());
+    t.serialize_uncompressed(&mut bytes).expect("Can serialize");
+    bytes
+}
+
+#[inline]
+#[expect(dead_code, reason = "here for later use")]
+pub(crate) fn from_db_ark_serialize_uncompressed<T: CanonicalDeserialize>(b: Vec<u8>) -> Result<T> {
+    T::deserialize_uncompressed(b.as_slice()).map_err(|e| {
+        PostgresDbError::from(eyre::eyre!("Cannot deserialize bytes: DB not sane: {e}"))
+    })
+}


### PR DESCRIPTION
- **feat(accountant): skeleton for oprf-accountant binary**
- **chore: add github code owners for accountant**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New service will store RP signature metadata used for later verification; the ingest path does not yet validate signatures or surface DB errors to clients, so bad or dropped data could go unnoticed until follow-up work.
> 
> **Overview**
> Introduces a new **`services/oprf-accountant`** workspace crate and binary, wired into the root `Cargo.toml` / `Cargo.lock`, with **CODEOWNERS** for the new path.
> 
> The service boots like other OPRF node binaries: **`TACEO_OPRF_ACCOUNTANT__*`** env config (Postgres + bind address default **`0.0.0.0:4322`**), telemetry/metrics hooks, graceful shutdown, and shared **`taceo-nodes-common`** health/version routes merged with an Axum router.
> 
> **Persistence:** SQLx migrations create **`rp_signatures`** (RP id, epoch, nonce, signed validity window, secp256k1 signature bytes) with a unique constraint on **`(rp_id, nonce, epoch)`** for replay protection.
> 
> **API:** **`POST /req`** accepts a JSON batch of **`RpVote`** records and bulk-inserts into Postgres with retries; conflicts are ignored via **`ON CONFLICT DO NOTHING`**. This is explicitly scaffold-level: **`action`** is in the request type but not stored, **`describe_metrics`** is empty, and the handler currently returns **200 OK** even when persistence fails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1b9193e953d45ec802b344c67c0661e354e137f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->