### PR TITLE
chore: Deprecate legacy recovery agent endpoints

### DIFF
--- a/services/common/src/axum/server_layers/deprecation.rs
+++ b/services/common/src/axum/server_layers/deprecation.rs
@@ -122,17 +122,18 @@ where
     }
 }
 
-/// Deprecation of the V1 recovery-agent management API after the V2 upgrade.
-pub enum V2RecoveryAgentDeprecation {}
+/// Deprecation of the V1 recovery-agent management methods.
+pub enum V1RecoveryAgentMethodsDeprecation {}
 
-impl Deprecation for V2RecoveryAgentDeprecation {
-    const ID: &'static str = "v2_recovery_agent";
+impl Deprecation for V1RecoveryAgentMethodsDeprecation {
+    const ID: &'static str = "v1_recovery_agent_methods";
     // Mon, 27 Jul 2026 00:00:00 GMT, encoded as an RFC 9651 date.
     const DEPRECATED_AT: &'static str = "@1785110400";
     const SUNSET: &'static str = "Tue, 27 Jul 2027 00:00:00 GMT";
 }
 
-pub type V2RecoveryAgentDeprecationLayer = DeprecationLayer<V2RecoveryAgentDeprecation>;
+pub type V1RecoveryAgentMethodsDeprecationLayer =
+    DeprecationLayer<V1RecoveryAgentMethodsDeprecation>;
 
 pub fn describe_deprecated_endpoint_metrics() {
     ::metrics::describe_counter!(

--- a/services/common/src/axum/server_layers/deprecation.rs
+++ b/services/common/src/axum/server_layers/deprecation.rs
@@ -1,54 +1,143 @@
-use ::axum::{
-    extract::{MatchedPath, Request},
-    http::HeaderValue,
-    middleware::Next,
-    response::Response,
+use std::{
+    marker::PhantomData,
+    pin::Pin,
+    task::{Context, Poll},
 };
+
+use ::axum::{extract::MatchedPath, http::HeaderValue};
+use tower::{Layer, Service};
 
 /// Counter for requests to HTTP endpoints scheduled for removal.
 pub const METRICS_DEPRECATED_ENDPOINT_REQUESTS: &str = "http.deprecated_endpoint_requests";
 
-/// The date these endpoints were formally marked as deprecated, encoded as an
-/// RFC 9651 date per RFC 9745.
-///
-/// The timestamp represents the date: Mon, 27 Jul 2026 00:00:00 GMT
-const DEPRECATION: HeaderValue = HeaderValue::from_static("@1785110400");
-/// One year after formal deprecation, encoded as an HTTP-date per RFC 8594.
-const SUNSET: HeaderValue = HeaderValue::from_static("Tue, 27 Jul 2027 00:00:00 GMT");
+/// Static metadata describing one API deprecation.
+pub trait Deprecation {
+    /// Stable identifier used to distinguish deprecations in telemetry.
+    const ID: &'static str;
+    /// Date the endpoint was deprecated, encoded as an RFC 9651 date per RFC 9745.
+    const DEPRECATED_AT: &'static str;
+    /// Date the endpoint is scheduled for removal, encoded as an HTTP-date per RFC 8594.
+    const SUNSET: &'static str;
+}
+
+/// Generic Tower layer that adds deprecation headers and usage telemetry.
+pub struct DeprecationLayer<D>(PhantomData<fn() -> D>);
+
+impl<D> DeprecationLayer<D> {
+    pub const fn new() -> Self {
+        Self(PhantomData)
+    }
+}
+
+impl<D> Clone for DeprecationLayer<D> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<D> Copy for DeprecationLayer<D> {}
+
+impl<D> Default for DeprecationLayer<D> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<S, D> Layer<S> for DeprecationLayer<D> {
+    type Service = DeprecationService<S, D>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        DeprecationService {
+            inner,
+            deprecation: PhantomData,
+        }
+    }
+}
+
+/// Service produced by [`DeprecationLayer`].
+pub struct DeprecationService<S, D> {
+    inner: S,
+    deprecation: PhantomData<fn() -> D>,
+}
+
+impl<S: Clone, D> Clone for DeprecationService<S, D> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            deprecation: PhantomData,
+        }
+    }
+}
+
+impl<S, D, RequestBody, ResponseBody> Service<http::Request<RequestBody>>
+    for DeprecationService<S, D>
+where
+    S: Service<http::Request<RequestBody>, Response = http::Response<ResponseBody>>,
+    S::Future: Send + 'static,
+    D: Deprecation,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, request: http::Request<RequestBody>) -> Self::Future {
+        let method = request.method().clone();
+        let route = request
+            .extensions()
+            .get::<MatchedPath>()
+            .map(MatchedPath::as_str)
+            .unwrap_or("UNKNOWN")
+            .to_string();
+
+        tracing::warn!(
+            deprecation = D::ID,
+            route,
+            method = method.as_str(),
+            sunset = D::SUNSET,
+            "deprecated endpoint used"
+        );
+        ::metrics::counter!(
+            METRICS_DEPRECATED_ENDPOINT_REQUESTS,
+            "deprecation" => D::ID,
+            "route" => route,
+            "method" => method.to_string()
+        )
+        .increment(1);
+
+        let future = self.inner.call(request);
+        Box::pin(async move {
+            let mut response = future.await?;
+            response
+                .headers_mut()
+                .insert("deprecation", HeaderValue::from_static(D::DEPRECATED_AT));
+            response
+                .headers_mut()
+                .insert("sunset", HeaderValue::from_static(D::SUNSET));
+            Ok(response)
+        })
+    }
+}
+
+/// Deprecation of the V1 recovery-agent management API after the V2 upgrade.
+pub enum V2RecoveryAgentDeprecation {}
+
+impl Deprecation for V2RecoveryAgentDeprecation {
+    const ID: &'static str = "v2_recovery_agent";
+    // Mon, 27 Jul 2026 00:00:00 GMT, encoded as an RFC 9651 date.
+    const DEPRECATED_AT: &'static str = "@1785110400";
+    const SUNSET: &'static str = "Tue, 27 Jul 2027 00:00:00 GMT";
+}
+
+pub type V2RecoveryAgentDeprecationLayer = DeprecationLayer<V2RecoveryAgentDeprecation>;
 
 pub fn describe_deprecated_endpoint_metrics() {
     ::metrics::describe_counter!(
         METRICS_DEPRECATED_ENDPOINT_REQUESTS,
         ::metrics::Unit::Count,
-        "Number of requests to deprecated HTTP endpoints, labelled by route and method."
+        "Number of requests to deprecated HTTP endpoints, labelled by deprecation, route, and method."
     );
-}
-
-/// Adds deprecation metadata and records use of an endpoint scheduled for removal.
-pub async fn deprecated_endpoint_middleware(request: Request, next: Next) -> Response {
-    let method = request.method().clone();
-    let route = request
-        .extensions()
-        .get::<MatchedPath>()
-        .map(MatchedPath::as_str)
-        .unwrap_or("UNKNOWN")
-        .to_string();
-
-    tracing::warn!(
-        route,
-        method = method.as_str(),
-        sunset = "2027-07-27T00:00:00Z",
-        "deprecated endpoint used"
-    );
-    ::metrics::counter!(
-        METRICS_DEPRECATED_ENDPOINT_REQUESTS,
-        "route" => route,
-        "method" => method.to_string()
-    )
-    .increment(1);
-
-    let mut response = next.run(request).await;
-    response.headers_mut().insert("deprecation", DEPRECATION);
-    response.headers_mut().insert("sunset", SUNSET);
-    response
 }

