### PR TITLE
chore: update crossbeam-epoch to 0.9.20 (RUSTSEC-2026-0204)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3289,9 +3289,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
One-line `cargo update -p crossbeam-epoch` (0.9.18 → 0.9.20) to clear [RUSTSEC-2026-0204](https://rustsec.org/advisories/RUSTSEC-2026-0204), which was published after main's last CI run and is now failing the `Cargo deny (advisories)` check on every open PR (including the #828/#831/#833 stack).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Patch-level transitive dependency update with no source changes; typical low-risk security advisory remediation.
> 
> **Overview**
> Bumps the transitive **`crossbeam-epoch`** dependency from **0.9.18** to **0.9.20** in `Cargo.lock` only, addressing **[RUSTSEC-2026-0204](https://rustsec.org/advisories/RUSTSEC-2026-0204)** so the Cargo deny advisories check can pass again.
> 
> No application or manifest changes beyond the lockfile entry and checksum for `crossbeam-epoch`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2bc6f3223ab1bffa7514664a2e8d68a5084f7cbc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->