### PR TITLE
chore: simple knowledge graph declaration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ crates/core/contracts/out/*.sol/*.json
 
 # Trusted setup generated media
 docs/world-id-4-trusted-setup/manim/media/
+
+# graph
+graph/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,9 @@
 # AGENTS.md
 
+## Knowledge graph (Experimental)
+
+This project MAY have a knowledge graph at `graph/`. If it does, look at the `graph/AGENTS.md` file first for instructions and you can ignore the rest of this file.
+
 ## Repo Overview
 - Rust workspace + Solidity contracts + Circom circuits + deployable services.
 - See `README.md` for global status and prerequisites.


### PR DESCRIPTION
Introduces a very simple knowledge graph declaration to experiment with more sophisticated knowledge graphs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and ignore rules only; no runtime, auth, or protocol code changes.
> 
> **Overview**
> Adds an **experimental knowledge graph** hook for AI agents: `AGENTS.md` now says the repo may include a graph at `graph/`, and agents should read `graph/AGENTS.md` first when it exists (and can skip the rest of `AGENTS.md` in that case).
> 
> **`.gitignore`** now ignores the entire `graph/` directory so local or generated graph content stays out of version control.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0885cbef6d5318fddc28caa9395fb8b91ed418d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->