--- a/services/common/src/axum/server_layers/deprecation.rs
+++ b/services/common/src/axum/server_layers/deprecation.rs
@@ -10,6 +10,8 @@ pub const METRICS_DEPRECATED_ENDPOINT_REQUESTS: &str = "http.deprecated_endpoint
 
 /// The date these endpoints were formally marked as deprecated, encoded as an
 /// RFC 9651 date per RFC 9745.
+///
+/// The timestamp represents the date: Mon, 27 Jul 2026 00:00:00 GMT
 const DEPRECATION: HeaderValue = HeaderValue::from_static("@1785110400");
 /// One year after formal deprecation, encoded as an HTTP-date per RFC 8594.
 const SUNSET: HeaderValue = HeaderValue::from_static("Tue, 27 Jul 2027 00:00:00 GMT");

--- a/services/common/src/axum/server_layers/deprecation.rs
+++ b/services/common/src/axum/server_layers/deprecation.rs
@@ -1,0 +1,52 @@
+use ::axum::{
+    extract::{MatchedPath, Request},
+    http::HeaderValue,
+    middleware::Next,
+    response::Response,
+};
+
+/// Counter for requests to HTTP endpoints scheduled for removal.
+pub const METRICS_DEPRECATED_ENDPOINT_REQUESTS: &str = "http.deprecated_endpoint_requests";
+
+/// The date these endpoints were formally marked as deprecated, encoded as an
+/// RFC 9651 date per RFC 9745.
+const DEPRECATION: HeaderValue = HeaderValue::from_static("@1785110400");
+/// One year after formal deprecation, encoded as an HTTP-date per RFC 8594.
+const SUNSET: HeaderValue = HeaderValue::from_static("Tue, 27 Jul 2027 00:00:00 GMT");
+
+pub fn describe_deprecated_endpoint_metrics() {
+    ::metrics::describe_counter!(
+        METRICS_DEPRECATED_ENDPOINT_REQUESTS,
+        ::metrics::Unit::Count,
+        "Number of requests to deprecated HTTP endpoints, labelled by route and method."
+    );
+}
+
+/// Adds deprecation metadata and records use of an endpoint scheduled for removal.
+pub async fn deprecated_endpoint_middleware(request: Request, next: Next) -> Response {
+    let method = request.method().clone();
+    let route = request
+        .extensions()
+        .get::<MatchedPath>()
+        .map(MatchedPath::as_str)
+        .unwrap_or("UNKNOWN")
+        .to_string();
+
+    tracing::warn!(
+        route,
+        method = method.as_str(),
+        sunset = "2027-07-27T00:00:00Z",
+        "deprecated endpoint used"
+    );
+    ::metrics::counter!(
+        METRICS_DEPRECATED_ENDPOINT_REQUESTS,
+        "route" => route,
+        "method" => method.to_string()
+    )
+    .increment(1);
+
+    let mut response = next.run(request).await;
+    response.headers_mut().insert("deprecation", DEPRECATION);
+    response.headers_mut().insert("sunset", SUNSET);
+    response
+}

