### PR TITLE
chore: bump ruint and event-listener to clear cargo-deny advisories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3145,15 +3145,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "concurrent-queue"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "config"
 version = "0.15.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4058,11 +4049,10 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "5.4.1"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
- "concurrent-queue",
  "parking",
  "pin-project-lite",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1249,6 +1249,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-ff"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7a806ac6c8307b929df4645776290a50ee2aac754ad09d8bdf73391309e43af"
+dependencies = [
+ "ark-ff-asm 0.6.0",
+ "ark-ff-macros 0.6.0",
+ "ark-serialize 0.6.0",
+ "ark-std 0.6.0",
+ "digest 0.10.7",
+ "educe",
+ "num-bigint",
+ "num-traits",
+ "zeroize",
+]
+
+[[package]]
 name = "ark-ff-asm"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1273,6 +1290,16 @@ name = "ark-ff-asm"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
+dependencies = [
+ "quote",
+ "syn 2.0.116",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1479009684adc073dff49a1025d3a7065b317a9ead25aaaca38cdc70058ba8a2"
 dependencies = [
  "quote",
  "syn 2.0.116",
@@ -1308,6 +1335,19 @@ name = "ark-ff-macros"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09be120733ee33f7693ceaa202ca41accd5653b779563608f1234f78ae07c4b3"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.116",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a0691ed21ef00ef89c1e9bda832eba493dda3ec2f8d892fb25b705f73f06bb8"
 dependencies = [
  "num-bigint",
  "num-traits",
@@ -1468,6 +1508,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-serialize"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a74dd304fd536fb95d0a328e72be759209cc496a9da094c5bc56e5fea4f9e86b"
+dependencies = [
+ "ark-serialize-derive 0.6.0",
+ "ark-std 0.6.0",
+ "digest 0.10.7",
+ "num-bigint",
+ "serde_with",
+]
+
+[[package]]
 name = "ark-serialize-derive"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1483,6 +1536,17 @@ name = "ark-serialize-derive"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "213888f660fddcca0d257e88e54ac05bca01885f258ccdf695bafd77031bb69d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.116",
+]
+
+[[package]]
+name = "ark-serialize-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f153690697a2b91e5e1251ff98411ee5371500a111a0fd317a70e588eb300f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1543,6 +1607,16 @@ dependencies = [
  "num-traits",
  "rand 0.8.6",
  "rayon",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "367c9c827ed431bff6868b7aa926e05b16eb46603cc8b6e768e4a5553fa1d155"
+dependencies = [
+ "num-traits",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -3053,7 +3127,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -8515,14 +8589,15 @@ dependencies = [
 
 [[package]]
 name = "ruint"
-version = "1.17.2"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c141e807189ad38a07276942c6623032d3753c8859c146104ac2e4d68865945a"
+checksum = "f5e99bff0393163bb25029a6af25d3d8d202ba5b5438a74d1bd8789f5c822970"
 dependencies = [
  "alloy-rlp",
  "ark-ff 0.3.0",
  "ark-ff 0.4.2",
  "ark-ff 0.5.0",
+ "ark-ff 0.6.0",
  "bytemuck",
  "bytes",
  "fastrlp 0.3.1",
@@ -11876,7 +11951,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]


### PR DESCRIPTION
Clears the two advisories currently failing `Cargo deny (advisories)`. Lockfile-only — both bumps satisfy the existing version requirements, no manifest changes.

| Crate | Bump | Advisory |
| --- | --- | --- |
| `ruint` | 1.17.2 → 1.20.0 | `RUSTSEC-2026-0220` |
| `event-listener` | 5.4.1 → 5.4.2 | `RUSTSEC-2026-0221` |

Both advisories also fail on `main`, so this is not specific to any feature branch. `RUSTSEC-2026-0221` was published after this PR was first opened, which is why it arrives as a second commit.

### `ruint` — RUSTSEC-2026-0220

`Uint::overflowing_shl`/`overflowing_shr` returned false-negative overflow flags. The values themselves were correct, but the wrong flag propagates: `checked_shl`/`checked_shr` return `Some` instead of `None`, `strict_*` fail to panic, and `saturating_*` wrap instead of saturating. The bad `checked_shl` result also makes `to_base_be` (and string formatting) loop forever on no-alloc builds for non-limb-aligned widths.

No call sites of the affected shift APIs exist in `crates/`, `services/` or `tools/`, so a `deny.toml` entry would also have silenced this. Bumping was preferred because `ruint` is a direct workspace dependency (`Cargo.toml:82`) used by `world-id-primitives`, `world-id-proof`, `world-id-authenticator`, `world-id-issuer` and `world-id-indexer`.

Side effect: this adds `ark-ff 0.6.0` (and its `ark-serialize`/`ark-std` companions) to the lockfile alongside the existing 0.5 line. `cargo deny check bans` accepts it and the workspace compiles unchanged.

### `event-listener` — RUSTSEC-2026-0221

Unsoundness allowing `!Send` tags to cross thread boundaries via `StackSlot`. Reached on a production path via `async-lock` → `moka` → `taceo-oprf-service`, so not dev-only. The advisory lists `patched = [">= 5.4.2"]`, and 5.4.2 is a patch release that also drops `concurrent-queue`.

### Test plan

- [ ] `cargo deny check advisories` reports `advisories ok`
- [ ] `cargo deny check bans licenses sources` passes
- [ ] `cargo check --workspace --all-targets` is clean
- [ ] `cargo test -p world-id-primitives` passes
- [ ] MSRV job passes (the `ruint` bump could raise the minimum supported Rust version)