### PR TITLE
feat(node): add metrics and query with id to batcher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12610,6 +12610,7 @@ dependencies = [
  "tikv-jemallocator",
  "tokio",
  "tracing",
+ "uuid",
  "world-id-primitives",
 ]
 

--- a/services/oprf-accountant/Cargo.toml
+++ b/services/oprf-accountant/Cargo.toml
@@ -35,6 +35,7 @@ tokio = { workspace = true, features = [
   "tokio-macros",
 ] }
 tracing = { workspace = true, features = ["release_max_level_debug"] }
+uuid.workspace = true
 world-id-primitives = { workspace = true }
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]

--- a/services/oprf-accountant/src/api.rs
+++ b/services/oprf-accountant/src/api.rs
@@ -1,8 +1,26 @@
-use axum::{Json, Router, extract::State, http::StatusCode, response::IntoResponse, routing::post};
+use axum::{
+    Json, Router,
+    extract::{Query, State},
+    http::StatusCode,
+    response::IntoResponse,
+    routing::post,
+};
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 use world_id_primitives::{oprf::NullifierOprfRequestAuthV1, rp::RpId};
 
 use crate::{AppState, postgres::PostgresDb};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct PostRequestQuery {
+    pub id: Uuid,
+}
+
+impl PostRequestQuery {
+    pub fn into_query_strings(self) -> (String, String) {
+        (String::from("id"), self.id.to_string())
+    }
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct BillableRpRequest {
@@ -15,6 +33,9 @@ pub struct BillableRpRequest {
     pub action: ark_babyjubjub::Fq,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub signature: Option<alloy_primitives::Signature>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(with = "world_id_primitives::serde_utils::hex_bytes_opt")]
+    pub wip101_data: Option<Vec<u8>>,
 }
 
 impl From<&NullifierOprfRequestAuthV1> for BillableRpRequest {
@@ -26,6 +47,7 @@ impl From<&NullifierOprfRequestAuthV1> for BillableRpRequest {
             expires_at,
             signature,
             rp_id,
+            wip101_data,
             ..
         } = value;
         Self {
@@ -35,12 +57,15 @@ impl From<&NullifierOprfRequestAuthV1> for BillableRpRequest {
             expires_at: *expires_at,
             created_at: *created_at,
             signature: *signature,
+            wip101_data: wip101_data.clone(),
         }
     }
 }
 
+// TODO add id to span
 async fn post_request(
     State(db): State<PostgresDb>,
+    Query(PostRequestQuery { id: _ }): Query<PostRequestQuery>,
     Json(rp_requests): Json<Vec<BillableRpRequest>>,
 ) -> impl IntoResponse {
     // TODO get the epochs for the RpVote from the contract

--- a/services/oprf-accountant/src/api.rs
+++ b/services/oprf-accountant/src/api.rs
@@ -11,15 +11,9 @@ use world_id_primitives::{oprf::NullifierOprfRequestAuthV1, rp::RpId};
 
 use crate::{AppState, postgres::PostgresDb};
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
 pub struct PostRequestQuery {
     pub id: Uuid,
-}
-
-impl PostRequestQuery {
-    pub fn into_query_strings(self) -> (String, String) {
-        (String::from("id"), self.id.to_string())
-    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/services/oprf-node/src/accountant_batcher.rs
+++ b/services/oprf-node/src/accountant_batcher.rs
@@ -310,7 +310,7 @@ impl AccountantBatcher {
             let result = (|| async {
                 self.client
                     .post(self.accountant_endpoint.clone())
-                    .query(&[query.clone().into_query_strings()])
+                    .query(&query)
                     .json(&batch)
                     .send()
                     .await?

--- a/services/oprf-node/src/accountant_batcher.rs
+++ b/services/oprf-node/src/accountant_batcher.rs
@@ -9,12 +9,13 @@
 use std::{num::NonZeroUsize, time::Duration};
 
 use backon::{ExponentialBuilder, Retryable};
-use oprf_accountant::api::BillableRpRequest;
+use oprf_accountant::api::{BillableRpRequest, PostRequestQuery};
 use reqwest::{StatusCode, Url};
 use serde::Deserialize;
 use tokio::sync::mpsc::{self, error::TrySendError};
 use tokio_util::sync::CancellationToken;
 use tracing::instrument;
+use uuid::Uuid;
 
 use crate::metrics;
 
@@ -224,8 +225,6 @@ impl AccountantBatcher {
             // set missed tick behavior to delay - in case we block during sending flush and we miss a tick, we want to send exactly one flush task and continue sleeping from that period again
             interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
             async move {
-                // first tick resolves immediately
-                interval.tick().await;
                 loop {
                     interval.tick().await;
                     tracing::trace!("sending account batch flush..");
@@ -268,12 +267,15 @@ impl AccountantBatcher {
         while let Some(job) = self.rx.recv().await {
             match job {
                 AccountantBatcherJob::Put(request) => self.put(request).await,
-                AccountantBatcherJob::Flush => self.flush().await,
+                AccountantBatcherJob::Flush => self.flush(Uuid::new_v4()).await,
                 AccountantBatcherJob::Close => {
                     self.close().await;
                     return;
                 }
             }
+            let channel_size = self.rx.len();
+            metrics::accountant_batcher::set_job_queue(channel_size);
+            tracing::trace!("still have {channel_size} jobs in channel");
         }
         tracing::error!("all handles dropped but there should be the flush task?");
     }
@@ -289,24 +291,26 @@ impl AccountantBatcher {
             self.buffer.len()
         );
         if self.buffer.len() >= self.buffer_size {
-            self.flush().await;
+            self.flush(Uuid::new_v4()).await;
         }
     }
 
     /// Flushes the buffer if buffer is not empty.
     ///
     /// Empties the buffer and attempts to send it to the endpoint.
-    #[instrument(level = "info", skip_all, name = "accountant_batcher::flush")]
-    async fn flush(&mut self) {
+    #[instrument(level = "info", skip_all, name = "accountant_batcher::flush", fields(%flush_id))]
+    async fn flush(&mut self, flush_id: Uuid) {
         tracing::trace!("attempting to flush the buffer");
         let batch = std::mem::replace(&mut self.buffer, Vec::with_capacity(self.buffer_size));
         if batch.is_empty() {
             tracing::trace!("buffer empty - no flush");
         } else {
             tracing::trace!("attempting to flush buffer with size {}", batch.len());
+            let query = PostRequestQuery { id: flush_id };
             let result = (|| async {
                 self.client
                     .post(self.accountant_endpoint.clone())
+                    .query(&[query.clone().into_query_strings()])
                     .json(&batch)
                     .send()
                     .await?
@@ -346,7 +350,7 @@ impl AccountantBatcher {
         {
             tracing::warn!(?err, "Got error during close from flush task");
         }
-        self.flush().await;
+        self.flush(Uuid::new_v4()).await;
     }
 }
 

--- a/services/oprf-node/src/metrics.rs
+++ b/services/oprf-node/src/metrics.rs
@@ -35,7 +35,7 @@ pub(crate) mod accountant_batcher {
         metrics::describe_gauge!(
             METRICS_ID_ACCOUNTANT_BATCHER_JOB_QUEUE,
             metrics::Unit::Count,
-            "Gauge for the job queue/channel size of the batcher. If this starts to to increase we have a back pressure problem"
+            "Gauge for the job queue/channel size of the batcher. If this starts to increase we have a back pressure problem"
         );
     }
 

--- a/services/oprf-node/src/metrics.rs
+++ b/services/oprf-node/src/metrics.rs
@@ -23,16 +23,28 @@ pub(crate) mod accountant_batcher {
     const METRICS_ID_ACCOUNTANT_BATCHER_DROPPED_REQUESTS: &str =
         "taceo.oprf.node.batcher.requests.dropped.full";
 
+    const METRICS_ID_ACCOUNTANT_BATCHER_JOB_QUEUE: &str = "taceo.oprf.node.batcher.job.queue";
+
     pub(super) fn describe_metrics() {
         metrics::describe_counter!(
             METRICS_ID_ACCOUNTANT_BATCHER_DROPPED_REQUESTS,
             metrics::Unit::Count,
             "Number of requests that were dropped because the channel is full."
         );
+
+        metrics::describe_gauge!(
+            METRICS_ID_ACCOUNTANT_BATCHER_JOB_QUEUE,
+            metrics::Unit::Count,
+            "Gauge for the job queue/channel size of the batcher. If this starts to to increase we have a back pressure problem"
+        );
     }
 
     pub(crate) fn inc_request_dropped_full() {
         metrics::counter!(METRICS_ID_ACCOUNTANT_BATCHER_DROPPED_REQUESTS).increment(1);
+    }
+
+    pub(crate) fn set_job_queue(val: usize) {
+        metrics::gauge!(METRICS_ID_ACCOUNTANT_BATCHER_JOB_QUEUE).set(val as f64);
     }
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the accountant ingest API contract (required `id` query param) and billing payload shape; failed batches still drop on retry exhaustion, now with new flush IDs per attempt on capacity/close flushes.
> 
> **Overview**
> The OPRF node’s accountant batcher now tags each flush to the accountant with a new **`id` query parameter** (`PostRequestQuery`), exposes that ID on the **`accountant_batcher::flush`** trace span, and records a **job-queue depth gauge** after each worker job so backpressure is visible in metrics. The periodic flush timer no longer fires an immediate first tick on startup.
> 
> The accountant **`POST /req`** handler requires that query `id` (not persisted yet; TODO to wire into tracing). **`BillableRpRequest`** also carries optional **`wip101_data`** from nullifier auth, serialized for the batch JSON body.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 457014de1b33a40fdef7b7abbded9b0693e3e9b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->