--- a/services/common/src/axum/server_layers/mod.rs
+++ b/services/common/src/axum/server_layers/mod.rs
@@ -5,7 +5,7 @@ mod trace;
 
 pub use deprecation::{
     Deprecation, DeprecationLayer, DeprecationService, METRICS_DEPRECATED_ENDPOINT_REQUESTS,
-    V2RecoveryAgentDeprecation, V2RecoveryAgentDeprecationLayer,
+    V1RecoveryAgentMethodsDeprecation, V1RecoveryAgentMethodsDeprecationLayer,
     describe_deprecated_endpoint_metrics,
 };
 pub use request_metrics::{

--- a/services/common/src/axum/server_layers/mod.rs
+++ b/services/common/src/axum/server_layers/mod.rs
@@ -4,7 +4,8 @@ mod timeout;
 mod trace;
 
 pub use deprecation::{
-    METRICS_DEPRECATED_ENDPOINT_REQUESTS, deprecated_endpoint_middleware,
+    Deprecation, DeprecationLayer, DeprecationService, METRICS_DEPRECATED_ENDPOINT_REQUESTS,
+    V2RecoveryAgentDeprecation, V2RecoveryAgentDeprecationLayer,
     describe_deprecated_endpoint_metrics,
 };
 pub use request_metrics::{

--- a/services/common/src/axum/server_layers/mod.rs
+++ b/services/common/src/axum/server_layers/mod.rs
@@ -1,7 +1,12 @@
+mod deprecation;
 mod request_metrics;
 mod timeout;
 mod trace;
 
+pub use deprecation::{
+    METRICS_DEPRECATED_ENDPOINT_REQUESTS, deprecated_endpoint_middleware,
+    describe_deprecated_endpoint_metrics,
+};
 pub use request_metrics::{
     METRICS_HTTP_LATENCY_MS, describe_http_request_metrics, request_latency_middleware,
 };

--- a/services/common/src/lib.rs
+++ b/services/common/src/lib.rs
@@ -12,8 +12,9 @@ pub use self::{
         },
     },
     axum::server_layers::{
-        METRICS_HTTP_LATENCY_MS, describe_http_request_metrics, request_latency_middleware,
-        timeout_layer, trace_layer,
+        METRICS_DEPRECATED_ENDPOINT_REQUESTS, METRICS_HTTP_LATENCY_MS,
+        deprecated_endpoint_middleware, describe_deprecated_endpoint_metrics,
+        describe_http_request_metrics, request_latency_middleware, timeout_layer, trace_layer,
     },
 };
 

