### PR TITLE
chore: update staging impl addresses

### DIFF
--- a/contracts/deployments/core/staging.json
+++ b/contracts/deployments/core/staging.json
@@ -12,11 +12,11 @@
   "timestamp": 1770925941,
   "verifier": "0x39CcB3b670651a14da8b3835f42924f49C2C5986",
   "worldIDRegistry": {
-    "implementation": "0x0eDa27c00436F2bB9f8CF67eFA2863141C727728",
+    "implementation": "0xB31e7AEb2fFB1dF2c69dc3F873CdF9cC4946B2e0",
     "proxy": "0x8556d07D75025f286fe757C7EeEceC40D54FA16D"
   },
   "worldIDVerifier": {
-    "implementation": "0x72EF65C95e7569024c8Bc37F055A781E7Cc61C66",
+    "implementation": "0xff93a0146bf6E7557B63315efeCe083Ca07D4C73",
     "proxy": "0x703a6316c975DEabF30b637c155edD53e24657DB"
   }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Staging-only deployment metadata update with no logic changes; wrong addresses could mislead operators until upgrades are run, but production is untouched.
> 
> **Overview**
> Updates **`contracts/deployments/core/staging.json`** so recorded **implementation** addresses match the current staging deploys for **`worldIDRegistry`** and **`worldIDVerifier`**. **Proxy** addresses and all other entries in the file are unchanged.
> 
> This keeps the deployment artifact aligned with what upgrade tooling (e.g. `just` core upgrade recipes that read `implementation` from this JSON) expects on staging, not a contract or application code change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0b6633eec15cf20a593c47a6da85a76fd348c24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->