### PR TITLE
refactor: add missing IWorldIDVerifierV2 interface

### DIFF
--- a/contracts/src/core/WorldIDVerifierV2.sol
+++ b/contracts/src/core/WorldIDVerifierV2.sol
@@ -3,23 +3,17 @@ pragma solidity ^0.8.13;
 
 import {WorldIDVerifier} from "./WorldIDVerifier.sol";
 import {IWorldIDVerifier} from "./interfaces/IWorldIDVerifier.sol";
+import {IWorldIDVerifierV2} from "./interfaces/IWorldIDVerifierV2.sol";
 
 /**
- * @title WorldIDVerifier
+ * @title WorldIDVerifierV2
  * @author World Contributors
  * @notice Verifies World ID proofs (Uniqueness and Session proofs).
  * @dev In addition to verifying the Groth16 Proof, it verifies relevant public inputs to the
  *  circuits through checks with the WorldIDRegistry, CredentialSchemaIssuerRegistry, and OprfKeyRegistry.
  * @custom:repo https://github.com/world-id/world-id-protocol
  */
-contract WorldIDVerifierV2 is WorldIDVerifier {
-    /**
-     * @dev Thrown when the action is not valid for the type of proof. The prefix is enforced
-     *  to ensure any nullifier request for a Uniqueness Proof is signed by the RP (actions
-     *  without this prefix, i.e. for sessions, it doesn't need to be signed).
-     */
-    error InvalidAction();
-
+contract WorldIDVerifierV2 is IWorldIDVerifierV2, WorldIDVerifier {
     /// @inheritdoc IWorldIDVerifier
     function verify(
         uint256 nullifier,
@@ -31,7 +25,7 @@ contract WorldIDVerifierV2 is WorldIDVerifier {
         uint64 issuerSchemaId,
         uint256 credentialGenesisIssuedAtMin,
         uint256[5] calldata zeroKnowledgeProof
-    ) external view virtual override onlyProxy onlyInitialized {
+    ) external view virtual override(IWorldIDVerifier, WorldIDVerifier) onlyProxy onlyInitialized {
         if (uint8(action >> 248) != uint8(0)) {
             revert InvalidAction();
         }
@@ -63,7 +57,7 @@ contract WorldIDVerifierV2 is WorldIDVerifier {
         uint256 sessionId,
         uint256[2] calldata sessionNullifier,
         uint256[5] calldata zeroKnowledgeProof
-    ) external view virtual override onlyProxy onlyInitialized {
+    ) external view virtual override(IWorldIDVerifier, WorldIDVerifier) onlyProxy onlyInitialized {
         uint256 action = sessionNullifier[1];
         if (uint8(action >> 248) != uint8(2)) {
             revert InvalidAction();

--- a/contracts/src/core/interfaces/IWorldIDVerifierV2.sol
+++ b/contracts/src/core/interfaces/IWorldIDVerifierV2.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import {IWorldIDVerifier} from "./IWorldIDVerifier.sol";
+
+/**
+ * @title IWorldIDVerifierV2
+ * @author World Contributors
+ * @notice Interface for verifying World ID proofs (Uniqueness and Session proofs).
+ * @dev V2 enforces the action-prefix convention on the convenience entry points:
+ *  `verify` requires the action's most significant byte to be `0x00` (RP-signed Uniqueness
+ *  actions) and `verifySession` requires `0x02` (randomized Session actions).
+ */
+interface IWorldIDVerifierV2 is IWorldIDVerifier {
+    ////////////////////////////////////////////////////////////
+    //                        ERRORS                          //
+    ////////////////////////////////////////////////////////////
+
+    /**
+     * @dev Thrown when the action is not valid for the type of proof. The prefix is enforced
+     *  to ensure any nullifier request for a Uniqueness Proof is signed by the RP (actions
+     *  without this prefix, i.e. for sessions, it doesn't need to be signed).
+     */
+    error InvalidAction();
+}

--- a/contracts/test/core/WorldIDVerifierV2Test.t.sol
+++ b/contracts/test/core/WorldIDVerifierV2Test.t.sol
@@ -5,6 +5,7 @@ import {Test} from "forge-std/Test.sol";
 import {WorldIDVerifierV2} from "../../src/core/WorldIDVerifierV2.sol";
 import {WorldIDVerifier} from "../../src/core/WorldIDVerifier.sol";
 import {IWorldIDVerifier} from "../../src/core/interfaces/IWorldIDVerifier.sol";
+import {IWorldIDVerifierV2} from "../../src/core/interfaces/IWorldIDVerifierV2.sol";
 import {BabyJubJub} from "oprf-key-registry/src/BabyJubJub.sol";
 import {Verifier} from "../../src/core/Verifier.sol";
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
@@ -60,7 +61,7 @@ contract WorldIDVerifierV2Test is Test {
         uint256 action = 0x15d4b66e5417cb9875f6a2b5be9814dca80651d7c74b3b21685fdd494566e79f;
 
         vm.warp(expiresAtMin + 1 hours);
-        vm.expectRevert(abi.encodeWithSelector(WorldIDVerifierV2.InvalidAction.selector));
+        vm.expectRevert(abi.encodeWithSelector(IWorldIDVerifierV2.InvalidAction.selector));
         verifier.verify(
             nullifier, action, rpIdCorrect, nonce, signalHash, expiresAtMin, credentialIssuerIdCorrect, 0, proof
         );
@@ -71,7 +72,7 @@ contract WorldIDVerifierV2Test is Test {
         vm.assume(uint8(action >> 248) != 0);
 
         vm.warp(expiresAtMin + 1 hours);
-        vm.expectRevert(abi.encodeWithSelector(WorldIDVerifierV2.InvalidAction.selector));
+        vm.expectRevert(abi.encodeWithSelector(IWorldIDVerifierV2.InvalidAction.selector));
         verifier.verify(
             nullifier, action, rpIdCorrect, nonce, signalHash, expiresAtMin, credentialIssuerIdCorrect, 0, proof
         );
@@ -83,7 +84,7 @@ contract WorldIDVerifierV2Test is Test {
         uint256 sessionId = 1;
 
         vm.warp(expiresAtMin + 1 hours);
-        vm.expectRevert(abi.encodeWithSelector(WorldIDVerifierV2.InvalidAction.selector));
+        vm.expectRevert(abi.encodeWithSelector(IWorldIDVerifierV2.InvalidAction.selector));
         verifier.verifySession(
             rpIdCorrect,
             nonce,
@@ -102,7 +103,7 @@ contract WorldIDVerifierV2Test is Test {
         uint256 sessionId = 1;
 
         vm.warp(expiresAtMin + 1 hours);
-        vm.expectRevert(abi.encodeWithSelector(WorldIDVerifierV2.InvalidAction.selector));
+        vm.expectRevert(abi.encodeWithSelector(IWorldIDVerifierV2.InvalidAction.selector));
         verifier.verifySession(
             rpIdCorrect,
             nonce,


### PR DESCRIPTION
## Summary

`WorldIDVerifierV2` is the only versioned core contract without a matching versioned interface — `WorldIDRegistryV2` pairs with `IWorldIDRegistryV2 is IWorldIDRegistry`, while the verifier V2 declares its `InvalidAction` error directly on the contract. This adds the missing `IWorldIDVerifierV2` so the verifier follows the same pattern, and so future verifier versions (e.g. a V3 adding new entry points) have a proper interface chain to extend.

- New `IWorldIDVerifierV2 is IWorldIDVerifier`: declares `InvalidAction` and documents V2's action-prefix semantics (`verify` requires MSB `0x00`, `verifySession` requires `0x02`).
- `WorldIDVerifierV2 is IWorldIDVerifierV2, WorldIDVerifier` (mirrors `WorldIDRegistryV2`): local error declaration removed; overrides now name both bases (`override(IWorldIDVerifier, WorldIDVerifier)`), as required by the diamond inheritance and consistent with the registry.
- Tests reference the error via the interface (`IWorldIDVerifierV2.InvalidAction.selector`), matching the registry test idiom.
- Also fixes the stale `@title WorldIDVerifier` on the V2 contract.

No behavior change: same functions, same checks, same error selector.

## Test plan

- [ ] `cd contracts && forge test` — 331 tests green