--- a/services/common/src/lib.rs
+++ b/services/common/src/lib.rs
@@ -12,9 +12,10 @@ pub use self::{
         },
     },
     axum::server_layers::{
-        METRICS_DEPRECATED_ENDPOINT_REQUESTS, METRICS_HTTP_LATENCY_MS,
-        deprecated_endpoint_middleware, describe_deprecated_endpoint_metrics,
-        describe_http_request_metrics, request_latency_middleware, timeout_layer, trace_layer,
+        Deprecation, DeprecationLayer, DeprecationService, METRICS_DEPRECATED_ENDPOINT_REQUESTS,
+        METRICS_HTTP_LATENCY_MS, V2RecoveryAgentDeprecation, V2RecoveryAgentDeprecationLayer,
+        describe_deprecated_endpoint_metrics, describe_http_request_metrics,
+        request_latency_middleware, timeout_layer, trace_layer,
     },
 };
 

--- a/services/common/src/lib.rs
+++ b/services/common/src/lib.rs
@@ -13,9 +13,9 @@ pub use self::{
     },
     axum::server_layers::{
         Deprecation, DeprecationLayer, DeprecationService, METRICS_DEPRECATED_ENDPOINT_REQUESTS,
-        METRICS_HTTP_LATENCY_MS, V2RecoveryAgentDeprecation, V2RecoveryAgentDeprecationLayer,
-        describe_deprecated_endpoint_metrics, describe_http_request_metrics,
-        request_latency_middleware, timeout_layer, trace_layer,
+        METRICS_HTTP_LATENCY_MS, V1RecoveryAgentMethodsDeprecation,
+        V1RecoveryAgentMethodsDeprecationLayer, describe_deprecated_endpoint_metrics,
+        describe_http_request_metrics, request_latency_middleware, timeout_layer, trace_layer,
     },
 };
 

--- a/services/common/tests/deprecation.rs
+++ b/services/common/tests/deprecation.rs
@@ -2,17 +2,24 @@ use axum::{
     Router,
     body::Body,
     http::{Request, StatusCode},
-    middleware::from_fn,
     routing::get,
 };
 use metrics_util::debugging::{DebugValue, DebuggingRecorder};
 use tower::ServiceExt;
 use world_id_services_common::{
-    METRICS_DEPRECATED_ENDPOINT_REQUESTS, deprecated_endpoint_middleware,
+    Deprecation, DeprecationLayer, METRICS_DEPRECATED_ENDPOINT_REQUESTS,
 };
 
+struct TestDeprecation;
+
+impl Deprecation for TestDeprecation {
+    const ID: &'static str = "test_deprecation";
+    const DEPRECATED_AT: &'static str = "@1785110400";
+    const SUNSET: &'static str = "Tue, 27 Jul 2027 00:00:00 GMT";
+}
+
 #[tokio::test]
