### PR TITLE
feat: continue implementing oprf-accountant v2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -557,7 +557,7 @@ checksum = "f36834a5c0a2fa56e171bf256c34d70fca07d0c0031583edea1c4946b7889c9e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -790,7 +790,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -808,7 +808,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sha3",
- "syn 2.0.116",
+ "syn 2.0.118",
  "syn-solidity",
 ]
 
@@ -826,7 +826,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.116",
+ "syn 2.0.118",
  "syn-solidity",
 ]
 
@@ -956,7 +956,7 @@ dependencies = [
  "darling 0.23.0",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1145,7 +1145,7 @@ checksum = "e7e89fe77d1f0f4fe5b96dfc940923d88d17b6a773808124f21e764dfb063c6a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1275,7 +1275,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
 dependencies = [
  "quote",
- "syn 2.0.116",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1313,7 +1313,7 @@ dependencies = [
  "num-traits",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1486,7 +1486,7 @@ checksum = "213888f660fddcca0d257e88e54ac05bca01885f258ccdf695bafd77031bb69d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1607,7 +1607,7 @@ dependencies = [
  "rustc-hash",
  "serde",
  "serde_derive",
- "syn 2.0.116",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1624,7 +1624,7 @@ dependencies = [
  "rustc-hash",
  "serde",
  "serde_derive",
- "syn 2.0.116",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1717,7 +1717,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1728,7 +1728,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1784,7 +1784,7 @@ checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2262,7 +2262,35 @@ checksum = "604fde5e028fea851ce1d8570bbdc034bec850d157f7569d10f347d06808c05c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "axum-test"
+version = "20.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a86bfe2ef15bee102ac34912f7f4542b0bb37dc464fa55461763999c4d625e7"
+dependencies = [
+ "anyhow",
+ "axum",
+ "bytes",
+ "bytesize",
+ "cookie",
+ "expect-json",
+ "http 1.4.0",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "mime",
+ "pretty_assertions",
+ "reserve-port",
+ "rust-multipart-rfc7578_2",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
+ "tower",
+ "url",
 ]
 
 [[package]]
@@ -2636,7 +2664,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.116",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2659,7 +2687,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2724,6 +2752,12 @@ dependencies = [
  "bytes",
  "either",
 ]
+
+[[package]]
+name = "bytesize"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7c8918969267b2932ffd5655509bbbea0833823058c378876953217f5fc50e"
 
 [[package]]
 name = "c-kzg"
@@ -2832,13 +2866,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.0",
+]
+
+[[package]]
 name = "chacha20poly1305"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
 dependencies = [
  "aead",
- "chacha20",
+ "chacha20 0.9.1",
  "cipher",
  "poly1305",
  "zeroize",
@@ -2846,9 +2891,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.43"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -2949,7 +2994,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3053,7 +3098,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3185,6 +3230,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
 dependencies = [
  "unicode-segmentation",
+]
+
+[[package]]
+name = "cookie"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
+dependencies = [
+ "time",
+ "version_check",
 ]
 
 [[package]]
@@ -3437,7 +3492,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3452,7 +3507,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn 2.0.116",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3486,7 +3541,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.116",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3500,7 +3555,7 @@ dependencies = [
  "quote",
  "serde",
  "strsim",
- "syn 2.0.116",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3511,7 +3566,7 @@ checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core 0.21.3",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3522,7 +3577,7 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core 0.23.0",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3553,7 +3608,7 @@ checksum = "780eb241654bf097afb00fc5f054a09b687dad862e485fdcf8399bb056565370"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3607,7 +3662,7 @@ checksum = "ef941ded77d15ca19b40374869ac6000af1c9f2a4c0f3d4c70926287e6364a8f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3629,9 +3684,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version 0.4.1",
- "syn 2.0.116",
+ "syn 2.0.118",
  "unicode-xid",
 ]
+
+[[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "digest"
@@ -3715,7 +3776,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3811,7 +3872,7 @@ dependencies = [
  "enum-ordinalize",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3843,6 +3904,15 @@ dependencies = [
  "serdect 0.2.0",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "email_address"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -3899,7 +3969,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3919,7 +3989,7 @@ checksum = "8ca9601fb2d62598ee17836250842873a413586e5d7ed88b356e38ddbb0ec631"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3931,7 +4001,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3958,7 +4028,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4001,6 +4071,35 @@ checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
  "event-listener",
  "pin-project-lite",
+]
+
+[[package]]
+name = "expect-json"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "869f97f4abe8e78fc812a94ad6b721d72c4fb5532877c79610f2c238d7ccf6c4"
+dependencies = [
+ "chrono",
+ "email_address",
+ "expect-json-macros",
+ "num",
+ "regex",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "typetag",
+ "uuid",
+]
+
+[[package]]
+name = "expect-json-macros"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0637949cd816934f3b7aab44ff98e7ec1fb903c379e07dcb9eac943ec33499e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4239,7 +4338,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4373,6 +4472,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
+ "rand_core 0.10.0",
  "wasip2",
  "wasip3",
 ]
@@ -4410,7 +4510,7 @@ checksum = "53010ccb100b96a67bc32c0175f0ed1426b31b655d562898e57325f81c023ac0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4620,7 +4720,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5130,7 +5230,7 @@ checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5278,7 +5378,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5370,7 +5470,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn 2.0.116",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5474,7 +5574,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5728,7 +5828,7 @@ checksum = "1b27834086c65ec3f9387b096d66e99f221cf081c2b738042aa252bcd41204e3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5910,7 +6010,7 @@ checksum = "82a2620949467f1c0f7c468958fea01ee6b5d7aff67c42b35ca589e430881482"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6165,7 +6265,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6581,7 +6681,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6635,7 +6735,7 @@ dependencies = [
  "regex",
  "regex-syntax",
  "structmeta",
- "syn 2.0.116",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6731,7 +6831,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6807,7 +6907,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6836,7 +6936,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6988,13 +7088,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "pretty_assertions"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
+dependencies = [
+ "diff",
+ "yansi",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.116",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -7060,7 +7170,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -7117,7 +7227,7 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -7127,7 +7237,7 @@ dependencies = [
  "prost 0.13.5",
  "prost-types 0.13.5",
  "regex",
- "syn 2.0.116",
+ "syn 2.0.118",
  "tempfile",
 ]
 
@@ -7141,7 +7251,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -7154,7 +7264,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -7831,14 +7941,14 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -7886,6 +7996,17 @@ dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
  "serde",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20 0.10.1",
+ "getrandom 0.4.1",
+ "rand_core 0.10.0",
 ]
 
 [[package]]
@@ -8094,7 +8215,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -8210,6 +8331,15 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+]
+
+[[package]]
+name = "reserve-port"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71ea98a177596a4579881992bd2bd4af27772fc95d0e5f5668a8f9535eca6380"
+dependencies = [
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -8654,7 +8784,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rust-embed-utils",
- "syn 2.0.116",
+ "syn 2.0.118",
  "walkdir",
 ]
 
@@ -8676,6 +8806,21 @@ checksum = "796e8d2b6696392a43bea58116b667fb4c29727dc5abd27d6acf338bb4f688c7"
 dependencies = [
  "cfg-if",
  "ordered-multimap",
+]
+
+[[package]]
+name = "rust-multipart-rfc7578_2"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00bdaa068902270ca7fa8619775e1838e23a63620abac0947ce0f715819b8cec"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http 1.4.0",
+ "mime",
+ "rand 0.10.2",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -8727,7 +8872,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8807,7 +8952,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 1.0.6",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8979,7 +9124,7 @@ checksum = "1783eabc414609e28a5ba76aee5ddd52199f7107a0b24c2e9746a1ecc34a683d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -9217,7 +9362,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -9252,7 +9397,7 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -9313,7 +9458,7 @@ dependencies = [
  "darling 0.21.3",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -9358,7 +9503,7 @@ checksum = "94e153fc76e1c6a068703d6d29c508a0b15c061c4b7e43da59cc097bc342673c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -9694,7 +9839,7 @@ dependencies = [
  "quote",
  "sqlx-core",
  "sqlx-macros-core",
- "syn 2.0.116",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -9717,7 +9862,7 @@ dependencies = [
  "sqlx-mysql",
  "sqlx-postgres",
  "sqlx-sqlite",
- "syn 2.0.116",
+ "syn 2.0.118",
  "tokio",
  "url",
 ]
@@ -9834,7 +9979,7 @@ dependencies = [
  "aes",
  "aes-gcm",
  "cbc",
- "chacha20",
+ "chacha20 0.9.1",
  "cipher",
  "ctr",
  "poly1305",
@@ -9898,7 +10043,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "structmeta-derive",
- "syn 2.0.116",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -9909,7 +10054,7 @@ checksum = "152a0b65a590ff6c3da95cabe2353ee04e6167c896b28e3b14478c2636c922fc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -9949,7 +10094,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -9971,9 +10116,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.116"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3df424c70518695237746f84cede799c9c58fcb37450d7b23716568cc8bc69cb"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9989,7 +10134,7 @@ dependencies = [
  "paste",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -10009,7 +10154,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -10157,13 +10302,17 @@ checksum = "15af1a54071def0649b8e55c8d87afff9cd537565345e939264313aeb7031fc1"
 dependencies = [
  "alloy",
  "axum",
+ "axum-test",
  "backon",
+ "eyre",
  "futures",
  "git-version",
  "humantime-serde",
+ "reserve-port",
  "secrecy",
  "serde",
  "sqlx",
+ "testcontainers-modules",
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
@@ -10454,7 +10603,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -10615,7 +10764,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -10626,7 +10775,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -10750,14 +10899,14 @@ checksum = "2d2e76690929402faae40aebdda620a2c0e25dd6d3b9afe48867dfd95991f4bd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "tokio"
-version = "1.49.0"
+version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
  "bytes",
  "libc",
@@ -10778,7 +10927,7 @@ checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -11090,7 +11239,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -11251,6 +11400,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
+name = "typetag"
+version = "0.2.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5a897b12c6c1151ad0b138b8db50252dc301f93bc3b027db05eec82aeed298c"
+dependencies = [
+ "erased-serde",
+ "inventory",
+ "once_cell",
+ "serde",
+ "typetag-impl",
+]
+
+[[package]]
+name = "typetag-impl"
+version = "0.2.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf808357c6ed7e13ba0f3277ec8d8f21b2d501274895104263985330c726c1c5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "ucd-trie"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11389,7 +11562,7 @@ dependencies = [
  "indexmap 2.13.0",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -11404,7 +11577,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.116",
+ "syn 2.0.118",
  "toml 0.9.12+spec-1.1.0",
  "uniffi_meta",
 ]
@@ -11552,7 +11725,7 @@ checksum = "6d79d08d92ab8af4c5e8a6da20c47ae3f61a0f1dabc1997cdf2d082b757ca08b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -11712,7 +11885,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.118",
  "wasm-bindgen-shared",
 ]
 
@@ -11876,7 +12049,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -11947,7 +12120,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -11958,7 +12131,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -12340,7 +12513,7 @@ dependencies = [
  "heck 0.5.0",
  "indexmap 2.13.0",
  "prettyplease",
- "syn 2.0.116",
+ "syn 2.0.118",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -12356,7 +12529,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.118",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -12589,16 +12762,18 @@ dependencies = [
 name = "world-id-oprf-accountant"
 version = "0.1.0"
 dependencies = [
- "alloy-primitives",
+ "alloy",
  "ark-serialize 0.5.0",
  "axum",
  "backon",
  "config",
  "eyre",
+ "futures-util",
  "humantime-serde",
  "itertools 0.14.0",
  "metrics",
  "rustls",
+ "secrecy",
  "serde",
  "serde_json",
  "sqlx",
@@ -12609,6 +12784,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tikv-jemallocator",
  "tokio",
+ "tokio-util",
  "tracing",
  "uuid",
  "world-id-primitives",
@@ -12947,6 +13123,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
+
+[[package]]
 name = "yoke"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12965,7 +13147,7 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.118",
  "synstructure",
 ]
 
@@ -12986,7 +13168,7 @@ checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -13006,7 +13188,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.118",
  "synstructure",
 ]
 
@@ -13027,7 +13209,7 @@ checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -13060,7 +13242,7 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.118",
 ]
 
 [[package]]

--- a/services/oprf-accountant/Cargo.toml
+++ b/services/oprf-accountant/Cargo.toml
@@ -8,7 +8,7 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
-alloy-primitives.workspace = true
+alloy = { workspace = true, features = ["full", "rpc", "rpc-client-ws"] }
 ark-babyjubjub = { workspace = true }
 ark-serde-compat = { workspace = true }
 ark-serialize = { workspace = true }
@@ -16,14 +16,16 @@ axum = { workspace = true, features = ["json", "macros"] }
 backon = { workspace = true, features = ["std", "tokio-sleep"] }
 config.workspace = true
 eyre = { workspace = true }
+futures-util = { workspace = true }
 humantime-serde = { workspace = true }
 itertools.workspace = true
 metrics = { workspace = true }
 rustls = { workspace = true }
+secrecy = { workspace = true, features = ["serde"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 sqlx = { workspace = true, features = ["postgres", "runtime-tokio-rustls"] }
-taceo-nodes-common = { workspace = true, features = ["api", "postgres"] }
+taceo-nodes-common = { workspace = true, features = ["api", "postgres", "web3"] }
 telemetry-batteries = { workspace = true }
 thiserror.workspace = true
 tokio = { workspace = true, features = [
@@ -34,9 +36,16 @@ tokio = { workspace = true, features = [
   "time",
   "tokio-macros",
 ] }
+tokio-util = { workspace = true }
 tracing = { workspace = true, features = ["release_max_level_debug"] }
 uuid.workspace = true
 world-id-primitives = { workspace = true }
+
+[dev-dependencies]
+taceo-nodes-common = { workspace = true, features = [
+  "postgres",
+  "test-utils",
+] }
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 tikv-jemallocator = { workspace = true }

--- a/services/oprf-accountant/migrations/20260703123015_init_db.up.sql
+++ b/services/oprf-accountant/migrations/20260703123015_init_db.up.sql
@@ -1,19 +1,20 @@
 -- Stores RP (relying party) signatures over proof requests so they can be verified later.
-create table if not exists rp_signatures (
+CREATE TABLE IF NOT EXISTS rp_signatures (
     id BIGINT GENERATED ALWAYS AS identity PRIMARY KEY,
     rp_id BIGINT NOT NULL,
-    epoch BIGINT NOT NULL,
     -- version is currently always 1
     version SMALLINT NOT NULL DEFAULT 1,
     nonce BYTEA NOT NULL,
     -- Signed validity window (u64 unix seconds stored as bigint)
-    signed_created_at BIGINT NOT NULL,
-    signed_expires_at BIGINT NOT NULL,
+    created_at BIGINT NOT NULL,
+    expires_at BIGINT NOT NULL,
+    -- The request's action field; part of the signed message for Uniqueness Proof requests.
+    action BYTEA NOT NULL,
     -- RP ECDSA (secp256k1) signature over the message (alloy Signature, 65 bytes)
-    signature BYTEA NOT NULL,
+    signature BYTEA,
+    -- Auxiliary data passed to a WIP101 signer contract's `verifyRpRequest`; only present
+    -- (and only meaningful) when `signature` is NULL, i.e. the RP is WIP101-backed.
+    wip101_data BYTEA,
     -- Record insertion timestamp (bookkeeping)
-    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-
-    -- A given nonce should be signed at most once per RP (replay protection)
-    constraint uq_rp_signatures_rp_id_nonce unique (rp_id, nonce, epoch)
+    recorded_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );

--- a/services/oprf-accountant/src/accountant_service.rs
+++ b/services/oprf-accountant/src/accountant_service.rs
@@ -1,0 +1,581 @@
+//! Aggregates recorded RP (relying party) OPRF request counts per epoch and submits them as
+//! billing votes to the `BillingContract`.
+//!
+//! [`OprfAccountantService::run`] drives this in a loop: each [`OprfAccountantService::tick`]
+//! asks the `BillingContract` for the latest epoch whose own span has fully elapsed, together
+//! with its span and voting-window close, via a single `currentVoteEpoch()` call — the contract
+//! is the one source of truth for era/epoch timing, so this service does no era bookkeeping of
+//! its own. It then
+//! sleeps until the voting window opens (plus a configured offset, giving OPRF nodes time to
+//! flush their batched requests), aggregates that epoch's recorded requests — those whose
+//! `expires_at` falls within the epoch's own span — by RP id (via
+//! [`PostgresDb::rp_counts_for_epoch_span`]), and submits the resulting counts as this node's
+//! vote. Whether this node already voted for an epoch is read straight from the
+//! `BillingContract` (bundled into the `currentVoteEpoch()` call), so a restart re-derives
+//! progress from chain state.
+
+use std::{
+    num::NonZeroUsize,
+    time::{Duration, SystemTime},
+};
+
+use alloy::{
+    primitives::Address,
+    providers::DynProvider,
+    signers::{Signer as _, local::PrivateKeySigner},
+    sol,
+    sol_types::{Eip712Domain, SolStruct as _, eip712_domain},
+};
+use eyre::Context;
+use taceo_nodes_common::web3::HttpRpcProvider;
+use tokio_util::sync::CancellationToken;
+use tracing::instrument;
+
+use crate::{accountant_service::IBillingContract::IBillingContractInstance, postgres::PostgresDb};
+
+// TODO replace with abi
+sol! {
+    /// @notice A single (rpId, count) entry inside a node's billing vote.
+    #[derive(Debug, PartialEq, Eq)]
+    struct RpCount {
+        // the Relying Party the count is reported for.
+        uint64 rpId;
+        // the number of unique requests the node observed for the RP in the epoch.
+        uint64 count;
+    }
+
+    /// @notice One chunk of an OPRF node's signed billing vote for a single epoch.
+    /// @dev The signed payload is the EIP-712
+    ///      `BillingVoteChunk(uint32 epoch,uint32 chunkIndex,bool isFinal,RpCount[] counts)` struct,
+    ///      where `epoch` is supplied as the call argument shared by every chunk in the batch.
+    #[derive(Debug, PartialEq, Eq)]
+    struct SignedVoteChunk {
+        // the zero-based chunk index for this node and epoch. Chunks must be submitted in order.
+        uint32 chunkIndex;
+        // true on the final chunk; the node counts as a voter only after this chunk is accepted.
+        bool isFinal;
+        // the per-RP counts reported by the node, strictly ascending globally across chunks,
+        // all counts non-zero.
+        RpCount[] counts;
+        // the node's EIP-712 signature over the chunk. The signer is recovered, not trusted from
+        // msg.sender, so any party may relay the chunks.
+        bytes signature;
+    }
+
+    #[sol(rpc)]
+    interface IBillingContract {
+        // The latest epoch whose own span has fully elapsed, if any, together with that span
+        // (`[start, end)`), the timestamp its voting window closes at, and whether `signer`
+        // already voted for it. `exists` is false only before the very first epoch has elapsed
+        // (protocol genesis, i.e. epoch 0 is still in progress), in which case the other fields
+        // are meaningless.
+        //
+        // Not yet implemented on `BillingContract` (pending PR); mirrors `_latestClosedEpoch`'s
+        // era walk, but keys off `era.startTime` (an epoch's own span start) instead of the
+        // voting-window close, then simply calls `epochEnd`/`votingWindowEnd` for the epoch
+        // found. Bundles in the `hasVoted` check for `signer` so callers don't need a second
+        // contract call to find out whether they still need to vote:
+        //
+        //   function currentVoteEpoch(address signer)
+        //       external view virtual onlyProxy onlyInitialized
+        //       returns (
+        //           bool exists,
+        //           uint32 epoch,
+        //           uint64 start,
+        //           uint64 end,
+        //           uint64 votingWindowEnd,
+        //           bool alreadyVoted
+        //       )
+        //   {
+        //       uint256 i = _timingEras.length;
+        //       while (i > 0) {
+        //           unchecked { i--; }
+        //           TimingEra storage era = _timingEras[i];
+        //           if (block.timestamp < era.startTime) continue; // this era hasn't started yet
+        //
+        //           uint256 k = (block.timestamp - era.startTime) / era.epochLength;
+        //           uint256 e = uint256(era.startEpoch) + k; // the in-progress epoch
+        //
+        //           if (i + 1 < _timingEras.length) {
+        //               uint256 regimeLastEpoch = _timingEras[i + 1].startEpoch - 1;
+        //               if (e > regimeLastEpoch) e = regimeLastEpoch; // clamp into this era's own regime
+        //           }
+        //
+        //           if (e == 0) return (false, 0, 0, 0, 0, false); // epoch 0 still in progress: nothing elapsed yet
+        //           if (e - 1 > type(uint32).max) revert EpochTooLarge();
+        //           epoch = uint32(e - 1); // the latest fully-elapsed epoch
+        //           start = epoch >= 1 ? epochEnd(epoch - 1) : 0;
+        //           end = epochEnd(epoch);
+        //           votingWindowEnd = votingWindowEnd(epoch);
+        //           alreadyVoted = _submitterState[epoch][signer].hasVoted;
+        //           return (true, epoch, start, end, votingWindowEnd, alreadyVoted);
+        //       }
+        //       return (false, 0, 0, 0, 0, false); // fresh deployment: epoch 0 still in progress
+        //   }
+        function currentVoteEpoch(address signer)
+            external
+            view
+            returns (
+                bool exists,
+                uint32 epoch,
+                uint64 start,
+                uint64 end,
+                uint64 votingWindowEnd,
+                bool alreadyVoted
+            );
+
+        // The timestamp at which epoch `epoch` ends (and its voting window opens). Defined for
+        // every epoch, past or future; already implemented on `BillingContract`. Used to know
+        // exactly when to check back for the next vote-able epoch, instead of polling blindly.
+        function epochEnd(uint32 epoch) external view returns (uint64);
+
+         // Submit one or more OPRF node billing vote chunks for a single epoch.
+         //
+         // Records votes only; does not finalize as a side effect (finalization is driven solely by
+         // {finalizeEpochs}), so a node's vote gas never carries another epoch's finalization cost.
+         // Quorum and pricing are read live at finalization (no per-epoch snapshot). Authenticates
+         // by recovered signer, not msg.sender. A node's chunks must be submitted in order and the
+         // node counts toward quorum only after its final chunk is accepted.
+        function submitBillingVotes(uint32 epoch, SignedVoteChunk[] calldata chunks) external;
+    }
+}
+
+sol! {
+    /// EIP-712 typed-data payload for a single [`SignedVoteChunk`] (without its `signature`
+    /// field, which is what's being computed). Used only for signature hashing/recovery, not
+    /// as a Solidity call type.
+    struct BillingVoteChunk {
+        uint32 epoch;
+        uint32 chunkIndex;
+        bool isFinal;
+        RpCount[] counts;
+    }
+}
+
+/// Aggregates recorded RP request counts per epoch and submits them as billing votes.
+///
+/// Constructed via [`OprfAccountantService::new`]; driven by repeatedly calling
+/// [`OprfAccountantService::tick`] (typically via [`OprfAccountantService::run`]).
+#[derive(Clone)]
+pub(crate) struct OprfAccountantService {
+    contract: IBillingContractInstance<DynProvider>,
+    billing_contract: Address,
+    chain_id: u64,
+    signer: PrivateKeySigner,
+    db: PostgresDb,
+    voting_window_offset: Duration,
+    billing_vote_chunk_size: NonZeroUsize,
+    cancellation_token: CancellationToken,
+}
+
+/// Construction parameters for [`OprfAccountantService::new`].
+pub(crate) struct OprfAccountantServiceArgs {
+    /// Provider used to call and sign transactions against the `BillingContract`.
+    pub(crate) provider: HttpRpcProvider,
+    /// Chain id `provider` is connected to.
+    pub(crate) chain_id: u64,
+    /// Address of the `BillingContract`.
+    pub(crate) billing_contract: Address,
+    /// Signer this node uses to sign its billing votes.
+    pub(crate) signer: PrivateKeySigner,
+    /// Database storing recorded RP requests.
+    pub(crate) db: PostgresDb,
+    /// Extra delay after an epoch's voting window opens before we aggregate and vote for it,
+    /// giving OPRF nodes time to flush their batched requests to us. Should be kept well below
+    /// the current era's `votingWindow`: [`OprfAccountantService::tick`] only has whatever time
+    /// remains until `votingWindowEnd` to submit the vote once it wakes up, so too large an
+    /// offset leaves no time to vote and the epoch's `submitBillingVotes` call times out.
+    pub(crate) voting_window_offset: Duration,
+    /// The maximum number of `RpCount`s per `SignedVoteChunk` submitted to `submitBillingVotes`.
+    pub(crate) billing_vote_chunk_size: NonZeroUsize,
+    /// Signals [`OprfAccountantService::run`] to stop.
+    pub(crate) cancellation_token: CancellationToken,
+}
+
+impl OprfAccountantService {
+    /// Constructs the service, building the `BillingContract` binding from `provider` and
+    /// `billing_contract`.
+    pub(crate) fn new(
+        OprfAccountantServiceArgs {
+            provider,
+            chain_id,
+            billing_contract,
+            signer,
+            db,
+            voting_window_offset,
+            billing_vote_chunk_size,
+            cancellation_token,
+        }: OprfAccountantServiceArgs,
+    ) -> Self {
+        let contract = IBillingContract::new(billing_contract, provider.inner());
+        Self {
+            contract,
+            billing_contract,
+            chain_id,
+            signer,
+            db,
+            voting_window_offset,
+            billing_vote_chunk_size,
+            cancellation_token,
+        }
+    }
+
+    /// Runs the service until `cancellation_token` is cancelled, immediately starting the next
+    /// [`Self::tick`] as soon as the previous one returns.
+    ///
+    /// A tick that returns an error is logged and retried on the next tick rather than stopping
+    /// the loop, since a transient failure (e.g. a dropped DB connection) shouldn't prevent
+    /// later epochs from being voted on.
+    pub(crate) async fn run(&self) {
+        tracing::info!("starting OprfAccountant worker");
+
+        loop {
+            tokio::select! {
+                res = self.tick() => {
+                    if let Err(err) = res {
+                        tracing::error!(error = ?err, "accountant tick failed; retrying next tick");
+                    }
+                }
+                _ = self.cancellation_token.cancelled() => {
+                    tracing::info!("shutdown signal received, stopping account worker");
+                    break;
+                }
+            }
+        }
+    }
+
+    /// Submits `counts` as this node's billing vote for `epoch`. Still submits a single chunk
+    /// with an empty `counts` when `counts` is itself empty — whether this node already voted
+    /// for `epoch` is tracked by the contract only via a submitted vote, so a real (if empty)
+    /// vote is required for `tick` to see this epoch as done and not retry it forever.
+    ///
+    /// Splits `counts` into `billing_vote_chunk_size`-sized [`SignedVoteChunk`]s (see
+    /// [`build_signed_vote_chunks`]), then submits each chunk for `epoch` in its own
+    /// `submitBillingVotes` call.
+    ///
+    /// # Errors
+    /// Returns an error if signing a chunk fails, if a `submitBillingVotes` transaction fails to
+    /// send or confirm, or if a transaction reverts.
+    #[instrument(
+        level = "info",
+        skip_all,
+        fields(epoch),
+        name = "accountant_service::vote_for_epoch"
+    )]
+    async fn vote_for_epoch(&self, epoch: u32, counts: Vec<RpCount>) -> eyre::Result<()> {
+        let domain = billing_vote_domain(self.chain_id, self.billing_contract);
+
+        let signed_chunks = build_signed_vote_chunks(
+            &self.signer,
+            &domain,
+            epoch,
+            counts,
+            self.billing_vote_chunk_size,
+        )
+        .await?;
+
+        for signed_chunk in signed_chunks {
+            tracing::info!(epoch, ?signed_chunk, "submitting billing vote chunk");
+            // TODO we need to implement the signing with the OPRF nodes keys but sending with a different wallet.
+            // Otherwise the nonces of the KeyGen will be wrong if we use the same wallet.
+            // TODO retry on failure, timeout handled by caller
+            // let receipt = self
+            //     .contract
+            //     .submitBillingVotes(epoch, vec![signed_chunk])
+            //     .send()
+            //     .await
+            //     .context("while submitting billing votes")?
+            //     .get_receipt()
+            //     .await
+            //     .context("while waiting for the billing vote receipt")?;
+
+            // if !receipt.status() {
+            //     eyre::bail!("submitBillingVotes transaction reverted for epoch {epoch}");
+            // }
+        }
+
+        Ok(())
+    }
+
+    #[instrument(level = "info", skip_all, name = "accountant_service::tick")]
+    pub(crate) async fn tick(&self) -> eyre::Result<()> {
+        let vote_epoch_info = self
+            .contract
+            .currentVoteEpoch(self.signer.address())
+            .call()
+            .await?;
+        if !vote_epoch_info.exists {
+            // Epoch 0 hasn't elapsed yet, nothing to vote for. Wait until it does, then
+            // start over so we re-read the current vote epoch from the contract.
+            let epoch_0_end = self.contract.epochEnd(0).call().await?;
+            tracing::info!("no epochs have elapsed yet, waiting for epoch 0 to elapse");
+            // We add a 10 second buffer to the sleep time to ensure we land after the epoch has ended.
+            sleep_until(epoch_0_end + 10).await;
+            return Ok(());
+        }
+
+        let vote_epoch = vote_epoch_info.epoch;
+        let epoch_span = vote_epoch_info.start..vote_epoch_info.end;
+
+        if vote_epoch_info.alreadyVoted {
+            // Already voted for this epoch. Wait until the epoch currently in
+            // progress (`vote_epoch + 1`) also elapses (plus a buffer, to be safe against clock
+            // drift), then start over so we re-read the current vote epoch from the contract.
+            let next_epoch_end = self.contract.epochEnd(vote_epoch + 1).call().await?;
+            tracing::trace!(vote_epoch, "already voted; waiting for the next epoch");
+            sleep_until(next_epoch_end + 10).await;
+            return Ok(());
+        }
+
+        // Not yet voted: wait for the voting window (+ offset) to open, then vote.
+        sleep_until(epoch_span.end + self.voting_window_offset.as_secs()).await;
+
+        // Aggregate the recorded RP request counts for the epoch span.
+        let counts = self.db.rp_counts_for_epoch_span(&epoch_span).await?;
+        tracing::info!(?counts, "collected counts for epoch span");
+
+        // Max time we can spend voting for this epoch, from now until the voting window closes.
+        let remaining_voting_window = Duration::from_secs(
+            vote_epoch_info
+                .votingWindowEnd
+                .saturating_sub(now_unix_timestamp()),
+        );
+        tokio::time::timeout(
+            remaining_voting_window,
+            self.vote_for_epoch(vote_epoch, counts),
+        )
+        .await??;
+        tracing::info!(vote_epoch, "successfully voted for epoch");
+
+        Ok(())
+    }
+}
+
+/// Returns the current unix timestamp in seconds.
+fn now_unix_timestamp() -> u64 {
+    SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("system clock after unix epoch")
+        .as_secs()
+}
+
+/// Sleeps until `target` (a unix timestamp in seconds), or returns immediately if it's already
+/// in the past.
+async fn sleep_until(target: u64) {
+    let sleep_duration = Duration::from_secs(target.saturating_sub(now_unix_timestamp()));
+    tracing::info!(?sleep_duration, target, "sleeping until target timestamp");
+    tokio::time::sleep(sleep_duration).await;
+}
+
+/// The EIP-712 domain of the `BillingContract` at `verifying_contract` on `chain_id`, matching
+/// its `EIP712_NAME`/`EIP712_VERSION` constants.
+fn billing_vote_domain(chain_id: u64, verifying_contract: Address) -> Eip712Domain {
+    eip712_domain!(
+        name: "BillingContract",
+        version: "1.0",
+        chain_id: chain_id,
+        verifying_contract: verifying_contract,
+    )
+}
+
+/// Splits `counts` into `chunk_size`-sized pieces and signs each as an EIP-712 `BillingVoteChunk`
+/// for `epoch` with `signer`, returning the resulting [`SignedVoteChunk`]s in ascending
+/// `chunkIndex` order. `isFinal` is set only on the last chunk. If `counts` is empty, returns a
+/// single chunk with `isFinal = true` and an empty `counts` — the node must still record a vote
+/// for `epoch` even when it observed nothing, since `hasVoted` is only set by a submitted vote.
+///
+/// # Errors
+/// Returns an error if `counts` needs more than [`u32::MAX`] chunks, or if signing a chunk fails.
+async fn build_signed_vote_chunks(
+    signer: &PrivateKeySigner,
+    domain: &Eip712Domain,
+    epoch: u32,
+    counts: Vec<RpCount>,
+    chunk_size: NonZeroUsize,
+) -> eyre::Result<Vec<SignedVoteChunk>> {
+    let chunk_total = counts.len().div_ceil(chunk_size.into()).max(1);
+    let mut signed_chunks = Vec::with_capacity(chunk_total);
+
+    let chunks = if counts.is_empty() {
+        vec![Vec::new()]
+    } else {
+        counts
+            .chunks(chunk_size.into())
+            .map(<[RpCount]>::to_vec)
+            .collect()
+    };
+
+    for (i, chunk) in chunks.into_iter().enumerate() {
+        let chunk_index = u32::try_from(i).context("too many billing vote chunks")?;
+        let is_final = i + 1 == chunk_total;
+
+        let typed_chunk = BillingVoteChunk {
+            epoch,
+            chunkIndex: chunk_index,
+            isFinal: is_final,
+            counts: chunk,
+        };
+        let digest = typed_chunk.eip712_signing_hash(domain);
+        let signature = signer
+            .sign_hash(&digest)
+            .await
+            .context("while signing billing vote chunk")?;
+
+        signed_chunks.push(SignedVoteChunk {
+            chunkIndex: chunk_index,
+            isFinal: is_final,
+            counts: typed_chunk.counts,
+            signature: signature.as_bytes().to_vec().into(),
+        });
+    }
+
+    Ok(signed_chunks)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::num::NonZeroUsize;
+
+    use alloy::{primitives::Address, signers::local::PrivateKeySigner, sol_types::SolStruct as _};
+
+    use super::{BillingVoteChunk, RpCount, billing_vote_domain, build_signed_vote_chunks};
+
+    fn rp_counts(n: u64) -> Vec<RpCount> {
+        (1..=n).map(|i| RpCount { rpId: i, count: i }).collect()
+    }
+
+    #[tokio::test]
+    async fn build_signed_vote_chunks_votes_with_a_single_empty_final_chunk_for_no_counts() {
+        let signer = PrivateKeySigner::random();
+        let domain = billing_vote_domain(31337, Address::ZERO);
+
+        let chunks = build_signed_vote_chunks(
+            &signer,
+            &domain,
+            0,
+            vec![],
+            NonZeroUsize::new(2).expect("non-zero"),
+        )
+        .await
+        .expect("builds chunks");
+
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].chunkIndex, 0);
+        assert!(chunks[0].isFinal);
+        assert!(chunks[0].counts.is_empty());
+    }
+
+    #[tokio::test]
+    async fn build_signed_vote_chunks_splits_evenly_divisible_counts() {
+        let signer = PrivateKeySigner::random();
+        let domain = billing_vote_domain(31337, Address::ZERO);
+
+        let chunks = build_signed_vote_chunks(
+            &signer,
+            &domain,
+            7,
+            rp_counts(4),
+            NonZeroUsize::new(2).expect("non-zero"),
+        )
+        .await
+        .expect("builds chunks");
+
+        assert_eq!(chunks.len(), 2);
+        assert_eq!(chunks[0].chunkIndex, 0);
+        assert!(!chunks[0].isFinal);
+        assert_eq!(
+            chunks[0].counts,
+            vec![RpCount { rpId: 1, count: 1 }, RpCount { rpId: 2, count: 2 }]
+        );
+        assert_eq!(chunks[1].chunkIndex, 1);
+        assert!(chunks[1].isFinal);
+        assert_eq!(
+            chunks[1].counts,
+            vec![RpCount { rpId: 3, count: 3 }, RpCount { rpId: 4, count: 4 }]
+        );
+    }
+
+    #[tokio::test]
+    async fn build_signed_vote_chunks_puts_the_remainder_in_the_last_chunk() {
+        let signer = PrivateKeySigner::random();
+        let domain = billing_vote_domain(31337, Address::ZERO);
+
+        // 5 counts over chunks of 2 -> [2, 2, 1], with only the last one final.
+        let chunks = build_signed_vote_chunks(
+            &signer,
+            &domain,
+            3,
+            rp_counts(5),
+            NonZeroUsize::new(2).expect("non-zero"),
+        )
+        .await
+        .expect("builds chunks");
+
+        assert_eq!(chunks.len(), 3);
+        let sizes: Vec<usize> = chunks.iter().map(|c| c.counts.len()).collect();
+        assert_eq!(sizes, vec![2, 2, 1]);
+
+        for (i, chunk) in chunks.iter().enumerate() {
+            assert_eq!(chunk.chunkIndex, u32::try_from(i).unwrap());
+            assert_eq!(chunk.isFinal, i == chunks.len() - 1);
+        }
+    }
+
+    #[tokio::test]
+    async fn build_signed_vote_chunks_single_chunk_when_smaller_than_chunk_size() {
+        let signer = PrivateKeySigner::random();
+        let domain = billing_vote_domain(31337, Address::ZERO);
+
+        let chunks = build_signed_vote_chunks(
+            &signer,
+            &domain,
+            3,
+            rp_counts(3),
+            NonZeroUsize::new(128).expect("non-zero"),
+        )
+        .await
+        .expect("builds chunks");
+
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].chunkIndex, 0);
+        assert!(chunks[0].isFinal);
+        assert_eq!(chunks[0].counts, rp_counts(3));
+    }
+
+    #[tokio::test]
+    async fn build_signed_vote_chunks_signatures_recover_to_the_signer() {
+        let signer = PrivateKeySigner::random();
+        let chain_id = 31337;
+        let verifying_contract = Address::repeat_byte(0x42);
+        let domain = billing_vote_domain(chain_id, verifying_contract);
+        let epoch = 9;
+
+        let chunks = build_signed_vote_chunks(
+            &signer,
+            &domain,
+            epoch,
+            rp_counts(5),
+            NonZeroUsize::new(2).expect("non-zero"),
+        )
+        .await
+        .expect("builds chunks");
+
+        for chunk in chunks {
+            let typed_chunk = BillingVoteChunk {
+                epoch,
+                chunkIndex: chunk.chunkIndex,
+                isFinal: chunk.isFinal,
+                counts: chunk.counts,
+            };
+            let digest = typed_chunk.eip712_signing_hash(&domain);
+
+            let signature = alloy::primitives::Signature::try_from(chunk.signature.as_ref())
+                .expect("valid signature bytes");
+            let recovered = signature
+                .recover_address_from_prehash(&digest)
+                .expect("signature recovers");
+
+            assert_eq!(recovered, signer.address());
+        }
+    }
+}

--- a/services/oprf-accountant/src/accountant_service.rs
+++ b/services/oprf-accountant/src/accountant_service.rs
@@ -14,10 +14,7 @@
 //! `BillingContract` (bundled into the `currentVoteEpoch()` call), so a restart re-derives
 //! progress from chain state.
 
-use std::{
-    num::NonZeroUsize,
-    time::{Duration, SystemTime},
-};
+use std::{num::NonZeroUsize, time::Duration};
 
 use alloy::{
     primitives::Address,
@@ -28,6 +25,7 @@ use alloy::{
 };
 use eyre::Context;
 use taceo_nodes_common::web3::HttpRpcProvider;
+use tokio::time::MissedTickBehavior;
 use tokio_util::sync::CancellationToken;
 use tracing::instrument;
 
@@ -65,28 +63,32 @@ sol! {
     #[sol(rpc)]
     interface IBillingContract {
         // The latest epoch whose own span has fully elapsed, if any, together with that span
-        // (`[start, end)`), the timestamp its voting window closes at, and whether `signer`
-        // already voted for it. `exists` is false only before the very first epoch has elapsed
-        // (protocol genesis, i.e. epoch 0 is still in progress), in which case the other fields
-        // are meaningless.
+        // (`[epochStart, epochEnd)`), the timestamp its voting window closes at, whether `signer` already
+        // voted for it, and the current block timestamp. `exists` is false only before the very
+        // first epoch has elapsed (protocol genesis, i.e. epoch 0 is still in progress), in which
+        // case the other fields are meaningless. `blockTime` is meaningful regardless of `exists`.
         //
         // Not yet implemented on `BillingContract` (pending PR); mirrors `_latestClosedEpoch`'s
         // era walk, but keys off `era.startTime` (an epoch's own span start) instead of the
         // voting-window close, then simply calls `epochEnd`/`votingWindowEnd` for the epoch
         // found. Bundles in the `hasVoted` check for `signer` so callers don't need a second
-        // contract call to find out whether they still need to vote:
+        // contract call to find out whether they still need to vote, and returns `block.timestamp`
+        // directly so callers don't need a separate call (e.g. `eth_getBlockByNumber`) to learn
+        // the chain's current time:
         //
         //   function currentVoteEpoch(address signer)
         //       external view virtual onlyProxy onlyInitialized
         //       returns (
         //           bool exists,
         //           uint32 epoch,
-        //           uint64 start,
-        //           uint64 end,
+        //           uint64 epochStart,
+        //           uint64 epochEnd,
         //           uint64 votingWindowEnd,
-        //           bool alreadyVoted
+        //           bool alreadyVoted,
+        //           uint64 blockTime
         //       )
         //   {
+        //       blockTime = uint64(block.timestamp);
         //       uint256 i = _timingEras.length;
         //       while (i > 0) {
         //           unchecked { i--; }
@@ -101,16 +103,16 @@ sol! {
         //               if (e > regimeLastEpoch) e = regimeLastEpoch; // clamp into this era's own regime
         //           }
         //
-        //           if (e == 0) return (false, 0, 0, 0, 0, false); // epoch 0 still in progress: nothing elapsed yet
+        //           if (e == 0) return (false, 0, 0, 0, 0, false, blockTime); // epoch 0 still in progress: nothing elapsed yet
         //           if (e - 1 > type(uint32).max) revert EpochTooLarge();
         //           epoch = uint32(e - 1); // the latest fully-elapsed epoch
-        //           start = epoch >= 1 ? epochEnd(epoch - 1) : 0;
-        //           end = epochEnd(epoch);
+        //           epochStart = epoch >= 1 ? epochEnd(epoch - 1) : _timingEras[0].startTime; // get epoch 0 start from _timingEras
+        //           epochEnd = this.epochEnd(epoch);
         //           votingWindowEnd = votingWindowEnd(epoch);
         //           alreadyVoted = _submitterState[epoch][signer].hasVoted;
-        //           return (true, epoch, start, end, votingWindowEnd, alreadyVoted);
+        //           return (true, epoch, epochStart, epochEnd, votingWindowEnd, alreadyVoted, blockTime);
         //       }
-        //       return (false, 0, 0, 0, 0, false); // fresh deployment: epoch 0 still in progress
+        //       return (false, 0, 0, 0, 0, false, blockTime); // fresh deployment: epoch 0 still in progress
         //   }
         function currentVoteEpoch(address signer)
             external
@@ -118,16 +120,12 @@ sol! {
             returns (
                 bool exists,
                 uint32 epoch,
-                uint64 start,
-                uint64 end,
+                uint64 epochStart,
+                uint64 epochEnd,
                 uint64 votingWindowEnd,
-                bool alreadyVoted
+                bool alreadyVoted,
+                uint64 blockTime
             );
-
-        // The timestamp at which epoch `epoch` ends (and its voting window opens). Defined for
-        // every epoch, past or future; already implemented on `BillingContract`. Used to know
-        // exactly when to check back for the next vote-able epoch, instead of polling blindly.
-        function epochEnd(uint32 epoch) external view returns (uint64);
 
          // Submit one or more OPRF node billing vote chunks for a single epoch.
          //
@@ -152,19 +150,49 @@ sol! {
     }
 }
 
+/// The outcome of [`OprfAccountantService::maybe_get_votes`] checking whether there's an epoch
+/// this node should vote for right now.
+#[derive(Debug, PartialEq, Eq)]
+enum MaybeVotes {
+    /// No epoch is currently vote-able: either epoch 0 hasn't elapsed yet, or the latest elapsed
+    /// epoch's voting window (plus [`OprfAccountantServiceArgs::voting_window_offset`]) hasn't
+    /// opened yet.
+    WindowNotOpen,
+    /// The latest elapsed epoch's voting window has already closed without this node voting for
+    /// it; the epoch can no longer be voted on.
+    WindowClosed,
+    /// This node already voted for the latest elapsed epoch, per the `BillingContract`.
+    AlreadyVoted,
+    /// The voting window for `epoch` is open and this node hasn't voted yet; `counts` are the
+    /// aggregated per-RP counts to submit.
+    Votes { epoch: u32, counts: Vec<RpCount> },
+}
+
 /// Aggregates recorded RP request counts per epoch and submits them as billing votes.
 ///
 /// Constructed via [`OprfAccountantService::new`]; driven by repeatedly calling
 /// [`OprfAccountantService::tick`] (typically via [`OprfAccountantService::run`]).
 #[derive(Clone)]
 pub(crate) struct OprfAccountantService {
+    /// Binding to the `BillingContract`, built from the args' `provider` and `billing_contract`.
     contract: IBillingContractInstance<DynProvider>,
+    /// Address of the `BillingContract`, used to derive the EIP-712 domain for vote signing.
     billing_contract: Address,
+    /// Chain id `contract` is connected to, used to derive the EIP-712 domain for vote signing.
     chain_id: u64,
+    /// Signer this node uses to sign its billing votes.
     signer: PrivateKeySigner,
+    /// Database storing recorded RP requests, aggregated per epoch for voting.
     db: PostgresDb,
+    /// How often [`Self::run`] calls [`Self::tick`].
+    tick_interval: Duration,
+    /// The maximum time to wait for a `submitBillingVotes` transaction to be confirmed.
+    vote_timeout: Duration,
+    /// Extra delay after an epoch's voting window opens before aggregating and voting for it.
     voting_window_offset: Duration,
+    /// The maximum number of `RpCount`s per `SignedVoteChunk` submitted to `submitBillingVotes`.
     billing_vote_chunk_size: NonZeroUsize,
+    /// Signals [`Self::run`] to stop.
     cancellation_token: CancellationToken,
 }
 
@@ -180,6 +208,11 @@ pub(crate) struct OprfAccountantServiceArgs {
     pub(crate) signer: PrivateKeySigner,
     /// Database storing recorded RP requests.
     pub(crate) db: PostgresDb,
+    /// How often to call [`OprfAccountantService::tick`] in [`OprfAccountantService::run`].
+    /// Needs to be smaller than the current era's `votingWindow` so we don't miss the voting window
+    pub(crate) tick_interval: Duration,
+    /// The maximum time to wait for a `submitBillingVotes` transaction to be confirmed.
+    pub(crate) vote_timeout: Duration,
     /// Extra delay after an epoch's voting window opens before we aggregate and vote for it,
     /// giving OPRF nodes time to flush their batched requests to us. Should be kept well below
     /// the current era's `votingWindow`: [`OprfAccountantService::tick`] only has whatever time
@@ -202,6 +235,8 @@ impl OprfAccountantService {
             billing_contract,
             signer,
             db,
+            tick_interval,
+            vote_timeout,
             voting_window_offset,
             billing_vote_chunk_size,
             cancellation_token,
@@ -214,6 +249,8 @@ impl OprfAccountantService {
             chain_id,
             signer,
             db,
+            tick_interval,
+            vote_timeout,
             voting_window_offset,
             billing_vote_chunk_size,
             cancellation_token,
@@ -229,10 +266,14 @@ impl OprfAccountantService {
     pub(crate) async fn run(&self) {
         tracing::info!("starting OprfAccountant worker");
 
+        let mut interval = tokio::time::interval(self.tick_interval);
+        // Burst would also be fine, but it is not needed here, Skip would be bad because it could skip epochs
+        interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
+
         loop {
             tokio::select! {
-                res = self.tick() => {
-                    if let Err(err) = res {
+                 _ = interval.tick() => {
+                    if let Err(err) = self.tick().await {
                         tracing::error!(error = ?err, "accountant tick failed; retrying next tick");
                     }
                 }
@@ -297,74 +338,81 @@ impl OprfAccountantService {
         Ok(())
     }
 
+    /// Votes for the next vote-able epoch, if any (see [`Self::maybe_get_votes`]); a no-op if no
+    /// epoch is currently vote-able.
+    ///
+    /// # Errors
+    /// Returns an error if querying the `BillingContract` or the database fails, or if voting
+    /// doesn't complete within [`OprfAccountantServiceArgs::vote_timeout`].
     #[instrument(level = "info", skip_all, name = "accountant_service::tick")]
     pub(crate) async fn tick(&self) -> eyre::Result<()> {
-        let vote_epoch_info = self
+        if let MaybeVotes::Votes { epoch, counts } = self.maybe_get_votes().await? {
+            tokio::time::timeout(self.vote_timeout, self.vote_for_epoch(epoch, counts)).await??;
+            tracing::info!(epoch, "successfully voted for epoch");
+        }
+        Ok(())
+    }
+
+    /// Determines whether there's an epoch this node should vote for right now, and if so,
+    /// aggregates its per-RP counts. See [`MaybeVotes`] for the possible outcomes.
+    ///
+    /// # Errors
+    /// Returns an error if the `currentVoteEpoch` contract call or the count aggregation query
+    /// fails.
+    #[instrument(level = "info", skip_all, name = "accountant_service::maybe_get_votes")]
+    async fn maybe_get_votes(&self) -> eyre::Result<MaybeVotes> {
+        // Ask the contract for the latest epoch whose own span has fully elapsed,
+        // together with its voting window close and whether this node already voted for it.
+        let vote_epoch = self
             .contract
             .currentVoteEpoch(self.signer.address())
             .call()
             .await?;
-        if !vote_epoch_info.exists {
-            // Epoch 0 hasn't elapsed yet, nothing to vote for. Wait until it does, then
-            // start over so we re-read the current vote epoch from the contract.
-            let epoch_0_end = self.contract.epochEnd(0).call().await?;
+        let epoch = vote_epoch.epoch;
+
+        // Return if no epochs have elapsed yet (i.e. epoch 0 is still in progress). The first epoch's
+        if !vote_epoch.exists {
             tracing::info!("no epochs have elapsed yet, waiting for epoch 0 to elapse");
-            // We add a 10 second buffer to the sleep time to ensure we land after the epoch has ended.
-            sleep_until(epoch_0_end + 10).await;
-            return Ok(());
+            return Ok(MaybeVotes::WindowNotOpen);
         }
 
-        let vote_epoch = vote_epoch_info.epoch;
-        let epoch_span = vote_epoch_info.start..vote_epoch_info.end;
-
-        if vote_epoch_info.alreadyVoted {
-            // Already voted for this epoch. Wait until the epoch currently in
-            // progress (`vote_epoch + 1`) also elapses (plus a buffer, to be safe against clock
-            // drift), then start over so we re-read the current vote epoch from the contract.
-            let next_epoch_end = self.contract.epochEnd(vote_epoch + 1).call().await?;
-            tracing::trace!(vote_epoch, "already voted; waiting for the next epoch");
-            sleep_until(next_epoch_end + 10).await;
-            return Ok(());
+        // Return if this node already voted for the epoch, since the contract is the source of truth for
+        if vote_epoch.alreadyVoted {
+            tracing::info!(epoch, "already voted, waiting for next epoch");
+            return Ok(MaybeVotes::AlreadyVoted);
         }
 
-        // Not yet voted: wait for the voting window (+ offset) to open, then vote.
-        sleep_until(epoch_span.end + self.voting_window_offset.as_secs()).await;
+        // Return if the additional voting window offset hasn't elapsed yet. OPRF nodes need time to flush batched requests.
+        if vote_epoch.blockTime < vote_epoch.epochEnd + self.voting_window_offset.as_secs() {
+            tracing::info!(
+                epoch,
+                block_time = vote_epoch.blockTime,
+                epoch_end = vote_epoch.epochEnd,
+                "voting window not open yet, waiting for next tick"
+            );
+            return Ok(MaybeVotes::WindowNotOpen);
+        }
+
+        // Return if the voting window has already closed, since we can't vote for it anymore.
+        if vote_epoch.blockTime >= vote_epoch.votingWindowEnd {
+            tracing::warn!(
+                epoch,
+                block_time = vote_epoch.blockTime,
+                voting_window_end = vote_epoch.votingWindowEnd,
+                "voting window already closed without voting, waiting for next epoch"
+            );
+            return Ok(MaybeVotes::WindowClosed);
+        }
 
         // Aggregate the recorded RP request counts for the epoch span.
-        let counts = self.db.rp_counts_for_epoch_span(&epoch_span).await?;
+        let counts = self
+            .db
+            .rp_counts_for_epoch_span(&(vote_epoch.epochStart..vote_epoch.epochEnd))
+            .await?;
         tracing::info!(?counts, "collected counts for epoch span");
 
-        // Max time we can spend voting for this epoch, from now until the voting window closes.
-        let remaining_voting_window = Duration::from_secs(
-            vote_epoch_info
-                .votingWindowEnd
-                .saturating_sub(now_unix_timestamp()),
-        );
-        tokio::time::timeout(
-            remaining_voting_window,
-            self.vote_for_epoch(vote_epoch, counts),
-        )
-        .await??;
-        tracing::info!(vote_epoch, "successfully voted for epoch");
-
-        Ok(())
+        Ok(MaybeVotes::Votes { epoch, counts })
     }
-}
-
-/// Returns the current unix timestamp in seconds.
-fn now_unix_timestamp() -> u64 {
-    SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .expect("system clock after unix epoch")
-        .as_secs()
-}
-
-/// Sleeps until `target` (a unix timestamp in seconds), or returns immediately if it's already
-/// in the past.
-async fn sleep_until(target: u64) {
-    let sleep_duration = Duration::from_secs(target.saturating_sub(now_unix_timestamp()));
-    tracing::info!(?sleep_duration, target, "sleeping until target timestamp");
-    tokio::time::sleep(sleep_duration).await;
 }
 
 /// The EIP-712 domain of the `BillingContract` at `verifying_contract` on `chain_id`, matching
@@ -382,7 +430,7 @@ fn billing_vote_domain(chain_id: u64, verifying_contract: Address) -> Eip712Doma
 /// for `epoch` with `signer`, returning the resulting [`SignedVoteChunk`]s in ascending
 /// `chunkIndex` order. `isFinal` is set only on the last chunk. If `counts` is empty, returns a
 /// single chunk with `isFinal = true` and an empty `counts` — the node must still record a vote
-/// for `epoch` even when it observed nothing, since `hasVoted` is only set by a submitted vote.
+/// for `epoch` even when it observed nothing, since `alreadyVoted` is only set by a submitted vote.
 ///
 /// # Errors
 /// Returns an error if `counts` needs more than [`u32::MAX`] chunks, or if signing a chunk fails.
@@ -434,14 +482,151 @@ async fn build_signed_vote_chunks(
 
 #[cfg(test)]
 mod tests {
-    use std::num::NonZeroUsize;
+    use std::{
+        num::{NonZeroU32, NonZeroUsize},
+        time::Duration,
+    };
 
-    use alloy::{primitives::Address, signers::local::PrivateKeySigner, sol_types::SolStruct as _};
+    use alloy::{
+        primitives::Address,
+        providers::{DynProvider, Provider as _, ProviderBuilder},
+        signers::local::PrivateKeySigner,
+        sol_types::{SolCall as _, SolStruct as _},
+        transports::mock::Asserter,
+    };
+    use secrecy::SecretString;
+    use taceo_nodes_common::{
+        postgres::PostgresConfig,
+        test_utils::{next_test_schema, shared_postgres_testcontainer},
+    };
+    use tokio_util::sync::CancellationToken;
 
-    use super::{BillingVoteChunk, RpCount, billing_vote_domain, build_signed_vote_chunks};
+    use super::{
+        BillingVoteChunk, IBillingContract, MaybeVotes, OprfAccountantService, PostgresDb, RpCount,
+        billing_vote_domain, build_signed_vote_chunks,
+    };
 
     fn rp_counts(n: u64) -> Vec<RpCount> {
         (1..=n).map(|i| RpCount { rpId: i, count: i }).collect()
+    }
+
+    /// Builds a [`PostgresDb`] backed by a fresh schema in the shared testcontainer, mirroring
+    /// `postgres::tests::setup_db`.
+    async fn setup_db() -> PostgresDb {
+        let connection_string = shared_postgres_testcontainer()
+            .await
+            .expect("shared postgres testcontainer starts");
+        let mut db_config = PostgresConfig::with_default_values(
+            SecretString::from(connection_string.to_owned()),
+            next_test_schema(),
+        );
+        db_config.max_connections = NonZeroU32::new(1).expect("non-zero");
+        PostgresDb::init(&db_config)
+            .await
+            .expect("postgres db initializes")
+    }
+
+    /// A [`DynProvider`] whose transport returns `response` for the single `currentVoteEpoch`
+    /// call it expects to see.
+    fn mock_vote_epoch_provider(response: IBillingContract::currentVoteEpochReturn) -> DynProvider {
+        let asserter = Asserter::new();
+        let encoded = IBillingContract::currentVoteEpochCall::abi_encode_returns(&response);
+        asserter.push_success(&format!("0x{}", alloy::hex::encode(encoded)));
+        ProviderBuilder::default()
+            .connect_mocked_client(asserter)
+            .erased()
+    }
+
+    /// Builds an [`OprfAccountantService`] whose `currentVoteEpoch` call returns `vote_epoch`
+    /// exactly once, backed by a real (testcontainer) [`PostgresDb`].
+    async fn test_service(
+        vote_epoch: IBillingContract::currentVoteEpochReturn,
+    ) -> OprfAccountantService {
+        let billing_contract = Address::repeat_byte(0x11);
+        let contract =
+            IBillingContract::new(billing_contract, mock_vote_epoch_provider(vote_epoch));
+        OprfAccountantService {
+            contract,
+            billing_contract,
+            chain_id: 31337,
+            signer: PrivateKeySigner::random(),
+            db: setup_db().await,
+            tick_interval: Duration::from_secs(1),
+            vote_timeout: Duration::from_secs(1),
+            voting_window_offset: Duration::from_secs(1),
+            billing_vote_chunk_size: NonZeroUsize::new(128).expect("non-zero"),
+            cancellation_token: CancellationToken::new(),
+        }
+    }
+
+    fn vote_epoch(
+        exists: bool,
+        epoch: u32,
+        epoch_start: u64,
+        epoch_end: u64,
+        voting_window_end: u64,
+        already_voted: bool,
+        block_time: u64,
+    ) -> IBillingContract::currentVoteEpochReturn {
+        assert!(
+            !exists || (epoch_start < epoch_end),
+            "epoch start must be before epoch end if it exists"
+        );
+        assert!(
+            !exists || (epoch_end < voting_window_end),
+            "epoch end must be before voting window end if it exists"
+        );
+        IBillingContract::currentVoteEpochReturn {
+            exists,
+            epoch,
+            epochStart: epoch_start,
+            epochEnd: epoch_end,
+            votingWindowEnd: voting_window_end,
+            alreadyVoted: already_voted,
+            blockTime: block_time,
+        }
+    }
+
+    #[tokio::test]
+    async fn maybe_get_votes_returns_window_not_open_when_no_epoch_has_elapsed_yet() {
+        let service = test_service(vote_epoch(false, 0, 0, 0, 0, false, 0)).await;
+        let result = service.maybe_get_votes().await.expect("no db error");
+        assert_eq!(result, MaybeVotes::WindowNotOpen);
+    }
+
+    #[tokio::test]
+    async fn maybe_get_votes_returns_already_voted() {
+        let service = test_service(vote_epoch(true, 3, 100, 200, 300, true, 250)).await;
+        let result = service.maybe_get_votes().await.expect("no db error");
+        assert_eq!(result, MaybeVotes::AlreadyVoted);
+    }
+
+    #[tokio::test]
+    async fn maybe_get_votes_returns_window_not_open_before_the_voting_window_offset_elapses() {
+        // epoch ends at 200, offset is 1s, so the window doesn't open until block time 201.
+        let service = test_service(vote_epoch(true, 3, 100, 200, 300, false, 200)).await;
+        let result = service.maybe_get_votes().await.expect("no db error");
+        assert_eq!(result, MaybeVotes::WindowNotOpen);
+    }
+
+    #[tokio::test]
+    async fn maybe_get_votes_returns_window_closed_once_voting_window_end_has_passed() {
+        let service = test_service(vote_epoch(true, 3, 100, 200, 300, false, 300)).await;
+        let result = service.maybe_get_votes().await.expect("no db error");
+        assert_eq!(result, MaybeVotes::WindowClosed);
+    }
+
+    #[tokio::test]
+    async fn maybe_get_votes_returns_votes_with_the_aggregated_counts_when_the_window_is_open() {
+        let service = test_service(vote_epoch(true, 3, 100, 200, 300, false, 250)).await;
+        let result = service.maybe_get_votes().await.expect("no db error");
+        assert_eq!(
+            result,
+            MaybeVotes::Votes {
+                epoch: 3,
+                counts: vec![]
+            }
+        );
     }
 
     #[tokio::test]

--- a/services/oprf-accountant/src/api.rs
+++ b/services/oprf-accountant/src/api.rs
@@ -58,14 +58,12 @@ impl From<&NullifierOprfRequestAuthV1> for BillableRpRequest {
     }
 }
 
-// TODO add id to span
-#[instrument(level = "info", skip_all)]
+#[instrument(level = "info", skip_all, fields(%id))]
 async fn post_request(
     State(db): State<PostgresDb>,
-    Query(PostRequestQuery { id: _ }): Query<PostRequestQuery>,
+    Query(PostRequestQuery { id }): Query<PostRequestQuery>,
     Json(rp_requests): Json<Vec<BillableRpRequest>>,
 ) -> impl IntoResponse {
-    // TODO check if requests are Uniqueness Proofs (first byte is 0x00)?
     match db.store_request_batch(rp_requests).await {
         Ok(()) => {
             tracing::trace!("Successfully recorded RP request batch");

--- a/services/oprf-accountant/src/api.rs
+++ b/services/oprf-accountant/src/api.rs
@@ -1,3 +1,4 @@
+use alloy::signers::Signature;
 use axum::{
     Json, Router,
     extract::{Query, State},
@@ -6,6 +7,7 @@ use axum::{
     routing::post,
 };
 use serde::{Deserialize, Serialize};
+use tracing::instrument;
 use uuid::Uuid;
 use world_id_primitives::{oprf::NullifierOprfRequestAuthV1, rp::RpId};
 
@@ -26,7 +28,7 @@ pub struct BillableRpRequest {
     #[serde(with = "ark_serde_compat::field")]
     pub action: ark_babyjubjub::Fq,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub signature: Option<alloy_primitives::Signature>,
+    pub signature: Option<Signature>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[serde(with = "world_id_primitives::serde_utils::hex_bytes_opt")]
     pub wip101_data: Option<Vec<u8>>,
@@ -57,14 +59,23 @@ impl From<&NullifierOprfRequestAuthV1> for BillableRpRequest {
 }
 
 // TODO add id to span
+#[instrument(level = "info", skip_all)]
 async fn post_request(
     State(db): State<PostgresDb>,
     Query(PostRequestQuery { id: _ }): Query<PostRequestQuery>,
     Json(rp_requests): Json<Vec<BillableRpRequest>>,
 ) -> impl IntoResponse {
-    // TODO get the epochs for the RpVote from the contract
-    let _ = db.store_request_batch(rp_requests).await;
-    StatusCode::OK
+    // TODO check if requests are Uniqueness Proofs (first byte is 0x00)?
+    match db.store_request_batch(rp_requests).await {
+        Ok(()) => {
+            tracing::trace!("Successfully recorded RP request batch");
+            StatusCode::OK
+        }
+        Err(err) => {
+            tracing::error!(?err, "Failed to record RP request batch: {err}");
+            StatusCode::INTERNAL_SERVER_ERROR
+        }
+    }
 }
 
 pub(crate) fn routes() -> Router<AppState> {

--- a/services/oprf-accountant/src/config.rs
+++ b/services/oprf-accountant/src/config.rs
@@ -1,7 +1,11 @@
 //! Configuration types and environment parsing for the OPRF accountant.
 
+use std::{num::NonZeroUsize, time::Duration};
+
+use alloy::primitives::Address;
+use secrecy::SecretString;
 use serde::Deserialize;
-use taceo_nodes_common::postgres::PostgresConfig;
+use taceo_nodes_common::{postgres::PostgresConfig, web3};
 
 /// The configuration for the OPRF accountant service.
 ///
@@ -12,4 +16,34 @@ pub struct OprfAccountantConfig {
     /// The postgres config
     #[serde(rename = "postgres")]
     pub postgres_config: PostgresConfig,
+
+    /// The address of the `BillingContract` smart contract
+    pub billing_contract: Address,
+
+    /// A additional offset to be added to the start of the voting window.
+    ///
+    /// This is used to ensure that the OPRF nodes have enough time to send their requests
+    /// to the accountant before the voting window starts.
+    /// The offset should be at least be 2x the flush interval of the `AccountantBatcher`.
+    pub voting_window_offset: Duration,
+
+    /// The blockchain RPC config
+    #[serde(rename = "rpc")]
+    pub rpc_provider_config: web3::HttpRpcProviderConfig,
+
+    // TODO split into 1 for the EIP-712 signature and 1 for the transaction signing.
+    /// The private key used to sign billing vote chunks and to submit `submitBillingVotes`
+    /// transactions.
+    pub wallet_private_key: SecretString,
+
+    /// The chunk size for billing votes to be submitted to the `BillingContract`.
+    #[serde(default = "OprfAccountantConfig::default_billing_vote_chunk_size")]
+    pub billing_vote_chunk_size: NonZeroUsize,
+}
+
+impl OprfAccountantConfig {
+    /// Default billing vote chunk size
+    fn default_billing_vote_chunk_size() -> NonZeroUsize {
+        NonZeroUsize::new(128).expect("non-zero")
+    }
 }

--- a/services/oprf-accountant/src/config.rs
+++ b/services/oprf-accountant/src/config.rs
@@ -20,6 +20,29 @@ pub struct OprfAccountantConfig {
     /// The address of the `BillingContract` smart contract
     pub billing_contract: Address,
 
+    /// How often the accountant checks the `BillingContract` for an epoch to vote on.
+    ///
+    /// Needs to be smaller than the current era's `votingWindow`, or the accountant risks waking
+    /// up after an epoch's voting window has already closed and missing the vote entirely.
+    #[serde(
+        default = "OprfAccountantConfig::default_tick_interval",
+        with = "humantime_serde"
+    )]
+    pub tick_interval: Duration,
+
+    /// The maximum time to wait for a `submitBillingVotes` transaction to be confirmed before
+    /// giving up on voting for an epoch.
+    ///
+    /// Should be kept well below the current era's `votingWindow`: once the voting window opens,
+    /// only whatever time remains until `votingWindowEnd` is available to submit the vote, so too
+    /// large a timeout can let a vote attempt run past the window close instead of failing fast
+    /// enough to retry.
+    #[serde(
+        default = "OprfAccountantConfig::default_vote_timeout",
+        with = "humantime_serde"
+    )]
+    pub vote_timeout: Duration,
+
     /// A additional offset to be added to the start of the voting window.
     ///
     /// This is used to ensure that the OPRF nodes have enough time to send their requests
@@ -45,5 +68,15 @@ impl OprfAccountantConfig {
     /// Default billing vote chunk size
     fn default_billing_vote_chunk_size() -> NonZeroUsize {
         NonZeroUsize::new(128).expect("non-zero")
+    }
+
+    /// Default tick interval
+    fn default_tick_interval() -> Duration {
+        Duration::from_secs(60)
+    }
+
+    /// Default vote timeout
+    fn default_vote_timeout() -> Duration {
+        Duration::from_mins(5)
     }
 }

--- a/services/oprf-accountant/src/lib.rs
+++ b/services/oprf-accountant/src/lib.rs
@@ -21,24 +21,76 @@
 //!
 //! It provides an Axum based HTTP server.
 
+use alloy::{providers::Provider, signers::local::PrivateKeySigner};
 use axum::{Router, extract::FromRef};
+use secrecy::ExposeSecret as _;
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
 
-use crate::{config::OprfAccountantConfig, postgres::PostgresDb};
+use crate::{
+    accountant_service::{OprfAccountantService, OprfAccountantServiceArgs},
+    config::OprfAccountantConfig,
+    postgres::PostgresDb,
+};
 
+pub mod accountant_service;
 pub mod api;
 pub mod config;
 pub mod metrics;
 pub mod postgres;
 
 #[derive(Clone)]
-struct AppState(PostgresDb);
+struct AppState {
+    db: PostgresDb,
+    accountant: OprfAccountantService,
+}
 
 impl FromRef<AppState> for PostgresDb {
     fn from_ref(input: &AppState) -> Self {
-        input.0.clone()
+        input.db.clone()
     }
 }
 
-pub async fn start(_config: &OprfAccountantConfig, db: PostgresDb) -> Router {
-    Router::new().merge(api::routes()).with_state(AppState(db))
+impl FromRef<AppState> for OprfAccountantService {
+    fn from_ref(input: &AppState) -> Self {
+        input.accountant.clone()
+    }
+}
+
+pub async fn start(
+    config: &OprfAccountantConfig,
+    db: PostgresDb,
+    cancellation_token: CancellationToken,
+) -> eyre::Result<(Router, JoinHandle<()>)> {
+    let provider =
+        taceo_nodes_common::web3::HttpRpcProviderBuilder::with_config(&config.rpc_provider_config)
+            .build()?;
+    let signer: PrivateKeySigner = config.wallet_private_key.expose_secret().parse()?;
+
+    let chain_id = provider.get_chain_id().await?;
+
+    let accountant = OprfAccountantService::new(OprfAccountantServiceArgs {
+        provider,
+        chain_id,
+        billing_contract: config.billing_contract,
+        signer,
+        db: db.clone(),
+        voting_window_offset: config.voting_window_offset,
+        billing_vote_chunk_size: config.billing_vote_chunk_size,
+        cancellation_token: cancellation_token.clone(),
+    });
+
+    let accountant_task = tokio::spawn({
+        let accountant = accountant.clone();
+        async move {
+            let _guard = cancellation_token.drop_guard_ref();
+            accountant.run().await
+        }
+    });
+
+    let app_state = AppState { db, accountant };
+
+    let router = Router::new().merge(api::routes()).with_state(app_state);
+
+    Ok((router, accountant_task))
 }

--- a/services/oprf-accountant/src/lib.rs
+++ b/services/oprf-accountant/src/lib.rs
@@ -75,6 +75,8 @@ pub async fn start(
         billing_contract: config.billing_contract,
         signer,
         db: db.clone(),
+        tick_interval: config.tick_interval,
+        vote_timeout: config.vote_timeout,
         voting_window_offset: config.voting_window_offset,
         billing_vote_chunk_size: config.billing_vote_chunk_size,
         cancellation_token: cancellation_token.clone(),

--- a/services/oprf-accountant/src/main.rs
+++ b/services/oprf-accountant/src/main.rs
@@ -12,7 +12,7 @@ use tikv_jemallocator::Jemalloc;
 #[global_allocator]
 static GLOBAL: Jemalloc = Jemalloc;
 
-use std::{net::SocketAddr, process::ExitCode};
+use std::{net::SocketAddr, process::ExitCode, time::Duration};
 
 use config::{Config, Environment};
 use eyre::Context;
@@ -24,6 +24,12 @@ struct FullOprfAccountantConfig {
     /// The bind addr of the AXUM server
     #[serde(default = "default_bind_addr")]
     pub bind_addr: SocketAddr,
+
+    /// Max wait time the service waits for its workers during shutdown.
+    #[serde(default = "default_max_wait_shutdown")]
+    #[serde(with = "humantime_serde")]
+    pub max_wait_time_shutdown: Duration,
+
     /// The OPRF accountant service config
     #[serde(rename = "service")]
     pub service_config: OprfAccountantConfig,
@@ -59,6 +65,10 @@ fn default_bind_addr() -> SocketAddr {
     "0.0.0.0:4322".parse().expect("valid SocketAddr")
 }
 
+fn default_max_wait_shutdown() -> Duration {
+    Duration::from_secs(10)
+}
+
 async fn run(config: FullOprfAccountantConfig) -> eyre::Result<()> {
     tracing::info!("{}", taceo_nodes_common::version_info!());
     tracing::info!("starting oprf-accountant with config: {config:#?}");
@@ -69,22 +79,61 @@ async fn run(config: FullOprfAccountantConfig) -> eyre::Result<()> {
     let db = PostgresDb::init(&config.service_config.postgres_config).await?;
     // Clone the values we need afterwards
     let bind_addr = config.bind_addr;
+    let max_wait_time_shutdown = config.max_wait_time_shutdown;
 
-    let accountant_router = world_id_oprf_accountant::start(&config.service_config, db).await;
+    let (accountant_router, accountant_task) =
+        world_id_oprf_accountant::start(&config.service_config, db, cancellation_token.clone())
+            .await?;
 
     let router = Router::new()
         .merge(taceo_nodes_common::api::routes(
             taceo_nodes_common::version_info!(),
         ))
         .merge(accountant_router);
-    tracing::info!("starting axum server on {bind_addr}",);
-    let listener = tokio::net::TcpListener::bind(bind_addr).await?;
-    axum::serve(listener, router)
-        .with_graceful_shutdown(async move { cancellation_token.cancelled().await })
-        .await
-        .context("while serving axum")?;
-    tracing::info!("axum server shutdown");
-    Ok(())
+
+    let server = tokio::spawn({
+        let cancellation_token = cancellation_token.clone();
+        async move {
+            // we cancel the token if this task closes for some reason
+            let _drop_guard = cancellation_token.drop_guard_ref();
+            tracing::info!("starting axum server on to {bind_addr}");
+            let tcp_listener = tokio::net::TcpListener::bind(bind_addr)
+                .await
+                .context("while binding tcp-listener")?;
+            let axum_result = axum::serve(tcp_listener, router)
+                .with_graceful_shutdown({
+                    let cancellation_token = cancellation_token.clone();
+                    async move { cancellation_token.cancelled().await }
+                })
+                .await
+                .context("while running axum");
+            tracing::info!("axum server shutdown");
+            axum_result
+        }
+    });
+
+    tracing::info!("everything started successfully - now waiting for shutdown...");
+    cancellation_token.cancelled().await;
+
+    tracing::info!("waiting for shutdown of services (max wait time {max_wait_time_shutdown:?})..");
+
+    match tokio::time::timeout(max_wait_time_shutdown, async move {
+        let (axum_result, accountant_result) = tokio::join!(server, accountant_task);
+        axum_result??;
+        accountant_result?;
+        eyre::Ok(())
+    })
+    .await
+    {
+        Ok(Ok(_)) => {
+            tracing::info!("successfully finished shutdown in time");
+            Ok(())
+        }
+        Ok(Err(err)) => Err(err),
+        Err(_) => {
+            eyre::bail!("could not finish shutdown in time");
+        }
+    }
 }
 
 fn main() -> ExitCode {

--- a/services/oprf-accountant/src/main.rs
+++ b/services/oprf-accountant/src/main.rs
@@ -12,7 +12,7 @@ use tikv_jemallocator::Jemalloc;
 #[global_allocator]
 static GLOBAL: Jemalloc = Jemalloc;
 
-use std::{net::SocketAddr, process::ExitCode, time::Duration};
+use std::{net::SocketAddr, process::ExitCode};
 
 use config::{Config, Environment};
 use eyre::Context;
@@ -24,11 +24,6 @@ struct FullOprfAccountantConfig {
     /// The bind addr of the AXUM server
     #[serde(default = "default_bind_addr")]
     pub bind_addr: SocketAddr,
-
-    /// Max wait time the service waits for its workers during shutdown.
-    #[serde(default = "default_max_wait_shutdown")]
-    #[serde(with = "humantime_serde")]
-    pub max_wait_time_shutdown: Duration,
 
     /// The OPRF accountant service config
     #[serde(rename = "service")]
@@ -65,10 +60,6 @@ fn default_bind_addr() -> SocketAddr {
     "0.0.0.0:4322".parse().expect("valid SocketAddr")
 }
 
-fn default_max_wait_shutdown() -> Duration {
-    Duration::from_secs(10)
-}
-
 async fn run(config: FullOprfAccountantConfig) -> eyre::Result<()> {
     tracing::info!("{}", taceo_nodes_common::version_info!());
     tracing::info!("starting oprf-accountant with config: {config:#?}");
@@ -79,8 +70,8 @@ async fn run(config: FullOprfAccountantConfig) -> eyre::Result<()> {
     let db = PostgresDb::init(&config.service_config.postgres_config).await?;
     // Clone the values we need afterwards
     let bind_addr = config.bind_addr;
-    let max_wait_time_shutdown = config.max_wait_time_shutdown;
 
+    tracing::info!("starting oprf-accountant service...");
     let (accountant_router, accountant_task) =
         world_id_oprf_accountant::start(&config.service_config, db, cancellation_token.clone())
             .await?;
@@ -91,49 +82,16 @@ async fn run(config: FullOprfAccountantConfig) -> eyre::Result<()> {
         ))
         .merge(accountant_router);
 
-    let server = tokio::spawn({
-        let cancellation_token = cancellation_token.clone();
-        async move {
-            // we cancel the token if this task closes for some reason
-            let _drop_guard = cancellation_token.drop_guard_ref();
-            tracing::info!("starting axum server on to {bind_addr}");
-            let tcp_listener = tokio::net::TcpListener::bind(bind_addr)
-                .await
-                .context("while binding tcp-listener")?;
-            let axum_result = axum::serve(tcp_listener, router)
-                .with_graceful_shutdown({
-                    let cancellation_token = cancellation_token.clone();
-                    async move { cancellation_token.cancelled().await }
-                })
-                .await
-                .context("while running axum");
-            tracing::info!("axum server shutdown");
-            axum_result
-        }
-    });
-
-    tracing::info!("everything started successfully - now waiting for shutdown...");
-    cancellation_token.cancelled().await;
-
-    tracing::info!("waiting for shutdown of services (max wait time {max_wait_time_shutdown:?})..");
-
-    match tokio::time::timeout(max_wait_time_shutdown, async move {
-        let (axum_result, accountant_result) = tokio::join!(server, accountant_task);
-        axum_result??;
-        accountant_result?;
-        eyre::Ok(())
-    })
-    .await
-    {
-        Ok(Ok(_)) => {
-            tracing::info!("successfully finished shutdown in time");
-            Ok(())
-        }
-        Ok(Err(err)) => Err(err),
-        Err(_) => {
-            eyre::bail!("could not finish shutdown in time");
-        }
-    }
+    tracing::info!("starting axum server on {bind_addr}",);
+    let listener = tokio::net::TcpListener::bind(bind_addr).await?;
+    let serve_result = axum::serve(listener, router)
+        .with_graceful_shutdown(async move { cancellation_token.cancelled().await })
+        .await;
+    tracing::info!("axum server shutdown");
+    tracing::info!("waiting for accountant task to finish processing...");
+    accountant_task.await?;
+    serve_result.context("while serving axum")?;
+    Ok(())
 }
 
 fn main() -> ExitCode {

--- a/services/oprf-accountant/src/postgres.rs
+++ b/services/oprf-accountant/src/postgres.rs
@@ -1,3 +1,5 @@
+use std::ops::Range;
+
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use backon::{ConstantBuilder, Retryable as _};
 use eyre::Context as _;
@@ -6,7 +8,7 @@ use sqlx::PgPool;
 use taceo_nodes_common::postgres::{CreateSchema, PostgresConfig};
 use tracing::instrument;
 
-use crate::api::BillableRpRequest;
+use crate::{accountant_service::RpCount, api::BillableRpRequest};
 
 type Result<T> = std::result::Result<T, PostgresDbError>;
 
@@ -52,16 +54,13 @@ impl PostgresDb {
     }
 
     pub(crate) async fn store_request_batch(
-        self,
+        &self,
         rp_requests: Vec<BillableRpRequest>,
     ) -> Result<()> {
         let rp_ids = rp_requests
             .iter()
             .map(|r| r.rp_id.into_inner() as i64)
             .collect_vec();
-        // let epochs: Vec<i64> = rp_requests.iter().map(|r| r.epoch).collect();
-        // TODO get epochs
-        let epochs: Vec<i64> = Vec::new();
         let nonces = rp_requests
             .iter()
             .map(|r| to_db_ark_serialize_uncompressed(&r.nonce))
@@ -74,33 +73,42 @@ impl PostgresDb {
             .iter()
             .map(|r| r.expires_at as i64)
             .collect_vec();
+        let actions = rp_requests
+            .iter()
+            .map(|r| to_db_ark_serialize_uncompressed(&r.action))
+            .collect_vec();
         let signatures = rp_requests
             .iter()
             .map(|r| r.signature.map(Vec::<u8>::from))
+            .collect_vec();
+        let wip101_datas = rp_requests
+            .iter()
+            .map(|r| r.wip101_data.clone())
             .collect_vec();
 
         let batch_insert = || async {
             Ok(sqlx::query(
                 "
                 INSERT INTO rp_signatures
-                    (rp_id, epoch, nonce, signed_created_at, signed_expires_at, signature)
+                    (rp_id, nonce, created_at, expires_at, action, signature, wip101_data)
                 SELECT * FROM UNNEST(
                     $1::bigint[],
-                    $2::bigint[],
-                    $3::bytea[],
+                    $2::bytea[],
+                    $3::bigint[],
                     $4::bigint[],
-                    $5::bigint[],
-                    $6::bytea[]
+                    $5::bytea[],
+                    $6::bytea[],
+                    $7::bytea[]
                 )
-                ON CONFLICT (rp_id, nonce, epoch) DO NOTHING
             ",
             )
             .bind(&rp_ids)
-            .bind(&epochs)
             .bind(&nonces)
             .bind(&created_ats)
             .bind(&expires_ats)
+            .bind(&actions)
             .bind(&signatures)
+            .bind(&wip101_datas)
             .execute(&self.pool)
             .await?
             .rows_affected())
@@ -109,6 +117,42 @@ impl PostgresDb {
         let _rows_affected = self.with_retry("store-request-batch", batch_insert).await?;
 
         Ok(())
+    }
+
+    /// Returns the number of unique requests observed per RP whose `expires_at` falls in
+    /// `epoch_span` (an epoch's own `[start, end)` span — NOT its voting window, which opens only
+    /// after the epoch has closed), ascending by `rp_id` (as required by `submitBillingVotes`).
+    ///
+    /// A request's nonce is only guaranteed unique within the epoch it was submitted for, so the
+    /// same nonce can show up more than once in `epoch_span` (e.g. a retried submission); `COUNT
+    /// (DISTINCT nonce)` collapses those duplicates down to a single count per `rp_id` before
+    /// they're reported.
+    pub(crate) async fn rp_counts_for_epoch_span(
+        &self,
+        epoch_span: &Range<u64>,
+    ) -> Result<Vec<RpCount>> {
+        let query = || async {
+            Ok(sqlx::query_as::<_, (i64, i64)>(
+                "
+                SELECT rp_id, COUNT(DISTINCT nonce) FROM rp_signatures
+                WHERE expires_at >= $1 AND expires_at < $2
+                GROUP BY rp_id
+                ORDER BY rp_id
+            ",
+            )
+            .bind(epoch_span.start as i64)
+            .bind(epoch_span.end as i64)
+            .fetch_all(&self.pool)
+            .await?)
+        };
+        let rows = self.with_retry("rp-counts-for-epoch-span", query).await?;
+        Ok(rows
+            .into_iter()
+            .map(|(rp_id, count)| RpCount {
+                rpId: rp_id as u64,
+                count: count as u64,
+            })
+            .collect())
     }
 
     async fn with_retry<F, Fut, T>(&self, op_name: &str, f: F) -> Result<T>
@@ -165,4 +209,207 @@ pub(crate) fn from_db_ark_serialize_uncompressed<T: CanonicalDeserialize>(b: Vec
     T::deserialize_uncompressed(b.as_slice()).map_err(|e| {
         PostgresDbError::from(eyre::eyre!("Cannot deserialize bytes: DB not sane: {e}"))
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::num::NonZeroU32;
+
+    use secrecy::SecretString;
+    use taceo_nodes_common::{
+        postgres::PostgresConfig,
+        test_utils::{next_test_schema, shared_postgres_testcontainer},
+    };
+    use world_id_primitives::rp::RpId;
+
+    use super::PostgresDb;
+    use crate::{accountant_service::RpCount, api::BillableRpRequest};
+
+    /// Builds a [`PostgresDb`] backed by a fresh Postgres schema in the shared testcontainer.
+    async fn setup_db() -> PostgresDb {
+        let connection_string = shared_postgres_testcontainer()
+            .await
+            .expect("shared postgres testcontainer starts");
+        let mut db_config = PostgresConfig::with_default_values(
+            SecretString::from(connection_string.to_owned()),
+            next_test_schema(),
+        );
+        db_config.max_connections = NonZeroU32::new(1).expect("non-zero");
+        PostgresDb::init(&db_config)
+            .await
+            .expect("postgres db initializes")
+    }
+
+    fn request(rp_id: u64, nonce: u64, expires_at: u64) -> BillableRpRequest {
+        BillableRpRequest {
+            rp_id: RpId::new(rp_id),
+            nonce: ark_babyjubjub::Fq::from(nonce),
+            created_at: expires_at,
+            expires_at,
+            action: ark_babyjubjub::Fq::from(0u64),
+            signature: None,
+            wip101_data: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn counts_are_empty_when_no_requests_recorded() {
+        let db = setup_db().await;
+
+        let counts = db
+            .rp_counts_for_epoch_span(&(1000..1100))
+            .await
+            .expect("computes counts");
+
+        assert_eq!(counts, vec![]);
+    }
+
+    #[tokio::test]
+    async fn counts_aggregate_recorded_requests_by_rp_id_within_the_window() {
+        let db = setup_db().await;
+
+        // requests for two different windows, to check that each window's counts only include
+        // its own requests.
+        db.store_request_batch(vec![
+            request(5, 1, 1010),
+            request(5, 2, 1020),
+            request(7, 3, 1030),
+            request(9, 4, 1150),
+        ])
+        .await
+        .expect("requests are recorded");
+
+        let window0 = db
+            .rp_counts_for_epoch_span(&(1000..1100))
+            .await
+            .expect("computes counts");
+        assert_eq!(
+            window0,
+            vec![RpCount { rpId: 5, count: 2 }, RpCount { rpId: 7, count: 1 }]
+        );
+
+        let window1 = db
+            .rp_counts_for_epoch_span(&(1100..1200))
+            .await
+            .expect("computes counts");
+        assert_eq!(window1, vec![RpCount { rpId: 9, count: 1 }]);
+    }
+
+    #[tokio::test]
+    async fn duplicate_nonces_within_a_window_count_once() {
+        let db = setup_db().await;
+
+        // rp 13's nonce 99 is used twice within the same window [1000, 1100) — the second is a
+        // replay and must not be double-counted — and once more in a different window
+        // [1100, 1200), where reusing the same (rp_id, nonce) pair is fine since uniqueness is
+        // only enforced per voting window.
+        db.store_request_batch(vec![
+            request(13, 99, 1010),
+            request(13, 99, 1020),
+            request(13, 99, 1150),
+        ])
+        .await
+        .expect("requests are recorded");
+
+        let window0 = db
+            .rp_counts_for_epoch_span(&(1000..1100))
+            .await
+            .expect("computes counts");
+        assert_eq!(window0, vec![RpCount { rpId: 13, count: 1 }]);
+
+        let window1 = db
+            .rp_counts_for_epoch_span(&(1100..1200))
+            .await
+            .expect("computes counts");
+        assert_eq!(window1, vec![RpCount { rpId: 13, count: 1 }]);
+    }
+
+    #[tokio::test]
+    async fn duplicate_nonce_with_a_different_expiry_in_the_same_window_still_counts_once() {
+        let db = setup_db().await;
+
+        // same (rp_id, nonce) pair, but not literal duplicate rows: the retry carries a
+        // different `expires_at` that still falls in the same window. Dedup must key on
+        // `nonce` alone, not on the full row.
+        db.store_request_batch(vec![request(21, 7, 1010), request(21, 7, 1090)])
+            .await
+            .expect("requests are recorded");
+
+        let window0 = db
+            .rp_counts_for_epoch_span(&(1000..1100))
+            .await
+            .expect("computes counts");
+        assert_eq!(window0, vec![RpCount { rpId: 21, count: 1 }]);
+    }
+
+    #[tokio::test]
+    async fn same_nonce_reused_across_different_rps_counts_independently() {
+        let db = setup_db().await;
+
+        // rp 1 and rp 2 both happen to use nonce 42 in the same window; the dedup is scoped
+        // per rp_id, so both should still count.
+        db.store_request_batch(vec![request(1, 42, 1010), request(2, 42, 1020)])
+            .await
+            .expect("requests are recorded");
+
+        let window0 = db
+            .rp_counts_for_epoch_span(&(1000..1100))
+            .await
+            .expect("computes counts");
+        assert_eq!(
+            window0,
+            vec![RpCount { rpId: 1, count: 1 }, RpCount { rpId: 2, count: 1 }]
+        );
+    }
+
+    #[tokio::test]
+    async fn window_is_half_open_on_expires_at() {
+        let db = setup_db().await;
+
+        // exactly at the window's start (included) and exactly at its end (excluded, belongs
+        // to the next window instead).
+        db.store_request_batch(vec![request(1, 1, 1000), request(1, 2, 1100)])
+            .await
+            .expect("requests are recorded");
+
+        let window0 = db
+            .rp_counts_for_epoch_span(&(1000..1100))
+            .await
+            .expect("computes counts");
+        assert_eq!(window0, vec![RpCount { rpId: 1, count: 1 }]);
+
+        let window1 = db
+            .rp_counts_for_epoch_span(&(1100..1200))
+            .await
+            .expect("computes counts");
+        assert_eq!(window1, vec![RpCount { rpId: 1, count: 1 }]);
+    }
+
+    #[tokio::test]
+    async fn results_are_ordered_by_rp_id_regardless_of_insertion_order() {
+        let db = setup_db().await;
+
+        // inserted in descending rp_id order, to make sure the ordering comes from the query
+        // and not from insertion order.
+        db.store_request_batch(vec![
+            request(9, 1, 1010),
+            request(5, 2, 1020),
+            request(7, 3, 1030),
+        ])
+        .await
+        .expect("requests are recorded");
+
+        let window0 = db
+            .rp_counts_for_epoch_span(&(1000..1100))
+            .await
+            .expect("computes counts");
+        assert_eq!(
+            window0,
+            vec![
+                RpCount { rpId: 5, count: 1 },
+                RpCount { rpId: 7, count: 1 },
+                RpCount { rpId: 9, count: 1 },
+            ]
+        );
+    }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches billing semantics, private-key signing, and a breaking DB shape; votes are not fully submitted on-chain yet, so behavior in production depends on finishing submission and aligning with the pending `currentVoteEpoch` contract API.
> 
> **Overview**
> Adds a background **OprfAccountantService** that periodically calls `BillingContract.currentVoteEpoch()`, waits for the configured post-epoch offset, aggregates per-RP request counts from Postgres for the epoch’s `[epochStart, epochEnd)` span, and builds EIP-712–signed `SignedVoteChunk`s for `submitBillingVotes` (on-chain submission is still commented out pending wallet/signer split and contract ABI).
> 
> **Storage and ingestion:** The `rp_signatures` migration is reshaped for v2—drops per-row `epoch` and the `(rp_id, nonce, epoch)` uniqueness rule, adds `action` and optional `wip101_data`, and makes `signature` nullable. Batch inserts persist the new fields; `POST /req` now returns 500 on DB errors. **`rp_counts_for_epoch_span`** supplies vote data with `COUNT(DISTINCT nonce)` per `rp_id`, ordered for the contract.
> 
> **Wiring:** Config gains billing contract address, RPC, wallet key, tick/vote timeouts, voting-window offset, and vote chunk size. Startup spawns the accountant loop alongside Axum and joins it on shutdown. Unit/integration tests cover vote-window logic, chunk signing, and aggregation edge cases. `Cargo.lock` picks up `alloy`/`web3` and `taceo-nodes-common` test-deps (e.g. `axum-test`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90766b9fb6262fa734ec00424d573024d368cc73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->