### PR TITLE
chore: ignore dev-only libcrux-sha3 advisories in cargo-deny

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -45,7 +45,9 @@ ignore = [
     "RUSTSEC-2025-0057", # Unmaintained `fxhash` (2026-04-10), requires bumps on `provekit`
     "RUSTSEC-2025-0141", # Unmaintained `bincode` (2026-04-10), requires bumps on `provekit`
     "RUSTSEC-2026-0074", # `libcrux-sha3` via testcontainers->russh; dev-only, does not affect our usage (2026-03-26)
-    "RUSTSEC-2026-0097", # Unsoundness in `rand@0.8.5` (2026-04-11), multiple upstream deps on `rand`. Not directly using custom logger
+    "RUSTSEC-2026-0207", # `libcrux-sha3` SHAKE incremental API; via testcontainers->russh->libcrux-ml-kem; dev-only, no safe upgrade (2026-07-21)
+    "RUSTSEC-2026-0208", # `libcrux-sha3` AVX2 SHAKE-256 panic; via testcontainers->russh->libcrux-ml-kem; dev-only, no safe upgrade (2026-07-21)
+    "RUSTSEC-2026-0212", # `libcrux-secrets`/`libcrux-sha3` const-time swap on aarch64; via testcontainers->russh->libcrux-ml-kem; dev-only, no safe upgrade (2026-07-21)
     "RUSTSEC-2026-0153", # russh-cryptovec broken, via testcontainers, dev-only, does not affect our usage (2026-06-02)
     "RUSTSEC-2026-0154", # russh-cryptovec broken, via testcontainers, dev-only, does not affect our usage (2026-06-02)
     "RUSTSEC-2026-0173"  # Unmaintained `proc-macro-error2`; transitive via alloy-sol-macro, no safe upgrade available (2026-06-08)


### PR DESCRIPTION
## What

Fixes the failing **Cargo deny (advisories)** CI job. Three RUSTSEC advisories were newly published against `libcrux-sha3 0.0.4` (and `libcrux-secrets 0.0.4`):

- `RUSTSEC-2026-0207` — incorrect SHAKE output on multiple squeeze calls
- `RUSTSEC-2026-0208` — panic in AVX2 SHAKE-256
- `RUSTSEC-2026-0212` — potentially incorrect constant-time swap/select on aarch64

## Why ignore rather than bump

- **Purely transitive and dev-only.** Dependency path: `libcrux-sha3 ← libcrux-ml-kem ← russh ← testcontainers`. `testcontainers` is test infrastructure only — same path as the already-ignored `RUSTSEC-2026-0074` on this crate.
- **No safe upgrade.** `0.0.4` is pinned by `libcrux-ml-kem 0.0.4 ← russh 0.56.0`, none of which we control; `0.0.x` releases are semver-incompatible, so `cargo update --precise 0.0.10` can't cross that boundary without a `russh`/`testcontainers` release that adopts newer `libcrux` (none available).
- The advisories themselves note the bugs do not affect ML-KEM/ML-DSA usage — which is exactly how `libcrux-ml-kem` uses the crate.

## Also

Removed the stale `RUSTSEC-2026-0097` (`rand@0.8.5`) ignore — cargo-deny reported `advisory-not-detected` (no crate matched), i.e. `rand 0.8.5` is no longer in the tree. Dropping dead ignores keeps a future reintroduction fail-loud.

Verified locally with `cargo deny check advisories` → `advisories ok` (no warnings).