-async fn deprecated_endpoint_adds_headers_and_records_usage() {
+async fn deprecation_layer_adds_headers_and_records_usage() {
     let recorder = DebuggingRecorder::new();
     let snapshotter = recorder.snapshotter();
     recorder.install().expect("install debugging recorder");
@@ -20,7 +27,7 @@ async fn deprecated_endpoint_adds_headers_and_records_usage() {
     let app = Router::new().route(
         "/deprecated",
         get(|| async { StatusCode::NO_CONTENT })
-            .route_layer(from_fn(deprecated_endpoint_middleware)),
+            .route_layer(DeprecationLayer::<TestDeprecation>::new()),
     );
 
     let response = app
@@ -54,6 +61,7 @@ async fn deprecated_endpoint_adds_headers_and_records_usage() {
             match value {
                 DebugValue::Counter(value)
                     if key.name() == METRICS_DEPRECATED_ENDPOINT_REQUESTS
+                        && has_label("deprecation", "test_deprecation")
                         && has_label("route", "/deprecated")
                         && has_label("method", "GET") =>
                 {

--- a/services/common/tests/deprecation.rs
+++ b/services/common/tests/deprecation.rs
@@ -1,0 +1,68 @@
+use axum::{
+    Router,
+    body::Body,
+    http::{Request, StatusCode},
+    middleware::from_fn,
+    routing::get,
+};
+use metrics_util::debugging::{DebugValue, DebuggingRecorder};
+use tower::ServiceExt;
+use world_id_services_common::{
+    METRICS_DEPRECATED_ENDPOINT_REQUESTS, deprecated_endpoint_middleware,
+};
+
+#[tokio::test]
+async fn deprecated_endpoint_adds_headers_and_records_usage() {
+    let recorder = DebuggingRecorder::new();
+    let snapshotter = recorder.snapshotter();
+    recorder.install().expect("install debugging recorder");
+
+    let app = Router::new().route(
+        "/deprecated",
+        get(|| async { StatusCode::NO_CONTENT })
+            .route_layer(from_fn(deprecated_endpoint_middleware)),
+    );
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/deprecated")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
+    assert_eq!(response.headers()["deprecation"], "@1785110400");
+    assert_eq!(
+        response.headers()["sunset"],
+        "Tue, 27 Jul 2027 00:00:00 GMT"
+    );
+
+    let count = snapshotter
+        .snapshot()
+        .into_vec()
+        .into_iter()
+        .filter_map(|(key, _unit, _description, value)| {
+            let key = key.key();
+            let has_label = |name: &str, expected: &str| {
+                key.labels()
+                    .any(|label| label.key() == name && label.value() == expected)
+            };
+
+            match value {
+                DebugValue::Counter(value)
+                    if key.name() == METRICS_DEPRECATED_ENDPOINT_REQUESTS
+                        && has_label("route", "/deprecated")
+                        && has_label("method", "GET") =>
+                {
+                    Some(value)
+                }
+                _ => None,
+            }
+        })
+        .sum::<u64>();
+
+    assert_eq!(count, 1);
+}

--- a/services/gateway/src/metrics.rs
+++ b/services/gateway/src/metrics.rs
@@ -31,6 +31,7 @@ pub const METRICS_REQUEST_REJECTED: &str = "request.rejected";
 
 pub fn describe_metrics() {
     world_id_services_common::describe_http_request_metrics();
+    world_id_services_common::describe_deprecated_endpoint_metrics();
 
     ::metrics::describe_counter!(
         METRICS_ROOT_CACHE_HITS,

--- a/services/gateway/src/routes.rs
+++ b/services/gateway/src/routes.rs
@@ -49,6 +49,7 @@ use world_id_primitives::api_types::{
     UpdateRecoveryAgentRequest,
 };
 use world_id_registries::world_id::WorldIdRegistry::WorldIdRegistryInstance;
+use world_id_services_common::V2RecoveryAgentDeprecationLayer;
 
 // Health and status routes
 mod health;
@@ -180,17 +181,15 @@ pub(crate) async fn build_app(
         .route(
             "/initiate-recovery-agent-update",
             post(initiate_recovery_agent_update)
-                .route_layer(world_id_services_common::V2RecoveryAgentDeprecationLayer::new()),
+                .route_layer(V2RecoveryAgentDeprecationLayer::new()),
         )
         .route(
             "/cancel-recovery-agent-update",
-            post(cancel_recovery_agent_update)
-                .route_layer(world_id_services_common::V2RecoveryAgentDeprecationLayer::new()),
+            post(cancel_recovery_agent_update).route_layer(V2RecoveryAgentDeprecationLayer::new()),
         )
         .route(
             "/execute-recovery-agent-update",
-            post(execute_recovery_agent_update)
-                .route_layer(world_id_services_common::V2RecoveryAgentDeprecationLayer::new()),
+            post(execute_recovery_agent_update).route_layer(V2RecoveryAgentDeprecationLayer::new()),
         )
         // WIP-102 optimistic recovery agent update (gated on V2 contract)
         .route("/update-recovery-agent", post(update_recovery_agent))

--- a/services/gateway/src/routes.rs
+++ b/services/gateway/src/routes.rs
@@ -49,7 +49,7 @@ use world_id_primitives::api_types::{
     UpdateRecoveryAgentRequest,
 };
 use world_id_registries::world_id::WorldIdRegistry::WorldIdRegistryInstance;
-use world_id_services_common::V2RecoveryAgentDeprecationLayer;
+use world_id_services_common::V1RecoveryAgentMethodsDeprecationLayer;
 
 // Health and status routes
 mod health;
@@ -181,15 +181,17 @@ pub(crate) async fn build_app(
         .route(
             "/initiate-recovery-agent-update",
             post(initiate_recovery_agent_update)
-                .route_layer(V2RecoveryAgentDeprecationLayer::new()),
+                .route_layer(V1RecoveryAgentMethodsDeprecationLayer::new()),
         )
         .route(
             "/cancel-recovery-agent-update",
-            post(cancel_recovery_agent_update).route_layer(V2RecoveryAgentDeprecationLayer::new()),
+            post(cancel_recovery_agent_update)
+                .route_layer(V1RecoveryAgentMethodsDeprecationLayer::new()),
         )
         .route(
             "/execute-recovery-agent-update",
-            post(execute_recovery_agent_update).route_layer(V2RecoveryAgentDeprecationLayer::new()),
+            post(execute_recovery_agent_update)
+                .route_layer(V1RecoveryAgentMethodsDeprecationLayer::new()),
         )
         // WIP-102 optimistic recovery agent update (gated on V2 contract)
         .route("/update-recovery-agent", post(update_recovery_agent))

--- a/services/gateway/src/routes.rs
+++ b/services/gateway/src/routes.rs
@@ -179,21 +179,18 @@ pub(crate) async fn build_app(
         // recovery agent management
         .route(
             "/initiate-recovery-agent-update",
-            post(initiate_recovery_agent_update).route_layer(from_fn(
-                world_id_services_common::deprecated_endpoint_middleware,
-            )),
+            post(initiate_recovery_agent_update)
+                .route_layer(world_id_services_common::V2RecoveryAgentDeprecationLayer::new()),
         )
         .route(
             "/cancel-recovery-agent-update",
-            post(cancel_recovery_agent_update).route_layer(from_fn(
-                world_id_services_common::deprecated_endpoint_middleware,
-            )),
+            post(cancel_recovery_agent_update)
+                .route_layer(world_id_services_common::V2RecoveryAgentDeprecationLayer::new()),
         )
         .route(
             "/execute-recovery-agent-update",
-            post(execute_recovery_agent_update).route_layer(from_fn(
-                world_id_services_common::deprecated_endpoint_middleware,
-            )),
+            post(execute_recovery_agent_update)
+                .route_layer(world_id_services_common::V2RecoveryAgentDeprecationLayer::new()),
         )
         // WIP-102 optimistic recovery agent update (gated on V2 contract)
         .route("/update-recovery-agent", post(update_recovery_agent))

--- a/services/gateway/src/routes.rs
+++ b/services/gateway/src/routes.rs
@@ -179,15 +179,21 @@ pub(crate) async fn build_app(
         // recovery agent management
         .route(
             "/initiate-recovery-agent-update",
-            post(initiate_recovery_agent_update),
+            post(initiate_recovery_agent_update).route_layer(from_fn(
+                world_id_services_common::deprecated_endpoint_middleware,
+            )),
         )
         .route(
             "/cancel-recovery-agent-update",
-            post(cancel_recovery_agent_update),
+            post(cancel_recovery_agent_update).route_layer(from_fn(
+                world_id_services_common::deprecated_endpoint_middleware,
+            )),
         )
         .route(
             "/execute-recovery-agent-update",
-            post(execute_recovery_agent_update),
+            post(execute_recovery_agent_update).route_layer(from_fn(
+                world_id_services_common::deprecated_endpoint_middleware,
+            )),
         )
         // WIP-102 optimistic recovery agent update (gated on V2 contract)
         .route("/update-recovery-agent", post(update_recovery_agent))

--- a/services/indexer/src/metrics.rs
+++ b/services/indexer/src/metrics.rs
@@ -51,6 +51,7 @@ pub fn describe_metrics() {
     );
 
     world_id_services_common::describe_http_request_metrics();
+    world_id_services_common::describe_deprecated_endpoint_metrics();
 
     world_id_services_common::describe_provider_transport_metrics();
 }

--- a/services/indexer/src/routes.rs
+++ b/services/indexer/src/routes.rs
@@ -6,6 +6,7 @@ use world_id_primitives::api_types::{
     IndexerPackedAccountResponse, IndexerPendingRecoveryAgentResponse, IndexerQueryRequest,
     IndexerRecoveryAgentResponse, IndexerSignatureNonceResponse,
 };
+use world_id_services_common::V2RecoveryAgentDeprecationLayer;
 
 use crate::config::AppState;
 mod get_authenticator_pubkeys;
@@ -72,7 +73,7 @@ pub(crate) fn handler(state: AppState, request_timeout_secs: u64) -> Router {
         .route(
             "/pending-recovery-agent",
             axum::routing::post(get_pending_recovery_agent::handler)
-                .route_layer(world_id_services_common::V2RecoveryAgentDeprecationLayer::new()),
+                .route_layer(V2RecoveryAgentDeprecationLayer::new()),
         )
         .route("/health", axum::routing::get(health::handler))
         .route("/openapi.json", axum::routing::get(openapi))

--- a/services/indexer/src/routes.rs
+++ b/services/indexer/src/routes.rs
@@ -71,9 +71,8 @@ pub(crate) fn handler(state: AppState, request_timeout_secs: u64) -> Router {
         )
         .route(
             "/pending-recovery-agent",
-            axum::routing::post(get_pending_recovery_agent::handler).route_layer(from_fn(
-                world_id_services_common::deprecated_endpoint_middleware,
-            )),
+            axum::routing::post(get_pending_recovery_agent::handler)
+                .route_layer(world_id_services_common::V2RecoveryAgentDeprecationLayer::new()),
         )
         .route("/health", axum::routing::get(health::handler))
         .route("/openapi.json", axum::routing::get(openapi))

--- a/services/indexer/src/routes.rs
+++ b/services/indexer/src/routes.rs
@@ -6,7 +6,7 @@ use world_id_primitives::api_types::{
     IndexerPackedAccountResponse, IndexerPendingRecoveryAgentResponse, IndexerQueryRequest,
     IndexerRecoveryAgentResponse, IndexerSignatureNonceResponse,
 };
-use world_id_services_common::V2RecoveryAgentDeprecationLayer;
+use world_id_services_common::V1RecoveryAgentMethodsDeprecationLayer;
 
 use crate::config::AppState;
 mod get_authenticator_pubkeys;
@@ -73,7 +73,7 @@ pub(crate) fn handler(state: AppState, request_timeout_secs: u64) -> Router {
         .route(
             "/pending-recovery-agent",
             axum::routing::post(get_pending_recovery_agent::handler)
-                .route_layer(V2RecoveryAgentDeprecationLayer::new()),
+                .route_layer(V1RecoveryAgentMethodsDeprecationLayer::new()),
         )
         .route("/health", axum::routing::get(health::handler))
         .route("/openapi.json", axum::routing::get(openapi))

--- a/services/indexer/src/routes.rs
+++ b/services/indexer/src/routes.rs
@@ -71,7 +71,9 @@ pub(crate) fn handler(state: AppState, request_timeout_secs: u64) -> Router {
         )
         .route(
             "/pending-recovery-agent",
-            axum::routing::post(get_pending_recovery_agent::handler),
+            axum::routing::post(get_pending_recovery_agent::handler).route_layer(from_fn(
+                world_id_services_common::deprecated_endpoint_middleware,
+            )),
         )
         .route("/health", axum::routing::get(health::handler))
         .route("/openapi.json", axum::routing::get(openapi))


### PR DESCRIPTION
- **feat: track deprecated recovery agent endpoints**
- **clarify date in comment**
- **refactor: generalize endpoint deprecation layer**
- **qualify path**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches account-recovery API surfaces clients may depend on, but only adds headers and telemetry without changing handler behavior or removing routes.
> 
> **Overview**
> Introduces a reusable **`DeprecationLayer`** in `world_id_services_common` that marks responses with **`deprecation`** and **`sunset`** headers (RFC 9651 / 8594), emits a structured warning log, and increments **`http.deprecated_endpoint_requests`** labeled by deprecation id, route, and method.
> 
> **V1 recovery-agent management** is wired to this layer on **gateway** (`/initiate-recovery-agent-update`, `/cancel-recovery-agent-update`, `/execute-recovery-agent-update`) and **indexer** (`/pending-recovery-agent`), with sunset **27 Jul 2027**. Gateway and indexer metric registration now describe the new counter; an integration test verifies headers and metrics for a sample deprecation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fcb49f196d9199044ad309b160230d97e506c3ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->