### PR TITLE
refactor(node): cleanup auth modules

### DIFF
--- a/services/oprf-node/src/auth.rs
+++ b/services/oprf-node/src/auth.rs
@@ -25,18 +25,21 @@ pub(crate) mod rp_module;
 pub(crate) mod rp_registry_watcher;
 pub(crate) mod schema_issuer_registry_watcher;
 
-/// Logs an auth-module error: `error!` for internal errors, `warn!` (with
-/// `auth_error=true`) for client-attributable auth failures.
-pub(crate) fn log_auth_module_error(
-    err: &(impl std::fmt::Debug + std::fmt::Display),
-    mapped: WorldIdRequestAuthError,
-    module: &str,
-) {
+/// Maps an auth-module error to its [`WorldIdRequestAuthError`] and logs it:
+/// `error!` for internal errors, `warn!` (with `auth_error=true`) for
+/// client-attributable auth failures.
+pub(crate) fn auth_module_error<E>(err: E, module: &str) -> WorldIdRequestAuthError
+where
+    E: std::fmt::Debug + std::fmt::Display,
+    for<'a> WorldIdRequestAuthError: From<&'a E>,
+{
+    let mapped = WorldIdRequestAuthError::from(&err);
     if matches!(mapped, WorldIdRequestAuthError::Internal) {
         tracing::error!(?err, "Internal error in {module}");
     } else {
         tracing::warn!(auth_error = true, ?err, "Error in {module}: {err}");
     }
+    mapped
 }
 
 pub(crate) fn verify_query_proof(

--- a/services/oprf-node/src/auth/credential_blinding_factor.rs
+++ b/services/oprf-node/src/auth/credential_blinding_factor.rs
@@ -130,11 +130,10 @@ impl OprfRequestAuthenticator for CredentialBlindingFactorModuleAuth {
         &self,
         request: &OprfRequest<Self::RequestAuth>,
     ) -> Result<OprfKeyId, OprfRequestAuthenticatorError> {
-        Ok(self.authenticate_inner(request).await.map_err(|err| {
-            let mapped = WorldIdRequestAuthError::from(&err);
-            super::log_auth_module_error(&err, mapped, "credential issuer blinding module");
-            mapped
-        })?)
+        Ok(self
+            .authenticate_inner(request)
+            .await
+            .map_err(|err| super::auth_module_error(err, "credential issuer blinding module"))?)
     }
 }
 

--- a/services/oprf-node/src/auth/merkle_watcher.rs
+++ b/services/oprf-node/src/auth/merkle_watcher.rs
@@ -74,21 +74,9 @@ impl MerkleWatcher {
         http_rpc_provider: &web3::HttpRpcProvider,
         cache_config: WatcherCacheConfig,
     ) -> Self {
-        let contract = WorldIdRegistry::new(contract_address, http_rpc_provider.inner());
-
-        let merkle_root_cache_builder = Cache::builder()
-            .max_capacity(cache_config.max_cache_size.get())
-            .time_to_live(cache_config.time_to_live);
-
-        let merkle_root_cache = if let Some(time_to_idle) = cache_config.time_to_idle {
-            merkle_root_cache_builder.time_to_idle(time_to_idle).build()
-        } else {
-            merkle_root_cache_builder.build()
-        };
-
         Self {
-            merkle_root_cache,
-            contract,
+            merkle_root_cache: cache_config.build_cache(),
+            contract: WorldIdRegistry::new(contract_address, http_rpc_provider.inner()),
         }
     }
 

--- a/services/oprf-node/src/auth/rp_module.rs
+++ b/services/oprf-node/src/auth/rp_module.rs
@@ -111,20 +111,10 @@ pub(crate) enum RpModuleError {
     InvalidSignature,
     #[error("RP signature is required for EOA-backed signers")]
     RpSignatureMissing,
-    #[error("Auxiliary data must be empty with EOA backed signer")]
-    Wip101AuxDataOnEoa,
     #[error(transparent)]
     DuplicateNonce(#[from] DuplicateNonce),
-    #[error("RP signer is a contract but does not conform to WIP101")]
-    Wip101IncompatibleRpSigner,
-    #[error("Ran into timeout while verifying RP signature")]
-    Wip101VerificationTimeout,
-    #[error("RP signer contract reverted with custom error")]
-    Wip101CustomRevert,
-    #[error("RP signer contract reverts with code: {0:?}")]
-    Wip101VerificationFailed(Option<U256>),
-    #[error("Auxiliary data for WIP101 contract too large")]
-    Wip101AuxDataTooLarge,
+    #[error(transparent)]
+    Wip101(#[from] wip101::Wip101Error),
     #[error("Internal error: {0:?}")]
     Internal(#[from] eyre::Report),
 }
@@ -135,8 +125,8 @@ impl From<&RpModuleError> for WorldIdRequestAuthError {
             RpModuleError::InvalidActionSession { .. } => Self::InvalidActionSession,
             RpModuleError::InvalidActionUniqueness { .. } => Self::InvalidActionNullifier,
             RpModuleError::InvalidQueryProof => Self::InvalidQueryProof,
-            RpModuleError::MerkleWatcher(e) => e.as_ref().into(),
-            RpModuleError::RpRegistry(e) => e.as_ref().into(),
+            RpModuleError::MerkleWatcher(e) => Self::from(e.as_ref()),
+            RpModuleError::RpRegistry(e) => Self::from(e.as_ref()),
             RpModuleError::TimestampTooOld { .. } => Self::TimestampTooOld,
             RpModuleError::TimestampTooFarInFuture { .. } => Self::TimestampTooFarInFuture,
             RpModuleError::RpSignatureExpired { .. } => Self::RpSignatureExpired,
@@ -147,12 +137,7 @@ impl From<&RpModuleError> for WorldIdRequestAuthError {
                 Self::InvalidRpSignature
             }
             RpModuleError::DuplicateNonce(_) => Self::DuplicateNonce,
-            RpModuleError::Wip101IncompatibleRpSigner => Self::Wip101IncompatibleRpSigner,
-            RpModuleError::Wip101VerificationTimeout => Self::Wip101VerificationTimeout,
-            RpModuleError::Wip101VerificationFailed(code) => Self::Wip101VerificationFailed(*code),
-            RpModuleError::Wip101CustomRevert => Self::Wip101CustomRevert,
-            RpModuleError::Wip101AuxDataOnEoa => Self::Wip101AuxDataOnEoa,
-            RpModuleError::Wip101AuxDataTooLarge => Self::Wip101AuxDataTooLarge,
+            RpModuleError::Wip101(e) => Self::from(e),
             RpModuleError::Internal(_) => Self::Internal,
         }
     }
@@ -207,7 +192,7 @@ impl RelyingParty {
             .signature
             .ok_or_else(|| RpModuleError::RpSignatureMissing)?;
         if request.auth.wip101_data.is_some() {
-            return Err(RpModuleError::Wip101AuxDataOnEoa);
+            return Err(RpModuleError::Wip101(wip101::Wip101Error::AuxDataOnEoa));
         }
         // check the RP nonce signature
         let msg = world_id_primitives::rp::compute_rp_signature_msg(
@@ -223,36 +208,6 @@ impl RelyingParty {
             return Err(RpModuleError::InvalidSignature);
         }
         Ok(())
-    }
-
-    async fn ensure_signature_valid(
-        &self,
-        kind: &RpModuleKind,
-        action: ark_babyjubjub::Fq,
-        request: &OprfRequest<NullifierOprfRequestAuthV1>,
-        wip101_timeout: Duration,
-        rpc_provider: &web3::HttpRpcProvider,
-    ) -> Result<(), RpModuleError> {
-        match self.account_type {
-            RpAccountType::Eoa => {
-                tracing::trace!("RP signer is EOA");
-                let action = match kind {
-                    RpModuleKind::Uniqueness(_) => Some(action),
-                    RpModuleKind::Session => None,
-                };
-                self.verify_eoa(action, request)
-            }
-            RpAccountType::Contract => {
-                tracing::trace!("RP signer is WIP101");
-                // TODO(session-proofs): WIP-101 does not currently support session proofs.
-                self.verify_wip101(action, &request.auth, rpc_provider, wip101_timeout)
-                    .await
-            }
-            RpAccountType::IncompatibleWip101 => {
-                tracing::trace!("RP signer is incompatible WIP101");
-                Err(RpModuleError::Wip101IncompatibleRpSigner)
-            }
-        }
     }
 }
 
@@ -270,6 +225,18 @@ pub(crate) struct RpModuleAuthArgs {
 impl RpModuleAuth {
     /// Initializes a session-module authenticator.
     pub(crate) fn new_session(args: RpModuleAuthArgs) -> Self {
+        Self::new(RpModuleKind::Session, args)
+    }
+
+    /// Initializes a uniqueness-module authenticator.
+    pub(crate) fn new_uniqueness(
+        args: RpModuleAuthArgs,
+        accountant_batcher: AccountantBatcherHandle,
+    ) -> Self {
+        Self::new(RpModuleKind::Uniqueness(accountant_batcher), args)
+    }
+
+    fn new(kind: RpModuleKind, args: RpModuleAuthArgs) -> Self {
         let RpModuleAuthArgs {
             merkle_watcher,
             rp_registry_watcher,
@@ -280,7 +247,7 @@ impl RpModuleAuth {
             query_vk,
         } = args;
         Self {
-            kind: RpModuleKind::Session,
+            kind,
             rp_registry_watcher,
             nonce_history,
             current_time_stamp_max_difference,
@@ -291,29 +258,71 @@ impl RpModuleAuth {
         }
     }
 
-    /// Initializes a uniqueness-module authenticator.
-    pub(crate) fn new_uniqueness(
-        args: RpModuleAuthArgs,
-        accountant_batcher: AccountantBatcherHandle,
-    ) -> Self {
-        let RpModuleAuthArgs {
-            merkle_watcher,
-            rp_registry_watcher,
-            nonce_history,
-            current_time_stamp_max_difference,
-            timeout_external_eth_call,
-            rpc_provider,
-            query_vk,
-        } = args;
-        Self {
-            kind: RpModuleKind::Uniqueness(accountant_batcher),
-            rp_registry_watcher,
-            nonce_history,
-            current_time_stamp_max_difference,
-            timeout_external_eth_call,
-            merkle_watcher,
-            rpc_provider,
-            query_vk,
+    /// Checks that the signature has not expired and that the request timestamp
+    /// is within the configured window around the node's system time.
+    fn validate_timestamps(&self, auth: &NullifierOprfRequestAuthV1) -> Result<(), RpModuleError> {
+        let current_time = Utc::now();
+
+        tracing::trace!("checking expiration timestamp on signature...");
+        let expiration_time_stamp = parse_timestamp(auth.expiration_timestamp)?;
+        if expiration_time_stamp <= current_time {
+            return Err(RpModuleError::RpSignatureExpired {
+                current: current_time,
+                expired_timestamp: expiration_time_stamp,
+            });
+        }
+
+        tracing::trace!("checking timestamp on signature...");
+        let timestamp = parse_timestamp(auth.current_time_stamp)?;
+        let max_difference = chrono::Duration::from_std(self.current_time_stamp_max_difference)
+            .expect("configured max difference fits into chrono::Duration");
+        if timestamp > current_time + max_difference {
+            return Err(RpModuleError::TimestampTooFarInFuture {
+                timestamp,
+                current: current_time,
+            });
+        }
+        if timestamp < current_time - max_difference {
+            return Err(RpModuleError::TimestampTooOld {
+                timestamp,
+                current: current_time,
+            });
+        }
+        Ok(())
+    }
+
+    async fn ensure_signature_valid(
+        &self,
+        rp: &RelyingParty,
+        action: ark_babyjubjub::Fq,
+        request: &OprfRequest<NullifierOprfRequestAuthV1>,
+    ) -> Result<(), RpModuleError> {
+        match rp.account_type {
+            RpAccountType::Eoa => {
+                tracing::trace!("RP signer is EOA");
+                let action = match self.kind {
+                    RpModuleKind::Uniqueness(_) => Some(action),
+                    RpModuleKind::Session => None,
+                };
+                rp.verify_eoa(action, request)
+            }
+            RpAccountType::Contract => {
+                // TODO(session-proofs): WIP-101 does not currently support session proofs.
+                Ok(rp
+                    .verify_wip101(
+                        action,
+                        &request.auth,
+                        &self.rpc_provider,
+                        self.timeout_external_eth_call,
+                    )
+                    .await?)
+            }
+            RpAccountType::IncompatibleWip101 => {
+                tracing::trace!("RP signer is incompatible WIP101");
+                Err(RpModuleError::Wip101(
+                    wip101::Wip101Error::IncompatibleRpSigner,
+                ))
+            }
         }
     }
 
@@ -322,40 +331,7 @@ impl RpModuleAuth {
         action: ark_babyjubjub::Fq,
         request: &OprfRequest<NullifierOprfRequestAuthV1>,
     ) -> Result<OprfKeyId, RpModuleError> {
-        let current_time = Utc::now();
-        let req_expiration_time_stamp = parse_timestamp(request.auth.expiration_timestamp)?;
-        tracing::trace!("checking expiration timestamp on signature...");
-
-        if req_expiration_time_stamp <= current_time {
-            return Err(RpModuleError::RpSignatureExpired {
-                current: current_time,
-                expired_timestamp: req_expiration_time_stamp,
-            });
-        }
-
-        // check the time stamp against system time +/- difference
-        tracing::trace!("checking timestamp on signature...");
-        let req_time_stamp = parse_timestamp(request.auth.current_time_stamp)?;
-        let diff = current_time.signed_duration_since(req_time_stamp);
-        let abs_diff = diff
-            .abs()
-            .to_std()
-            .expect("absolute value is always non-negative");
-
-        if abs_diff > self.current_time_stamp_max_difference {
-            if diff < chrono::Duration::zero() {
-                // req is in the future
-                return Err(RpModuleError::TimestampTooFarInFuture {
-                    timestamp: req_time_stamp,
-                    current: current_time,
-                });
-            }
-            // req is in the past
-            return Err(RpModuleError::TimestampTooOld {
-                timestamp: req_time_stamp,
-                current: current_time,
-            });
-        }
+        self.validate_timestamps(&request.auth)?;
 
         tracing::trace!("fetching RP info...");
         // fetch the RP info
@@ -369,33 +345,7 @@ impl RpModuleAuth {
             });
         }
 
-        rp.ensure_signature_valid(
-            &self.kind,
-            action,
-            request,
-            self.timeout_external_eth_call,
-            &self.rpc_provider,
-        )
-        .await?;
-
-        tracing::trace!("add nonce to store...");
-        // Add nonce to history to check if the nonce was only used once in this scope.
-        let nonce_scope = match self.kind {
-            RpModuleKind::Uniqueness(_) => NonceScope::Uniqueness,
-            RpModuleKind::Session => {
-                let action = FieldElement::from(action);
-                if action.is_valid_for_session(SessionFeType::OprfSeed) {
-                    NonceScope::SessionOprfSeed
-                } else if action.is_valid_for_session(SessionFeType::Action) {
-                    NonceScope::SessionAction
-                } else {
-                    return Err(RpModuleError::InvalidActionSession { action });
-                }
-            }
-        };
-        self.nonce_history
-            .add_nonce(FieldElement::from(request.auth.nonce), nonce_scope)
-            .await?;
+        self.ensure_signature_valid(&rp, action, request).await?;
 
         tracing::trace!("RP signature authentication successful");
         Ok(rp.oprf_key_id)
@@ -408,12 +358,15 @@ impl RpModuleAuth {
         tracing::trace!("Validating action for {}", self.kind);
         let action = FieldElement::from(request.auth.action);
 
-        match self.kind {
+        // Validate the action per kind and derive the nonce scope it consumes.
+        let nonce_scope = match self.kind {
             RpModuleKind::Session => {
                 metrics::auth_module::inc_session();
-                if !action.is_valid_for_session(SessionFeType::OprfSeed)
-                    && !action.is_valid_for_session(SessionFeType::Action)
-                {
+                if action.is_valid_for_session(SessionFeType::OprfSeed) {
+                    NonceScope::SessionOprfSeed
+                } else if action.is_valid_for_session(SessionFeType::Action) {
+                    NonceScope::SessionAction
+                } else {
                     return Err(RpModuleError::InvalidActionSession { action });
                 }
             }
@@ -422,8 +375,9 @@ impl RpModuleAuth {
                 if action.to_be_bytes()[0] != 0 {
                     return Err(RpModuleError::InvalidActionUniqueness { action });
                 }
+                NonceScope::Uniqueness
             }
-        }
+        };
 
         let (verify_rp_signature_check, merkle_check) = tokio::join!(
             self.verify_rp_signature(request.auth.action, request),
@@ -444,6 +398,12 @@ impl RpModuleAuth {
             request.auth.nonce,
         );
         if valid {
+            tracing::trace!("add nonce to store...");
+            // Add nonce to history to check if the nonce was only used once in this scope.
+            // Only add if everything else was successful
+            self.nonce_history
+                .add_nonce(FieldElement::from(request.auth.nonce), nonce_scope)
+                .await?;
             tracing::trace!("authentication successful!");
             Ok(oprf_key_id)
         } else {
@@ -475,11 +435,7 @@ impl OprfRequestAuthenticator for RpModuleAuth {
                     handle.record_request(BillableRpRequest::from(&request.auth));
                 }
             })
-            .map_err(|err| {
-                let mapped = WorldIdRequestAuthError::from(&err);
-                super::log_auth_module_error(&err, mapped, "RP-module");
-                mapped
-            })?)
+            .map_err(|err| super::auth_module_error(err, "RP-module"))?)
     }
 }
 

--- a/services/oprf-node/src/auth/rp_module/wip101.rs
+++ b/services/oprf-node/src/auth/rp_module/wip101.rs
@@ -1,19 +1,59 @@
 use std::time::Duration;
 
 use alloy::{
-    primitives::{Address, Bytes},
+    primitives::{Address, Bytes, U256},
     sol_types::SolCall as _,
 };
 use taceo_nodes_common::web3::{self, erc165::ERC165ConfirmError};
 use tracing::instrument;
-use world_id_primitives::{RequestVersion, oprf::NullifierOprfRequestAuthV1};
-
-use crate::auth::rp_module::{
-    RelyingParty, RpAccountType, RpModuleError, wip101::IWIP101::IWIP101Instance,
+use world_id_primitives::{
+    RequestVersion,
+    oprf::{NullifierOprfRequestAuthV1, WorldIdRequestAuthError},
 };
+
+use crate::auth::rp_module::{RelyingParty, RpAccountType, wip101::IWIP101::IWIP101Instance};
 
 #[cfg(test)]
 pub(crate) mod tests;
+
+/// WIP101-specific authentication failures.
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum Wip101Error {
+    #[error("Auxiliary data must be empty with EOA backed signer")]
+    AuxDataOnEoa,
+    #[error("Auxiliary data for WIP101 contract too large")]
+    AuxDataTooLarge,
+    #[error("RP signer is a contract but does not conform to WIP101")]
+    IncompatibleRpSigner,
+    #[error("Ran into timeout while verifying RP signature")]
+    VerificationTimeout,
+    #[error("RP signer contract reverted with custom error")]
+    CustomRevert,
+    #[error("RP signer contract reverts with code: {0:?}")]
+    VerificationFailed(Option<U256>),
+    #[error(transparent)]
+    Internal(#[from] eyre::Report),
+}
+
+impl From<&Wip101Error> for WorldIdRequestAuthError {
+    fn from(value: &Wip101Error) -> Self {
+        match value {
+            Wip101Error::AuxDataOnEoa => Self::Wip101AuxDataOnEoa,
+            Wip101Error::AuxDataTooLarge => Self::Wip101AuxDataTooLarge,
+            Wip101Error::IncompatibleRpSigner => Self::Wip101IncompatibleRpSigner,
+            Wip101Error::VerificationTimeout => Self::Wip101VerificationTimeout,
+            Wip101Error::CustomRevert => Self::Wip101CustomRevert,
+            Wip101Error::VerificationFailed(code) => Self::Wip101VerificationFailed(*code),
+            Wip101Error::Internal(_) => Self::Internal,
+        }
+    }
+}
+
+impl From<Wip101Error> for WorldIdRequestAuthError {
+    fn from(value: Wip101Error) -> Self {
+        Self::from(&value)
+    }
+}
 
 /// Max size of the auxiliary data according to WIP101.
 const MAX_AUX_DATA_SIZE: usize = 1024;
@@ -48,7 +88,7 @@ impl RelyingParty {
         auth: &NullifierOprfRequestAuthV1,
         rpc_provider: &web3::HttpRpcProvider,
         timeout: Duration,
-    ) -> Result<(), RpModuleError> {
+    ) -> Result<(), Wip101Error> {
         tracing::trace!("RP signer is WIP101");
         let iwip101 = IWIP101Instance::new(self.signer, rpc_provider.inner());
 
@@ -57,7 +97,7 @@ impl RelyingParty {
             .as_ref()
             .is_some_and(|bytes| bytes.len() > MAX_AUX_DATA_SIZE)
         {
-            return Err(RpModuleError::Wip101AuxDataTooLarge);
+            return Err(Wip101Error::AuxDataTooLarge);
         }
         // cloning here is not a problem as we only allow up to 1kb anyways
         let auxiliary_data = auth
@@ -76,29 +116,29 @@ impl RelyingParty {
 
         match tokio::time::timeout(timeout, wip101_call.call())
             .await
-            .map_err(|_| RpModuleError::Wip101VerificationTimeout)?
+            .map_err(|_| Wip101Error::VerificationTimeout)?
         {
             Ok(x) if x == SUCCESS_MAGIC_VALUE => Ok(()),
-            Ok(_) => Err(RpModuleError::Wip101VerificationFailed(None)),
+            Ok(_) => Err(Wip101Error::VerificationFailed(None)),
             Err(
                 alloy::contract::Error::UnknownFunction(_)
                 | alloy::contract::Error::UnknownSelector(_),
-            ) => Err(RpModuleError::Wip101IncompatibleRpSigner),
+            ) => Err(Wip101Error::IncompatibleRpSigner),
             Err(err) => {
                 if let Some(IWIP101::RpInvalidRequest { code }) =
                     err.as_decoded_error::<IWIP101::RpInvalidRequest>()
                 {
-                    Err(RpModuleError::Wip101VerificationFailed(Some(code)))
+                    Err(Wip101Error::VerificationFailed(Some(code)))
                 } else if let Some(x) = err.as_revert_data() {
                     if x.is_empty() {
                         // empty revert reason - most likely this contract reported it supports WIP101 without actually supporting it
-                        Err(RpModuleError::Wip101IncompatibleRpSigner)
+                        Err(Wip101Error::IncompatibleRpSigner)
                     } else {
                         // most likely we got some specific revert reason that was not the agreed RpInvalidRequest
-                        Err(RpModuleError::Wip101CustomRevert)
+                        Err(Wip101Error::CustomRevert)
                     }
                 } else {
-                    Err(RpModuleError::Internal(eyre::Report::from(err)))
+                    Err(Wip101Error::Internal(eyre::Report::from(err)))
                 }
             }
         }

--- a/services/oprf-node/src/auth/rp_registry_watcher.rs
+++ b/services/oprf-node/src/auth/rp_registry_watcher.rs
@@ -110,18 +110,8 @@ impl RpRegistryWatcher {
         timeout_external_eth_call: Duration,
         cache_config: WatcherCacheConfig,
     ) -> Self {
-        let rp_store_builder = Cache::builder()
-            .max_capacity(cache_config.max_cache_size.get())
-            .time_to_live(cache_config.time_to_live);
-
-        let rp_store = if let Some(time_to_idle) = cache_config.time_to_idle {
-            rp_store_builder.time_to_idle(time_to_idle).build()
-        } else {
-            rp_store_builder.build()
-        };
-
         Self {
-            rp_store,
+            rp_store: cache_config.build_cache(),
             rp_registry_contract: RpRegistry::new(rp_registry_address, http_rpc_provider.inner()),
             billing_contract: BillingContract::new(
                 billing_contract_address,

--- a/services/oprf-node/src/auth/schema_issuer_registry_watcher.rs
+++ b/services/oprf-node/src/auth/schema_issuer_registry_watcher.rs
@@ -70,17 +70,8 @@ impl SchemaIssuerRegistryWatcher {
         http_rpc_provider: &web3::HttpRpcProvider,
         cache_config: WatcherCacheConfig,
     ) -> Self {
-        let store_builder = Cache::builder()
-            .max_capacity(cache_config.max_cache_size.get())
-            .time_to_live(cache_config.time_to_live);
-        let issuer_schema_store = if let Some(time_to_idle) = cache_config.time_to_idle {
-            store_builder.time_to_idle(time_to_idle).build()
-        } else {
-            store_builder.build()
-        };
-
         Self {
-            issuer_schema_store,
+            issuer_schema_store: cache_config.build_cache(),
             contract: CredentialSchemaIssuerRegistryInstance::new(
                 contract_address,
                 http_rpc_provider.inner(),

--- a/services/oprf-node/src/config.rs
+++ b/services/oprf-node/src/config.rs
@@ -104,6 +104,22 @@ impl WatcherCacheConfig {
             time_to_idle: None,
         }
     }
+
+    /// Builds a [`moka::future::Cache`] with this configuration.
+    pub(crate) fn build_cache<K, V>(&self) -> moka::future::Cache<K, V>
+    where
+        K: std::hash::Hash + Eq + Send + Sync + 'static,
+        V: Clone + Send + Sync + 'static,
+    {
+        let builder = moka::future::Cache::builder()
+            .max_capacity(self.max_cache_size.get())
+            .time_to_live(self.time_to_live);
+        if let Some(time_to_idle) = self.time_to_idle {
+            builder.time_to_idle(time_to_idle).build()
+        } else {
+            builder.build()
+        }
+    }
 }
 
 impl Default for WatcherCacheConfig {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes live in World ID OPRF request authentication, including nonce replay timing and RP/WIP-101 verification wiring; the nonce-after-proof fix reduces replay edge cases but any auth refactor warrants careful review.
> 
> **Overview**
> Refactors OPRF node auth helpers and RP-module structure without changing the outward error taxonomy.
> 
> **Shared helpers:** `log_auth_module_error` becomes `auth_module_error`, which maps module errors to `WorldIdRequestAuthError` and logs in one step; credential blinding and RP modules use it in their `map_err` paths. Watcher `init` code paths build Moka caches via new `WatcherCacheConfig::build_cache()` instead of duplicating builder logic in merkle, RP registry, and schema issuer watchers.
> 
> **WIP-101:** Contract verification failures move into `wip101::Wip101Error` (with `From` into `WorldIdRequestAuthError`); `RpModuleError` wraps them with `#[from]` instead of many parallel variants.
> 
> **RP module:** Session vs uniqueness constructors share a private `new`; timestamp checks are extracted into `validate_timestamps` with explicit future/late bounds; RP signature routing lives on `RpModuleAuth::ensure_signature_valid` using `RelyingParty` for EOA/WIP-101. **Behavioral fix:** nonces are recorded in `nonce_history` only after merkle, RP signature, and query proof all succeed (previously nonce could be consumed before a failed proof).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3d0d75fb9dfc4163e99bb3dca8e7784ddd4a2c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->