### PR TITLE
ci: add workflow to build accountant

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -130,7 +130,7 @@ jobs:
           subject-digest: ${{ steps.docker_build.outputs.digest }}
 
       - name: Trigger staging deploy
-        if: (github.ref_type == 'tag' || inputs.version != '') && matrix.service != 'oprf-node'
+        if: (github.ref_type == 'tag' || inputs.version != '') && matrix.service != 'oprf-node' && matrix.service != 'oprf-accountant'
         uses: actions/github-script@v7
         env:
           SERVICE: ${{ matrix.service }}

--- a/.github/workflows/release-oprf-accountant.yml
+++ b/.github/workflows/release-oprf-accountant.yml
@@ -1,0 +1,73 @@
+name: Release OPRF Accountant
+
+on:
+  push:
+    tags:
+      - "world-id-oprf-accountant-v*"
+
+permissions:
+  contents: read
+
+jobs:
+  prepare:
+    name: Prepare release metadata
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.v.outputs.version }}
+      prerelease: ${{ steps.v.outputs.prerelease }}
+    steps:
+      - name: Resolve version
+        id: v
+        run: |
+          VERSION="${GITHUB_REF_NAME#world-id-oprf-accountant-}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          if [[ "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  build-docker:
+    name: Build Docker
+    needs: prepare
+    permissions:
+      contents: read
+      id-token: write
+      packages: write
+      attestations: write
+    uses: ./.github/workflows/build-docker.yml
+    with:
+      service: oprf-accountant
+      version: ${{ needs.prepare.outputs.version }}
+    secrets: inherit
+
+  github-release:
+    name: GitHub Release
+    needs: [prepare, build-docker]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Generate release notes
+        id: notes
+        uses: orhun/git-cliff-action@v4
+        with:
+          config: services/oprf-accountant/cliff.toml
+          args: --include-path "services/oprf-accountant/**" --latest --strip all
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PRERELEASE_FLAG=""
+          if [[ "${{ needs.prepare.outputs.prerelease }}" == "true" ]]; then
+            PRERELEASE_FLAG="--prerelease"
+          fi
+          gh release create "$GITHUB_REF_NAME" \
+            --title "world-id-oprf-accountant ${{ needs.prepare.outputs.version }}" \
+            --notes-file "${{ steps.notes.outputs.changelog }}" \
+            $PRERELEASE_FLAG

--- a/services/oprf-accountant/cliff.toml
+++ b/services/oprf-accountant/cliff.toml
@@ -1,0 +1,75 @@
+# git-cliff configuration for world-id-oprf-accountant release notes.
+# Used only by the Release OPRF Accountant workflow; does not affect the crate changelogs
+# managed by release-plz.
+
+[changelog]
+# Template for the release body (no header/footer -- the workflow strips those).
+body = """
+{% for group, commits in commits | group_by(attribute="group") %}
+### {{ group | upper_first }}
+{% for commit in commits %}
+- {% if commit.breaking %}**breaking** {% endif %}\
+{{ commit.message | upper_first }}\
+{% if commit.github.username %} by @{{ commit.github.username }}{% endif %}\
+{% if commit.github.pr_number %} in [#{{ commit.github.pr_number }}]({{ commit.github.pr_url }}){% endif %}
+{% endfor %}
+{% endfor %}
+"""
+footer = ""
+trim = true
+
+[git]
+# Only process conventional commits; drop everything else.
+conventional_commits = true
+filter_unconventional = true
+split_commits = false
+
+# Restrict --latest to OPRF-accountant tag boundaries only.
+# Without this, git-cliff would pick the most recent tag across all prefixes
+# (world-id-gateway-v*, world-id-core-v*, ...) in this monorepo.
+tag_pattern = "world-id-oprf-accountant-v[0-9]*"
+
+filter_commits = false
+# Sort commits newest-first within each group.
+sort_commits = "newest"
+
+# Skip merge commits.
+commit_preprocessors = [
+  { pattern = "^Merge ", replace = "" },
+]
+
+[[git.commit_parsers]]
+message = "^feat"
+group = "Features"
+
+[[git.commit_parsers]]
+message = "^fix"
+group = "Bug Fixes"
+
+[[git.commit_parsers]]
+message = "^perf"
+group = "Performance"
+
+[[git.commit_parsers]]
+message = "^refactor"
+group = "Refactoring"
+
+[[git.commit_parsers]]
+message = "^docs"
+group = "Documentation"
+
+[[git.commit_parsers]]
+message = "^test"
+group = "Testing"
+
+[[git.commit_parsers]]
+message = "^chore"
+group = "Miscellaneous"
+
+[[git.commit_parsers]]
+message = "^build"
+group = "Build"
+
+[[git.commit_parsers]]
+message = "^ci"
+skip = true


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI-only changes following an established OPRF node release pattern; no application runtime or auth logic is modified.
> 
> **Overview**
> Adds **tag-driven release automation** for `oprf-accountant`, aligned with the existing OPRF node release pattern.
> 
> Pushing a `world-id-oprf-accountant-v*` tag runs a new workflow that resolves stable vs prerelease versions, calls the reusable **Build Docker** workflow for `oprf-accountant`, and creates a GitHub release with notes generated by **git-cliff** from `services/oprf-accountant/cliff.toml` (scoped to accountant tags and `services/oprf-accountant/**` commits).
> 
> **Build Docker** is updated so the post-build **staging deploy** dispatch is skipped for `oprf-accountant` as well as `oprf-node`, so accountant images are built and released without auto-deploying to staging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1aeeefd5c388138265958f4e6ae2bb227d774d99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->