### PR TITLE
feat: add DeepFace Query Proof circuit in Noir with benchmarks

### DIFF
--- a/.github/workflows/noir-ci.yml
+++ b/.github/workflows/noir-ci.yml
@@ -13,6 +13,12 @@ jobs:
   test:
     name: Noir CI
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - ownership-proof
+          - deepface-query-proof
     defaults:
       run:
         working-directory: ./crates/proof/noir
@@ -22,4 +28,4 @@ jobs:
         with:
           # See https://github.com/worldfnd/provekit, a specific nargo toolchain version is required
           toolchain: v1.0.0-beta.11
-      - run: cd ownership-proof && nargo fmt --check && nargo test
+      - run: cd ${{ matrix.package }} && nargo fmt --check && nargo test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12807,6 +12807,7 @@ dependencies = [
  "provekit-r1cs-compiler",
  "provekit-verifier",
  "rand 0.8.6",
+ "rand_chacha 0.3.1",
  "rayon",
  "reqwest 0.12.28",
  "ruint",

--- a/crates/proof/Cargo.toml
+++ b/crates/proof/Cargo.toml
@@ -32,6 +32,12 @@ embed-ownership-prover = ["dep:provekit-r1cs-compiler"]
 embed-ownership-verifier = ["dep:provekit-r1cs-compiler"]
 embed-noir-artifacts = ["embed-ownership-prover", "embed-ownership-verifier"]
 
+# DeepFace Query Proof (billing gate for the Verifier TEE). Deliberately not part of
+# `embed-noir-artifacts`: the circuit is unaudited and the prover is multi-MB, so it is
+# only pulled in by consumers that explicitly want it (currently `zk-mobile-bench`).
+embed-deepface-query-prover = ["dep:provekit-r1cs-compiler"]
+embed-deepface-query-verifier = ["dep:provekit-r1cs-compiler"]
+
 # Embed everything
 embed-zk-artifacts = ["embed-zkeys", "embed-noir-artifacts"]
 
@@ -80,3 +86,4 @@ provekit-r1cs-compiler = { workspace = true, optional = true }
 
 [dev-dependencies]
 world-id-test-utils = { workspace = true }
+rand_chacha = { workspace = true }

--- a/crates/proof/README.md
+++ b/crates/proof/README.md
@@ -56,7 +56,7 @@ Same mechanism as the ownership proof features, for the DeepFace Query Proof
 (`noir/deepface-query-proof`) — the billing gate presented to the Verifier TEE.
 
 Deliberately **not** part of `embed-noir-artifacts`: the circuit is UNAUDITED and adds a
-558 KiB prover, so only consumers that explicitly want it pull it in (currently
+718 KiB prover, so only consumers that explicitly want it pull it in (currently
 `crates/zk-mobile-bench`). See `noir/deepface-query-proof/docs/benchmarks.md`.
 
 ##### Umbrellas

--- a/crates/proof/README.md
+++ b/crates/proof/README.md
@@ -50,6 +50,15 @@ the verifier. Requires `nargo` on PATH at the pinned version — use `nix develo
 noirup --version v1.0.0-beta.11
 ```
 
+##### `embed-deepface-query-prover` / `embed-deepface-query-verifier`
+
+Same mechanism as the ownership proof features, for the DeepFace Query Proof
+(`noir/deepface-query-proof`) — the billing gate presented to the Verifier TEE.
+
+Deliberately **not** part of `embed-noir-artifacts`: the circuit is UNAUDITED and adds a
+558 KiB prover, so only consumers that explicitly want it pull it in (currently
+`crates/zk-mobile-bench`). See `noir/deepface-query-proof/docs/benchmarks.md`.
+
 ##### Umbrellas
 
 - `embed-noir-artifacts` = ownership prover + verifier

--- a/crates/proof/build.rs
+++ b/crates/proof/build.rs
@@ -35,8 +35,20 @@ fn main() -> eyre::Result<()> {
         feature = "embed-ownership-prover",
         feature = "embed-ownership-verifier"
     ))]
-    if noir_artifacts::should_embed() {
-        noir_artifacts::setup(&out_dir)?;
+    if noir_artifacts::should_embed_ownership() {
+        noir_artifacts::setup(&out_dir, "noir/ownership-proof", "ownership_proof")?;
+    }
+
+    #[cfg(any(
+        feature = "embed-deepface-query-prover",
+        feature = "embed-deepface-query-verifier"
+    ))]
+    if noir_artifacts::should_embed_deepface_query() {
+        noir_artifacts::setup(
+            &out_dir,
+            "noir/deepface-query-proof",
+            "deepface_query_proof",
+        )?;
     }
 
     if env::var("CARGO_FEATURE_EMBED_ZKEYS").is_err() {
@@ -228,7 +240,9 @@ fn ark_compress_zkeys(out_dir: &Path) -> eyre::Result<()> {
 
 #[cfg(any(
     feature = "embed-ownership-prover",
-    feature = "embed-ownership-verifier"
+    feature = "embed-ownership-verifier",
+    feature = "embed-deepface-query-prover",
+    feature = "embed-deepface-query-verifier"
 ))]
 mod noir_artifacts {
     use std::process::Command;
@@ -242,11 +256,28 @@ mod noir_artifacts {
     /// and what provekit expects (see https://github.com/worldfnd/provekit).
     const REQUIRED_NARGO_VERSION: &str = "1.0.0-beta.11";
 
-    pub(super) fn should_embed() -> bool {
-        let target_arch = env::var("CARGO_CFG_TARGET_ARCH").ok();
-        target_arch.as_deref() != Some("wasm32")
+    fn is_native() -> bool {
+        env::var("CARGO_CFG_TARGET_ARCH").ok().as_deref() != Some("wasm32")
+    }
+
+    #[cfg(any(
+        feature = "embed-ownership-prover",
+        feature = "embed-ownership-verifier"
+    ))]
+    pub(super) fn should_embed_ownership() -> bool {
+        is_native()
             && (env::var_os("CARGO_FEATURE_EMBED_OWNERSHIP_PROVER").is_some()
                 || env::var_os("CARGO_FEATURE_EMBED_OWNERSHIP_VERIFIER").is_some())
+    }
+
+    #[cfg(any(
+        feature = "embed-deepface-query-prover",
+        feature = "embed-deepface-query-verifier"
+    ))]
+    pub(super) fn should_embed_deepface_query() -> bool {
+        is_native()
+            && (env::var_os("CARGO_FEATURE_EMBED_DEEPFACE_QUERY_PROVER").is_some()
+                || env::var_os("CARGO_FEATURE_EMBED_DEEPFACE_QUERY_VERIFIER").is_some())
     }
 
     /// Checks that `nargo` is on PATH and is exactly [`REQUIRED_NARGO_VERSION`].
@@ -282,14 +313,17 @@ mod noir_artifacts {
         Ok(())
     }
 
-    /// Builds the Noir ownership proof artifacts ad-hoc with `nargo` and the
+    /// Builds a Noir package's ProveKit artifacts ad-hoc with `nargo` and the
     /// provekit R1CS compiler. This is the only way to obtain them: the
     /// proving/verifying keys must come from the checked-in circuit source, built
     /// with the pinned nargo toolchain (see `flake.nix`), so every builder
     /// produces identical bytes.
-    pub(super) fn setup(out_dir: &Path) -> eyre::Result<()> {
+    ///
+    /// `package_dir` is relative to the crate manifest, `package_name` is the Nargo
+    /// package name, which also names the emitted `.pkp`/`.pkv`.
+    pub(super) fn setup(out_dir: &Path, package_dir: &str, package_name: &str) -> eyre::Result<()> {
         let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR")?);
-        let circuit_dir = manifest_dir.join("noir/ownership-proof");
+        let circuit_dir = manifest_dir.join(package_dir);
 
         println!(
             "cargo:rerun-if-changed={}",
@@ -310,21 +344,22 @@ mod noir_artifacts {
 
         if !nargo_output.status.success() {
             let stderr = String::from_utf8_lossy(&nargo_output.stderr);
-            eyre::bail!("nargo compile failed:\n{stderr}");
+            eyre::bail!("nargo compile failed for {package_name}:\n{stderr}");
         }
 
-        let scheme = NoirProofScheme::from_file(circuit_dir.join("target/ownership_proof.json"))
-            .map_err(|e| eyre::eyre!(e.to_string()))?;
+        let scheme =
+            NoirProofScheme::from_file(circuit_dir.join(format!("target/{package_name}.json")))
+                .map_err(|e| eyre::eyre!(e.to_string()))?;
 
         provekit_common::file::write(
             &Prover::from_noir_proof_scheme(scheme.clone()),
-            &out_dir.join("ownership_proof.pkp"),
+            &out_dir.join(format!("{package_name}.pkp")),
         )
         .map_err(|e| eyre::eyre!(e.to_string()))?;
 
         provekit_common::file::write(
             &Verifier::from_noir_proof_scheme(scheme),
-            &out_dir.join("ownership_proof.pkv"),
+            &out_dir.join(format!("{package_name}.pkv")),
         )
         .map_err(|e| eyre::eyre!(e.to_string()))?;
 

--- a/crates/proof/noir/deepface-query-proof/.gitignore
+++ b/crates/proof/noir/deepface-query-proof/.gitignore
@@ -1,0 +1,1 @@
+artifacts/

--- a/crates/proof/noir/deepface-query-proof/Nargo.toml
+++ b/crates/proof/noir/deepface-query-proof/Nargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "deepface_query_proof"
+type = "bin"
+descrption = "UNAUDITED. ALPHA. Noir Circuit Implementation of the DeepFace Query Proof (billing gate for the Verifier TEE) for the World ID Protocol."
+authors = ["@kilianglas"]
+license = "MIT"
+backend = "provekit"
+
+[dependencies]
+poseidon2 = { tag = "v0.5.0-beta.0", git = "https://github.com/TaceoLabs/noir-poseidon", directory = "poseidon2" }
+eddsa_poseidon2 = { tag = "taceo-oprf-v0.12.0", git = "https://github.com/TaceoLabs/oprf-service.git", directory = "noir/eddsa_poseidon2" }

--- a/crates/proof/noir/deepface-query-proof/docs/benchmarks.md
+++ b/crates/proof/noir/deepface-query-proof/docs/benchmarks.md
@@ -98,32 +98,48 @@ distribute or pin.
 
 The YABS doc names a public `PCP hash` input and says the TEE must check it "matches the
 one derived from `hashes.json`", without naming the signed credential field that carries
-it. Resolved as **one claim slot**, `claims[PCP_CLAIM_INDEX]`:
+it. It is **claim slot 0 of the iris (orb signup) credential**, which `signup-service`
+already issues.
 
-- `claims` are documented in `world-id-primitives` as "commitments to data (e.g. passport
-  image)" that the issuer attests about the subject -- exactly what a PCP commitment is.
-  A slot is set as `H(b"CLAIMS_HASH_V1" || bytes)`, which the enclave can derive from the
-  `hashes.json` it already holds.
-- `associated_data_commitment` is ruled out. The `Credential` docs make it issuer-private
+The PoH credential is not issued in this repo, so the schema has to be read there:
+`createClaimFromPcp` in `iris/app-api/handlers/utils.go` sets a single claim to
+`base64(hashes.json)`, and `Claims` entries are documented as "raw claim values (base64
+encoded)" that "the signer will compute the Poseidon2 hash for", with "indices assigned
+automatically (0, 1, 2, ...)". So the base64 is JSON transport, the pre-image is the
+`hashes.json` bytes, the value is `H(b"CLAIMS_HASH_V1" || hashes.json)`, and the slot is 0 --
+precisely what the enclave can derive from the `hashes.json` it already holds.
+
+Ruled out:
+
+- `associated_data_commitment`. The `Credential` docs make it issuer-private
   ("never exposed to RPs or others") with a structure "solely determined by the issuer", so
   binding the protocol to it would misuse the field *and* let an issuer break this circuit
   by changing its own encoding.
-- The aggregate `claims_hash` is ruled out because **the TEE cannot check it**: deriving it
-  needs every claim slot, and the TEE only ever sees the PCP. Publishing it would also leak
-  a handle to claims the TEE has no business learning.
+- The aggregate `claims_hash`, because **the TEE cannot check it**: deriving it needs every
+  claim slot, and the TEE only ever sees the PCP. Publishing it would also leak a handle to
+  claims the TEE has no business learning.
 
-Two caveats:
+Note `services/faux-issuer` sets no claims, so it says nothing about the real schema -- it
+is a stand-in, not the PoH issuer.
 
-- **No issuer populates `claims` today.** They are marked "For Future Use" in
-  `world-id-primitives`, and nothing in the repo -- the faux issuer included -- sets one.
-  This circuit is the first consumer, so `PCP_CLAIM_INDEX` is provisional and has to be
-  pinned down with the PoH credential schema. Changing it changes the keys.
+Three caveats:
+
+- **Claim indices are schema-scoped.** The *face* credential, from the same service, uses
+  slot 0 for a uniqueness flag and slot 1 for a score, written via `ClaimHashes` so they
+  land verbatim instead of Poseidon2-hashed. A slot index therefore only means something
+  alongside `issuer_schema_id`, which the TEE must pin to the PoH schema. Not directly
+  exploitable -- the face credential's slot 0 is the constant `1`, which cannot match a
+  `hashes.json` digest -- but the pin is what gives the index meaning.
+- **`hashes.json` is version-dependent.** The PCP versions doc specifies it as a flattened,
+  entry-sorted JSON of file to sha256, and several PCP versions are in circulation. The
+  enclave has to canonicalise identically to the orb for the version it is handed, or the
+  claim will not match.
 - `Credential::claims_hash` has **no domain separator**: all 16 slots are data, and the
   t16 output is taken at index 1 -- the same permutation and output index as
   `MerkleLeaf` in `circom/client_side_proofs/oprf_query.circom`, which *does* reserve a
-  capacity element for one. Claim values are issuer-set and domain-separated individually,
-  so this is not obviously exploitable, but the aggregate shares a hash domain with other
-  t16 uses and there is no spare slot to add a separator without a credential version bump.
+  capacity element for one. Iris claim values are domain-separated individually, but the
+  face domain writes claim values verbatim, so that mitigation is not universal, and there
+  is no spare slot to add a separator without a credential version bump.
 
 ## Cost of proving control of the World ID
 

--- a/crates/proof/noir/deepface-query-proof/docs/benchmarks.md
+++ b/crates/proof/noir/deepface-query-proof/docs/benchmarks.md
@@ -1,0 +1,157 @@
+# DeepFace Query Proof benchmarks
+
+Measurements for the `Query Proof` of the YABS "Updated Design", implemented in Noir and
+proved with ProveKit.
+
+All numbers below are reproducible from a clean checkout; see [Reproducing](#reproducing).
+
+## Environment
+
+| | |
+|---|---|
+| Machine | Apple M4 Max, 14 cores, 36 GiB |
+| OS | macOS 26.6 |
+| Toolchain | `nargo` 1.0.0-beta.11, ProveKit 0.1.4, `--release` |
+
+Numbers are from a laptop, not a phone. They bound the *shape* of the cost, not the
+end-user latency; see [Mobile devices](#mobile-devices) for the real-device path.
+
+## Circuit size
+
+| Circuit | ACIR opcodes |
+|---|---|
+| `deepface_query_proof` (billing tree depth 30) | 25,652 |
+| `ownership_proof`, for reference | 26,059 |
+
+The Query Proof costs about the same as the existing WIP-103 ownership proof.
+
+### Cost by billing tree depth
+
+| Billing tree depth | ACIR opcodes |
+|---|---|
+| 10 | 18,452 |
+| 20 | 22,052 |
+| 30 | 25,652 |
+
+Exactly linear: **14,852 fixed + 360 per level**. The fixed part is the credential
+signature check, the session id commitment and the nonce binding.
+
+Depth 30 is what this package ships, to keep the comparison against the registry-sized
+trees honest. It is not what the design needs: the billing tree holds only the humans
+enrolled under one `(rp_id, period)` pair, so depth `ceil(log2(n))` suffices. At the Zoom
+plugin's 100 World IDs per seat, 100 seats is 10,000 leaves, i.e. depth 14 and **19,892
+opcodes — 22% cheaper than depth 30**. Sizing the tree to the purchased quota is free
+performance.
+
+## Proving
+
+One benchmark per process, 1 warmup + 3 measured iterations.
+
+| Benchmark | Mean | Min | Max | Process peak RSS |
+|---|---|---|---|---|
+| `bench_deepface_query_proof_generation` (cold) | 0.354 s | 0.326 s | 0.406 s | 113 MiB |
+| `bench_deepface_query_cached_proof_generation` | 0.235 s | 0.230 s | 0.241 s | 102 MiB |
+
+- *cold* includes fixture generation, deserializing the embedded prover, witness
+  generation and proving. It is the path a client hits on its first DeepFace request of a
+  billing period.
+- *cached* skips fixture setup and prover deserialization, so it is witness generation
+  plus proving, and one clone of the prover, which
+  `provekit_prover::Prove::prove` requires because it consumes the prover.
+
+Verification is measured by `cargo test --release --test deepface_query_proof`: 7 tests,
+each of which proves and verifies once, complete in 0.40 s total.
+
+### Methodology note
+
+Run **one benchmark per process**. Running the cold and cached benchmarks in a single
+process inflated both (0.872 s and 1.473 s mean) and pushed max to 1.8 s, because they
+share the allocator and the process-wide ProveKit NTT tables. The isolated numbers above
+are the ones to quote. `run_local` takes benchmark names as arguments for this reason.
+
+## Artifact size
+
+This is where the Noir/ProveKit choice pays off, and it contradicts the trade-off recorded
+in the YABS doc ("needs a Circom circuit which needs a heavyweight artifact to be shipped
+with the app").
+
+| Artifact | Size |
+|---|---|
+| `deepface_query_proof.pkp` (prover) | 558 KiB |
+| `deepface_query_proof.pkv` (verifier) | 340 KiB |
+| `OPRFQuery.arks.zkey` + graph, for reference | 11.4 MiB |
+| `OPRFNullifier.arks.zkey` + graph, for reference | 26.7 MiB |
+
+The prover is **~49x smaller** than the Circom nullifier material. There is also no
+trusted setup: the artifacts are derived from the checked-in Noir source by the ProveKit
+R1CS compiler at build time, so there is no ceremony to run and no ceremony output to
+distribute or pin.
+
+## Cost of proving control of the World ID
+
+The circuit deliberately does not prove that the prover controls the `mt_index` it opens
+the billing leaf to — no `WorldIDRegistry` inclusion proof and no authenticator signature.
+See the module docs in `src/main.nr`.
+
+Closing that gap means adding exactly the `ownership_proof` circuit's constraints. Since
+that circuit measures 26,059 opcodes and the two share only the session id commitment,
+adding it roughly **doubles the circuit, to about 50,000 opcodes**, and by the linearity
+above, proving time with it. That is an estimate from the two measured circuit sizes, not
+a measurement of a combined circuit.
+
+Whether it is worth paying is a design question, not a performance one: without it,
+soundness rests on `r` and the credential being secrets only the holder has.
+
+## Mobile devices
+
+Yes, this can be benchmarked on real devices, and the plumbing is in place.
+
+`crates/zk-mobile-bench` drives [mobench](https://github.com/worldcoin/mobile-bench-rs) on
+BrowserStack, and the two benchmark functions above are registered there alongside the
+existing Circom ones. The prover is loaded from the binary via
+`embed-deepface-query-prover`, so nothing has to be fetched at runtime on device.
+
+```sh
+cargo-mobench run \
+  --target ios \
+  --function zk_mobile_bench::bench_deepface_query_proof_generation \
+  --iterations 30 --warmup 5 \
+  --devices "iPhone 11-13" \
+  --crate-path crates/zk-mobile-bench \
+  --release --fetch
+```
+
+In CI, `/mobench platform=both iterations=30 warmup=5` on a PR, or the `bench` label.
+Note that `mobile-bench.yml` lists the benchmark functions explicitly via the `functions`
+input, so the two new ones must be added there before CI picks them up.
+
+Two caveats before trusting a device run:
+
+- The existing mobile benchmarks are Circom/Groth16. These two are the first ProveKit
+  benchmarks in the crate, so an iOS/Android build of the ProveKit prover has not been
+  exercised here.
+- Peak RSS is the number to watch on device, not time. 102 MiB of process peak on a laptop
+  is comfortable; iOS jetsam limits are far tighter than the headroom that suggests.
+
+## Reproducing
+
+```sh
+# Circuit size and unit tests
+cd crates/proof/noir/deepface-query-proof
+nargo test
+nargo info
+
+# Correctness, including negative controls
+cargo test -p world-id-proof --release \
+  --features embed-deepface-query-prover,embed-deepface-query-verifier \
+  --test deepface_query_proof
+
+# Proving, one benchmark per process
+cargo run -p zk-mobile-bench --example run_local --release -- \
+  bench_deepface_query_proof_generation
+cargo run -p zk-mobile-bench --example run_local --release -- \
+  bench_deepface_query_cached_proof_generation
+```
+
+`nargo` must be exactly 1.0.0-beta.11 (`nix develop`, or
+`noirup --version v1.0.0-beta.11`); `crates/proof/build.rs` fails the build otherwise.

--- a/crates/proof/noir/deepface-query-proof/docs/benchmarks.md
+++ b/crates/proof/noir/deepface-query-proof/docs/benchmarks.md
@@ -20,7 +20,7 @@ end-user latency; see [Mobile devices](#mobile-devices) for the real-device path
 
 | Circuit | ACIR opcodes |
 |---|---|
-| `deepface_query_proof` (billing tree depth 30) | 25,652 |
+| `deepface_query_proof` (billing tree depth 30) | 26,520 |
 | `ownership_proof`, for reference | 26,059 |
 
 The Query Proof costs about the same as the existing WIP-103 ownership proof.
@@ -29,19 +29,26 @@ The Query Proof costs about the same as the existing WIP-103 ownership proof.
 
 | Billing tree depth | ACIR opcodes |
 |---|---|
-| 10 | 18,452 |
-| 20 | 22,052 |
-| 30 | 25,652 |
+| 10 | 19,320 |
+| 20 | 22,920 |
+| 30 | 26,520 |
 
-Exactly linear: **14,852 fixed + 360 per level**. The fixed part is the credential
-signature check, the session id commitment and the nonce binding.
+Exactly linear: **15,720 fixed + 360 per level**. The fixed part is the credential
+signature check, the claims-hash opening, the session id commitment and the nonce binding.
 
 Depth 30 is what this package ships, to keep the comparison against the registry-sized
 trees honest. It is not what the design needs: the billing tree holds only the humans
 enrolled under one `(rp_id, period)` pair, so depth `ceil(log2(n))` suffices. At the Zoom
-plugin's 100 World IDs per seat, 100 seats is 10,000 leaves, i.e. depth 14 and **19,892
-opcodes — 22% cheaper than depth 30**. Sizing the tree to the purchased quota is free
-performance.
+plugin's 100 World IDs per seat, 100 seats is 10,000 leaves, i.e. depth 14 and **20,760
+opcodes -- 22% cheaper than depth 30**. Sizing the tree to the purchased quota is free
+performance, and the quota is already known at `purchase()` time.
+
+### Cost of opening a single claim
+
+Publishing `pcp_hash` as one claim slot and recomputing the aggregate `claims_hash`
+in-circuit -- rather than publishing the aggregate directly -- costs one Poseidon2 t16
+permutation: **868 opcodes**, 3.4% of the circuit. See
+[Which credential field `pcp_hash` is](#which-credential-field-pcp_hash-is).
 
 ## Proving
 
@@ -49,8 +56,8 @@ One benchmark per process, 1 warmup + 3 measured iterations.
 
 | Benchmark | Mean | Min | Max | Process peak RSS |
 |---|---|---|---|---|
-| `bench_deepface_query_proof_generation` (cold) | 0.354 s | 0.326 s | 0.406 s | 113 MiB |
-| `bench_deepface_query_cached_proof_generation` | 0.235 s | 0.230 s | 0.241 s | 102 MiB |
+| `bench_deepface_query_proof_generation` (cold) | 0.339 s | 0.335 s | 0.346 s | 117 MiB |
+| `bench_deepface_query_cached_proof_generation` | 0.234 s | 0.232 s | 0.236 s | 105 MiB |
 
 - *cold* includes fixture generation, deserializing the embedded prover, witness
   generation and proving. It is the path a client hits on its first DeepFace request of a
@@ -59,8 +66,8 @@ One benchmark per process, 1 warmup + 3 measured iterations.
   plus proving, and one clone of the prover, which
   `provekit_prover::Prove::prove` requires because it consumes the prover.
 
-Verification is measured by `cargo test --release --test deepface_query_proof`: 7 tests,
-each of which proves and verifies once, complete in 0.40 s total.
+Verification is measured by `cargo test --release --test deepface_query_proof`: 9 tests,
+each of which proves and verifies once, complete in 0.46 s total.
 
 ### Methodology note
 
@@ -77,30 +84,62 @@ with the app").
 
 | Artifact | Size |
 |---|---|
-| `deepface_query_proof.pkp` (prover) | 558 KiB |
-| `deepface_query_proof.pkv` (verifier) | 340 KiB |
+| `deepface_query_proof.pkp` (prover) | 718 KiB |
+| `deepface_query_proof.pkv` (verifier) | 419 KiB |
 | `OPRFQuery.arks.zkey` + graph, for reference | 11.4 MiB |
 | `OPRFNullifier.arks.zkey` + graph, for reference | 26.7 MiB |
 
-The prover is **~49x smaller** than the Circom nullifier material. There is also no
+The prover is **~38x smaller** than the Circom nullifier material. There is also no
 trusted setup: the artifacts are derived from the checked-in Noir source by the ProveKit
 R1CS compiler at build time, so there is no ceremony to run and no ceremony output to
 distribute or pin.
 
+## Which credential field `pcp_hash` is
+
+The YABS doc names a public `PCP hash` input and says the TEE must check it "matches the
+one derived from `hashes.json`", without naming the signed credential field that carries
+it. Resolved as **one claim slot**, `claims[PCP_CLAIM_INDEX]`:
+
+- `claims` are documented in `world-id-primitives` as "commitments to data (e.g. passport
+  image)" that the issuer attests about the subject -- exactly what a PCP commitment is.
+  A slot is set as `H(b"CLAIMS_HASH_V1" || bytes)`, which the enclave can derive from the
+  `hashes.json` it already holds.
+- `associated_data_commitment` is ruled out. The `Credential` docs make it issuer-private
+  ("never exposed to RPs or others") with a structure "solely determined by the issuer", so
+  binding the protocol to it would misuse the field *and* let an issuer break this circuit
+  by changing its own encoding.
+- The aggregate `claims_hash` is ruled out because **the TEE cannot check it**: deriving it
+  needs every claim slot, and the TEE only ever sees the PCP. Publishing it would also leak
+  a handle to claims the TEE has no business learning.
+
+Two caveats:
+
+- **No issuer populates `claims` today.** They are marked "For Future Use" in
+  `world-id-primitives`, and nothing in the repo -- the faux issuer included -- sets one.
+  This circuit is the first consumer, so `PCP_CLAIM_INDEX` is provisional and has to be
+  pinned down with the PoH credential schema. Changing it changes the keys.
+- `Credential::claims_hash` has **no domain separator**: all 16 slots are data, and the
+  t16 output is taken at index 1 -- the same permutation and output index as
+  `MerkleLeaf` in `circom/client_side_proofs/oprf_query.circom`, which *does* reserve a
+  capacity element for one. Claim values are issuer-set and domain-separated individually,
+  so this is not obviously exploitable, but the aggregate shares a hash domain with other
+  t16 uses and there is no spare slot to add a separator without a credential version bump.
+
 ## Cost of proving control of the World ID
 
 The circuit deliberately does not prove that the prover controls the `mt_index` it opens
-the billing leaf to — no `WorldIDRegistry` inclusion proof and no authenticator signature.
+the billing leaf to -- no `WorldIDRegistry` inclusion proof and no authenticator signature.
 See the module docs in `src/main.nr`.
 
-Closing that gap means adding exactly the `ownership_proof` circuit's constraints. Since
-that circuit measures 26,059 opcodes and the two share only the session id commitment,
-adding it roughly **doubles the circuit, to about 50,000 opcodes**, and by the linearity
-above, proving time with it. That is an estimate from the two measured circuit sizes, not
-a measurement of a combined circuit.
+Closing that gap in *this* circuit means adding the `ownership_proof` constraints. Since
+that circuit measures 26,059 opcodes and the two share only the session id commitment and
+the nonce binding, it would add roughly 25,800 -- **about doubling the circuit, to ~52,000
+opcodes**, and by the linearity above, proving time with it. That is an estimate from the
+two measured circuit sizes, not a measurement of a combined circuit.
 
-Whether it is worth paying is a design question, not a performance one: without it,
-soundness rests on `r` and the credential being secrets only the holder has.
+Whether to pay it here is a design question. The cheaper alternative is to keep ownership
+on the cold path -- enrollment already carries such a proof -- and add a rotation operation
+so a compromised session secret can be revoked without re-enrolling.
 
 ## Mobile devices
 
@@ -130,7 +169,7 @@ Two caveats before trusting a device run:
 - The existing mobile benchmarks are Circom/Groth16. These two are the first ProveKit
   benchmarks in the crate, so an iOS/Android build of the ProveKit prover has not been
   exercised here.
-- Peak RSS is the number to watch on device, not time. 102 MiB of process peak on a laptop
+- Peak RSS is the number to watch on device, not time. 105 MiB of process peak on a laptop
   is comfortable; iOS jetsam limits are far tighter than the headroom that suggests.
 
 ## Reproducing

--- a/crates/proof/noir/deepface-query-proof/src/commitment.nr
+++ b/crates/proof/noir/deepface-query-proof/src/commitment.nr
@@ -1,0 +1,26 @@
+use super::constants::DS_SESSION_COMMITMENT;
+use poseidon2::bn254::perm;
+
+/// Recomputes the session id commitment, which is the billing tree leaf.
+///
+/// `H(DS_C || mt_index || r)`, identical to `SessionId::commitment` in
+/// `world-id-primitives` and to `computed_id_commitment` in `oprf_nullifier.circom`.
+///
+/// Opening the leaf to `mt_index` is what stops one enrolled slot from being
+/// re-used for a different World ID.
+pub(crate) fn session_id_commitment(mt_index: Field, commitment_r: Field) -> Field {
+    let state = perm::x5_3([DS_SESSION_COMMITMENT, mt_index, commitment_r]);
+    state[1]
+}
+
+#[test]
+fn test_commitment_deterministic() {
+    assert_eq(session_id_commitment(1, 100), session_id_commitment(1, 100));
+}
+
+#[test]
+fn test_commitment_binds_both_inputs() {
+    let base = session_id_commitment(1, 100);
+    assert(base != session_id_commitment(2, 100));
+    assert(base != session_id_commitment(1, 200));
+}

--- a/crates/proof/noir/deepface-query-proof/src/constants.nr
+++ b/crates/proof/noir/deepface-query-proof/src/constants.nr
@@ -1,0 +1,21 @@
+// Maximum depth of the per-RP-per-period billing Merkle tree.
+//
+// The tree only ever holds the humans enrolled for one (rp_id, period) pair, so it is
+// far smaller than the `WorldIDRegistry` tree. It is set to the same value here so the
+// benchmark is directly comparable to the registry-sized trees used by the other
+// circuits; the per-level cost is reported in `docs/benchmarks.md`.
+pub global BILLING_MAX_DEPTH: u32 = 30;
+
+// b"H(id, r)" -- domain separator of the session id commitment.
+//
+// Same value and construction as `signal computed_id_commitment` in
+// `circom/client_side_proofs/oprf_nullifier.circom` and `SessionId::DS_C` in
+// `world-id-primitives`, so the leaf this circuit opens is exactly the
+// `SessionId::commitment` the authenticator already derives.
+pub global DS_SESSION_COMMITMENT: Field = 5199521648757207593;
+
+// b"H_CS(id, r)" -- domain separator of the credential subject commitment (`sub`).
+pub global DS_CREDENTIAL_SUB: Field = 87492525752134038588518953;
+
+// b"POSEIDON2+EDDSA-BJJ" -- domain separator of the credential signature message.
+pub global DS_CREDENTIAL_MESSAGE: Field = 1790969822004668215611014194230797064349043274;

--- a/crates/proof/noir/deepface-query-proof/src/constants.nr
+++ b/crates/proof/noir/deepface-query-proof/src/constants.nr
@@ -17,5 +17,15 @@ pub global DS_SESSION_COMMITMENT: Field = 5199521648757207593;
 // b"H_CS(id, r)" -- domain separator of the credential subject commitment (`sub`).
 pub global DS_CREDENTIAL_SUB: Field = 87492525752134038588518953;
 
+// Number of claim slots in a V1 credential (`Credential::MAX_CLAIMS`).
+pub global MAX_CLAIMS: u32 = 16;
+
+// Which claim slot carries the PCP commitment.
+//
+// PROVISIONAL. No issuer populates `claims` today, so no slot is spoken for yet; see
+// the module docs in `main.nr`. Changing this changes the circuit and therefore the
+// proving/verifying keys, so it needs to be fixed with the PoH credential schema.
+pub global PCP_CLAIM_INDEX: u32 = 0;
+
 // b"POSEIDON2+EDDSA-BJJ" -- domain separator of the credential signature message.
 pub global DS_CREDENTIAL_MESSAGE: Field = 1790969822004668215611014194230797064349043274;

--- a/crates/proof/noir/deepface-query-proof/src/constants.nr
+++ b/crates/proof/noir/deepface-query-proof/src/constants.nr
@@ -22,9 +22,15 @@ pub global MAX_CLAIMS: u32 = 16;
 
 // Which claim slot carries the PCP commitment.
 //
-// PROVISIONAL. No issuer populates `claims` today, so no slot is spoken for yet; see
-// the module docs in `main.nr`. Changing this changes the circuit and therefore the
-// proving/verifying keys, so it needs to be fixed with the PoH credential schema.
+// Slot 0 of the *iris* (orb signup) credential. `signup-service` issues exactly one claim
+// there, `base64(hashes.json)` passed as a raw `Claims` entry so the signer Poseidon2-hashes
+// it -- see the module docs in `main.nr`.
+//
+// Claim indices are scoped to the credential schema, not global: slot 0 of the *face*
+// credential is a uniqueness flag, not a PCP. `issuer_schema_id` is what disambiguates,
+// which is why it is a public input the TEE has to pin.
+//
+// Changing this changes the circuit and therefore the proving/verifying keys.
 pub global PCP_CLAIM_INDEX: u32 = 0;
 
 // b"POSEIDON2+EDDSA-BJJ" -- domain separator of the credential signature message.

--- a/crates/proof/noir/deepface-query-proof/src/credential.nr
+++ b/crates/proof/noir/deepface-query-proof/src/credential.nr
@@ -82,10 +82,7 @@ pub(crate) fn verify_credential(
     current_timestamp.assert_max_bit_size::<64>();
     genesis_issued_at_min.assert_max_bit_size::<64>();
 
-    assert(
-        current_timestamp as u64 < credential.expires_at as u64,
-        "Credential expired",
-    );
+    assert(current_timestamp as u64 < credential.expires_at as u64, "Credential expired");
     assert(
         genesis_issued_at_min as u64 <= credential.genesis_issued_at as u64,
         "Credential issued before the minimum genesis time",

--- a/crates/proof/noir/deepface-query-proof/src/credential.nr
+++ b/crates/proof/noir/deepface-query-proof/src/credential.nr
@@ -1,4 +1,4 @@
-use super::constants::{DS_CREDENTIAL_MESSAGE, DS_CREDENTIAL_SUB};
+use super::constants::{DS_CREDENTIAL_MESSAGE, DS_CREDENTIAL_SUB, MAX_CLAIMS, PCP_CLAIM_INDEX};
 use super::types::{CredentialWitness, PublicKey};
 use eddsa_poseidon2::verify_eddsa_poseidon2;
 use poseidon2::bn254::perm;
@@ -8,6 +8,29 @@ use poseidon2::bn254::perm;
 /// `user_id` is the `mt_index`, which is what binds the credential to one World ID.
 fn credential_sub(user_id: Field, blinding_factor: Field) -> Field {
     let state = perm::x5_3([DS_CREDENTIAL_SUB, user_id, blinding_factor]);
+    state[1]
+}
+
+/// Recomputes the credential's `claims_hash` from the PCP claim and the other slots.
+///
+/// Mirrors `Credential::claims_hash` in `world-id-primitives`: all `MAX_CLAIMS` slots are
+/// data (there is no capacity element reserved for a domain separator), permuted with
+/// Poseidon2 t16, output taken at index 1.
+///
+/// Opening a single slot -- rather than taking the aggregate `claims_hash` as the public
+/// input -- is what lets the TEE check the PCP: it can derive one claim from the
+/// `hashes.json` it already holds, but not the aggregate, which commits to claims it never
+/// sees. It also keeps the other claims private.
+fn claims_hash(pcp_claim: Field, other_claims: [Field; MAX_CLAIMS - 1]) -> Field {
+    let mut claims: [Field; MAX_CLAIMS] = [0; MAX_CLAIMS];
+    claims[PCP_CLAIM_INDEX] = pcp_claim;
+
+    for i in 0..MAX_CLAIMS - 1 {
+        let slot = if i < PCP_CLAIM_INDEX { i } else { i + 1 };
+        claims[slot] = other_claims[i];
+    }
+
+    let state = perm::x5_16(claims);
     state[1]
 }
 
@@ -39,9 +62,10 @@ fn credential_message(
 
 /// Verifies a Proof of Human credential and that it belongs to `mt_index`.
 ///
-/// `claims_hash` is passed in from the `pcp_hash` public input, so a valid proof ties
-/// that PCP hash to this `mt_index` -- an enrolled World ID cannot be used to verify a
-/// different human.
+/// `pcp_claim` is the `pcp_hash` public input. It is placed in slot `PCP_CLAIM_INDEX` and
+/// the credential's `claims_hash` is recomputed around it, so a valid proof ties that
+/// exact PCP commitment to this `mt_index` -- an enrolled World ID cannot be used to
+/// verify a different human.
 ///
 /// The two timestamp bounds are range checked before the `u64` comparisons so the casts
 /// are sound. `oprf_nullifier.circom` leaves the two public timestamps to be checked
@@ -52,18 +76,19 @@ pub(crate) fn verify_credential(
     mt_index: Field,
     issuer_schema_id: Field,
     issuer_pk: PublicKey,
-    claims_hash: Field,
+    pcp_claim: Field,
     current_timestamp: Field,
     genesis_issued_at_min: Field,
 ) {
     let sub = credential_sub(mt_index, credential.sub_blinding_factor);
+    let claims = claims_hash(pcp_claim, credential.other_claims);
 
     let message = credential_message(
         issuer_schema_id,
         sub,
         credential.genesis_issued_at,
         credential.expires_at,
-        claims_hash,
+        claims,
         credential.associated_data_hash,
         credential.cred_id,
     );

--- a/crates/proof/noir/deepface-query-proof/src/credential.nr
+++ b/crates/proof/noir/deepface-query-proof/src/credential.nr
@@ -1,0 +1,105 @@
+use super::constants::{DS_CREDENTIAL_MESSAGE, DS_CREDENTIAL_SUB};
+use super::types::{CredentialWitness, PublicKey};
+use eddsa_poseidon2::verify_eddsa_poseidon2;
+use poseidon2::bn254::perm;
+
+/// The credential subject commitment, `H(DS_CS_C || user_id || r)`.
+///
+/// `user_id` is the `mt_index`, which is what binds the credential to one World ID.
+fn credential_sub(user_id: Field, blinding_factor: Field) -> Field {
+    let state = perm::x5_3([DS_CREDENTIAL_SUB, user_id, blinding_factor]);
+    state[1]
+}
+
+/// The message the issuer signs over.
+///
+/// Mirrors the `Poseidon2(8)` layout of `CheckCredentialSignature` in
+/// `circom/client_side_proofs/oprf_nullifier.circom` field for field.
+fn credential_message(
+    issuer_schema_id: Field,
+    sub: Field,
+    genesis_issued_at: Field,
+    expires_at: Field,
+    claims_hash: Field,
+    associated_data_hash: Field,
+    cred_id: Field,
+) -> Field {
+    let state = perm::x5_8([
+        DS_CREDENTIAL_MESSAGE,
+        issuer_schema_id,
+        sub,
+        genesis_issued_at,
+        expires_at,
+        claims_hash,
+        associated_data_hash,
+        cred_id,
+    ]);
+    state[1]
+}
+
+/// Verifies a Proof of Human credential and that it belongs to `mt_index`.
+///
+/// `claims_hash` is passed in from the `pcp_hash` public input, so a valid proof ties
+/// that PCP hash to this `mt_index` -- an enrolled World ID cannot be used to verify a
+/// different human.
+///
+/// The two timestamp bounds are range checked before the `u64` comparisons so the casts
+/// are sound. `oprf_nullifier.circom` leaves the two public timestamps to be checked
+/// outside the proof; doing it in-circuit costs two 64-bit range checks and removes a
+/// caller obligation.
+pub(crate) fn verify_credential(
+    credential: CredentialWitness,
+    mt_index: Field,
+    issuer_schema_id: Field,
+    issuer_pk: PublicKey,
+    claims_hash: Field,
+    current_timestamp: Field,
+    genesis_issued_at_min: Field,
+) {
+    let sub = credential_sub(mt_index, credential.sub_blinding_factor);
+
+    let message = credential_message(
+        issuer_schema_id,
+        sub,
+        credential.genesis_issued_at,
+        credential.expires_at,
+        claims_hash,
+        credential.associated_data_hash,
+        credential.cred_id,
+    );
+
+    let is_valid = verify_eddsa_poseidon2(
+        issuer_pk.x,
+        issuer_pk.y,
+        credential.sig_s,
+        credential.sig_r,
+        message,
+    );
+    assert(is_valid, "Invalid credential signature");
+
+    credential.genesis_issued_at.assert_max_bit_size::<64>();
+    credential.expires_at.assert_max_bit_size::<64>();
+    current_timestamp.assert_max_bit_size::<64>();
+    genesis_issued_at_min.assert_max_bit_size::<64>();
+
+    assert(
+        current_timestamp as u64 < credential.expires_at as u64,
+        "Credential expired",
+    );
+    assert(
+        genesis_issued_at_min as u64 <= credential.genesis_issued_at as u64,
+        "Credential issued before the minimum genesis time",
+    );
+}
+
+#[test]
+fn test_credential_sub_binds_user_id() {
+    assert(credential_sub(1, 7) != credential_sub(2, 7));
+}
+
+#[test]
+fn test_credential_message_binds_claims_hash() {
+    let a = credential_message(1, 2, 3, 4, 5, 6, 7);
+    let b = credential_message(1, 2, 3, 4, 99, 6, 7);
+    assert(a != b);
+}

--- a/crates/proof/noir/deepface-query-proof/src/main.nr
+++ b/crates/proof/noir/deepface-query-proof/src/main.nr
@@ -22,6 +22,20 @@
 //! being secrets only the holder has. Adding the missing block is exactly the
 //! `ownership_proof` circuit, so its measured cost is the price of closing this gap --
 //! see `docs/benchmarks.md`.
+//!
+//! ## Which credential field `pcp_hash` is
+//!
+//! Resolved here as the credential's `claims_hash`, i.e. `hashes[0]` in
+//! `CheckCredentialSignature`. The YABS doc says only "Pub. `PCP hash`", and the TEE side
+//! says it must "match the one derived from `hashes.json`", which does not say which
+//! signed credential field carries it. The other candidate is
+//! `associated_data_commitment` (`hashes[1]`), whose construction is issuer-defined.
+//!
+//! Both are authenticated by the same issuer signature, so the choice does not change the
+//! circuit's cost or its security argument -- but it does have to match what the PoH
+//! issuer actually puts where, and what the enclave derives from `hashes.json`. Swapping
+//! it is a one-line change here plus the matching field in
+//! `DeepFaceQueryProofCircuitInput`.
 pub(crate) mod commitment;
 pub(crate) mod constants;
 pub(crate) mod credential;

--- a/crates/proof/noir/deepface-query-proof/src/main.nr
+++ b/crates/proof/noir/deepface-query-proof/src/main.nr
@@ -25,25 +25,36 @@
 //!
 //! ## Which credential field `pcp_hash` is
 //!
-//! `pcp_hash` is **one claim slot**, not the aggregate `claims_hash` and not
-//! `associated_data_commitment`:
+//! `pcp_hash` is **claim slot 0 of the iris (orb signup) credential**, which is what
+//! `signup-service` already issues. Its `createClaimFromPcp` sets a single claim to
+//! `base64(hashes.json)`, passed as a raw `Claims` entry so the credential signer
+//! Poseidon2-hashes it -- the base64 is JSON transport, so the pre-image is the
+//! `hashes.json` bytes and the value is `H(b"CLAIMS_HASH_V1" || hashes.json)`. That is
+//! exactly what the enclave can derive from the `hashes.json` it already holds. Claim
+//! indices are assigned in order from 0, and iris passes one claim, so slot 0 it is.
 //!
-//! - `claims` are documented as "commitments to data (e.g. passport image)" that the
-//!   issuer attests about the subject, which is exactly what a PCP commitment is. A slot
-//!   is set as `H(b"CLAIMS_HASH_V1" || bytes)`, so the enclave can derive it from the
-//!   `hashes.json` it already holds.
-//! - `associated_data_commitment` is ruled out: the `Credential` docs make it
-//!   issuer-private ("never exposed to RPs or others") with a structure "solely determined
-//!   by the issuer", so binding the protocol to it would both misuse the field and let the
-//!   issuer break this circuit by changing its own encoding.
-//! - The aggregate `claims_hash` is ruled out because the TEE cannot check it: deriving it
-//!   needs *every* claim slot, and the TEE only ever sees the PCP. Publishing it would
-//!   also leak a handle to claims the TEE has no business learning.
+//! Note the PoH credential is *not* issued in this repo -- `services/faux-issuer` is a
+//! stand-in and sets no claims, so it says nothing about the real schema.
 //!
-//! Caveat, and the reason `PCP_CLAIM_INDEX` is provisional: **no issuer populates `claims`
-//! today** -- they are marked "For Future Use" in `world-id-primitives` and nothing in the
-//! repo, the faux issuer included, sets one. So this circuit is the first consumer, and
-//! the slot index has to be pinned down together with the PoH credential schema.
+//! Ruled out:
+//!
+//! - `associated_data_commitment`: the `Credential` docs make it issuer-private ("never
+//!   exposed to RPs or others") with a structure "solely determined by the issuer", so
+//!   binding the protocol to it would both misuse the field and let the issuer break this
+//!   circuit by changing its own encoding.
+//! - The aggregate `claims_hash`: the TEE cannot check it, because deriving it needs
+//!   *every* claim slot and the TEE only ever sees the PCP. Publishing it would also leak a
+//!   handle to claims the TEE has no business learning.
+//!
+//! ## Claim indices are schema-scoped
+//!
+//! Slot 0 does not mean "PCP" in general. The *face* credential, issued by the same
+//! service, uses slot 0 for a uniqueness flag and slot 1 for a score, written through
+//! `ClaimHashes` so they land verbatim rather than Poseidon2-hashed. So a claim slot is
+//! only meaningful together with `issuer_schema_id`, which is a public input the TEE must
+//! pin to the PoH schema. Failing to pin it is not directly exploitable -- a face
+//! credential's slot 0 is the constant `1`, which cannot match a `hashes.json` digest --
+//! but the check is what makes the slot index mean anything.
 pub(crate) mod commitment;
 pub(crate) mod constants;
 pub(crate) mod credential;

--- a/crates/proof/noir/deepface-query-proof/src/main.nr
+++ b/crates/proof/noir/deepface-query-proof/src/main.nr
@@ -1,0 +1,85 @@
+//! DeepFace Query Proof -- the billing gate a user presents to the Verifier TEE.
+//!
+//! Implements the `Query Proof` of the YABS "Updated Design". The user proves, without
+//! revealing which human it is, that:
+//!
+//! 1. it is enrolled for billing under some `(rp_id, period)` -- the billing tree whose
+//!    `billing_root` the TEE holds in its host-fed root map, and from which `rp_id` and
+//!    `period` are inferred, so neither is an explicit input;
+//! 2. the enrolled billing leaf opens to *its* World ID (`mt_index`);
+//! 3. a valid, unexpired Proof of Human credential for that same `mt_index` carries
+//!    `pcp_hash` -- which is what stops one enrolled World ID from being used to verify a
+//!    different human.
+//!
+//! Everything identity-bearing (`mt_index`, `r`, the leaf, the path) is a witness. The
+//! public inputs are shared by everyone enrolled under that root, so requests from the
+//! same human are unlinkable to the TEE.
+//!
+//! ## Not proven here
+//!
+//! Control of `mt_index` is *not* proven: there is no `WorldIDRegistry` inclusion proof
+//! and no authenticator signature. Soundness therefore rests on `r` and the credential
+//! being secrets only the holder has. Adding the missing block is exactly the
+//! `ownership_proof` circuit, so its measured cost is the price of closing this gap --
+//! see `docs/benchmarks.md`.
+pub(crate) mod commitment;
+pub(crate) mod constants;
+pub(crate) mod credential;
+pub(crate) mod merkle_proof;
+pub(crate) mod types;
+
+use commitment::session_id_commitment;
+use constants::BILLING_MAX_DEPTH;
+use credential::verify_credential;
+use merkle_proof::compute_merkle_root_poseidon2;
+use types::{DeepFaceQueryProofInputs, PublicKey};
+
+pub fn main(
+    // Root of the per-RP-per-period billing Merkle tree. The TEE accepts it only if it is
+    // in the root map the host feeds it, which is what ties the proof to (rp_id, period).
+    billing_root: pub Field,
+    billing_depth: pub Field,
+    // Hash of the PCP this query is for. The TEE checks it against the hash it derives
+    // from `hashes.json` itself. It is the credential's `claims_hash`.
+    pcp_hash: pub Field,
+    // Proof of Human credential inputs the TEE has to see to judge the credential.
+    issuer_schema_id: pub Field,
+    issuer_pk: pub PublicKey,
+    current_timestamp: pub Field,
+    genesis_issued_at_min: pub Field,
+    // Nonce of the RP request, deduplicated by the host to stop replays.
+    nonce: pub Field,
+    inputs: DeepFaceQueryProofInputs<BILLING_MAX_DEPTH>,
+) {
+    // 1. The billing tree leaf is this human's session id commitment.
+    let leaf = session_id_commitment(inputs.mt_index, inputs.commitment_r);
+
+    // 2. That leaf is enrolled under `billing_root`.
+    let computed_root = compute_merkle_root_poseidon2(
+        leaf,
+        billing_depth,
+        inputs.billing_proof.mt_index,
+        inputs.billing_proof.siblings,
+    );
+    assert(computed_root == billing_root, "Billing inclusion proof failed");
+
+    // 3. A valid credential for the same `mt_index` carries `pcp_hash`.
+    verify_credential(
+        inputs.credential,
+        inputs.mt_index,
+        issuer_schema_id,
+        issuer_pk,
+        pcp_hash,
+        current_timestamp,
+        genesis_issued_at_min,
+    );
+
+    // SAFETY: The multiplication is constrained below, this is just to emulate the signal
+    // hash coming from Circom/Semaphore.
+    let nonce_squared = unsafe { unconstrained_mul(nonce, nonce) };
+    assert(nonce_squared == nonce * nonce, "Nonce dummy constraint failed");
+}
+
+unconstrained fn unconstrained_mul(a: Field, b: Field) -> Field {
+    a * b
+}

--- a/crates/proof/noir/deepface-query-proof/src/main.nr
+++ b/crates/proof/noir/deepface-query-proof/src/main.nr
@@ -25,17 +25,25 @@
 //!
 //! ## Which credential field `pcp_hash` is
 //!
-//! Resolved here as the credential's `claims_hash`, i.e. `hashes[0]` in
-//! `CheckCredentialSignature`. The YABS doc says only "Pub. `PCP hash`", and the TEE side
-//! says it must "match the one derived from `hashes.json`", which does not say which
-//! signed credential field carries it. The other candidate is
-//! `associated_data_commitment` (`hashes[1]`), whose construction is issuer-defined.
+//! `pcp_hash` is **one claim slot**, not the aggregate `claims_hash` and not
+//! `associated_data_commitment`:
 //!
-//! Both are authenticated by the same issuer signature, so the choice does not change the
-//! circuit's cost or its security argument -- but it does have to match what the PoH
-//! issuer actually puts where, and what the enclave derives from `hashes.json`. Swapping
-//! it is a one-line change here plus the matching field in
-//! `DeepFaceQueryProofCircuitInput`.
+//! - `claims` are documented as "commitments to data (e.g. passport image)" that the
+//!   issuer attests about the subject, which is exactly what a PCP commitment is. A slot
+//!   is set as `H(b"CLAIMS_HASH_V1" || bytes)`, so the enclave can derive it from the
+//!   `hashes.json` it already holds.
+//! - `associated_data_commitment` is ruled out: the `Credential` docs make it
+//!   issuer-private ("never exposed to RPs or others") with a structure "solely determined
+//!   by the issuer", so binding the protocol to it would both misuse the field and let the
+//!   issuer break this circuit by changing its own encoding.
+//! - The aggregate `claims_hash` is ruled out because the TEE cannot check it: deriving it
+//!   needs *every* claim slot, and the TEE only ever sees the PCP. Publishing it would
+//!   also leak a handle to claims the TEE has no business learning.
+//!
+//! Caveat, and the reason `PCP_CLAIM_INDEX` is provisional: **no issuer populates `claims`
+//! today** -- they are marked "For Future Use" in `world-id-primitives` and nothing in the
+//! repo, the faux issuer included, sets one. So this circuit is the first consumer, and
+//! the slot index has to be pinned down together with the PoH credential schema.
 pub(crate) mod commitment;
 pub(crate) mod constants;
 pub(crate) mod credential;

--- a/crates/proof/noir/deepface-query-proof/src/merkle_proof.nr
+++ b/crates/proof/noir/deepface-query-proof/src/merkle_proof.nr
@@ -1,0 +1,77 @@
+use poseidon2::bn254::perm;
+
+/// Recomputes a binary Merkle root in Poseidon2 compression mode.
+///
+/// Duplicated verbatim from `noir/ownership-proof/src/merkle_proof.nr`: that package is a
+/// `bin`, so its modules cannot be imported. Both must stay in sync with
+/// `circom/merkle_tree/binary_merkle_root.circom`, which is why extracting a shared Noir
+/// lib is tracked as a follow-up.
+///
+/// `merkle_leaf` is not duplicated -- the billing tree's leaf is the session id
+/// commitment, not a hashed authenticator key set.
+pub(crate) fn compute_merkle_root_poseidon2<let N: u32>(
+    leaf: Field,
+    depth: Field,
+    index: Field,
+    hashpath: [Field; N],
+) -> Field {
+    let mut current = leaf;
+    // we check index < 2^32 to allow the below cast
+    index.assert_max_bit_size::<32>();
+    let mut idx = index as u32;
+    // depth is public and checked outside of the circuit to be < 32 and < MAX_DEPTH
+    // we check it anyways below since it actually produces more efficient constraints
+    depth.assert_max_bit_size::<5>();
+    let depth_u32 = depth as u32;
+    assert(idx < (1 << depth_u32), "Index must be less than 2^depth");
+    assert(depth as u32 <= N);
+
+    for i in 0..N {
+        if i < depth_u32 {
+            let sibling = hashpath[i];
+            let is_right = idx & 1;
+
+            // Use branchless selection
+            let is_right_field = is_right as Field;
+            let diff = current - sibling;
+            let left = sibling + (diff * (1 - is_right_field));
+            let right = sibling + (diff * is_right_field);
+
+            let hash_state = perm::x5_2([left, right]);
+            current = hash_state[0] + left;
+
+            idx >>= 1;
+        }
+    }
+
+    current
+}
+
+#[test]
+fn test_compute_merkle_root_left_child() {
+    let leaf: Field = 123;
+    let sibling: Field = 456;
+
+    // index=0: leaf is the left child
+    let hash_state = perm::x5_2([leaf, sibling]);
+    let expected_root = hash_state[0] + leaf;
+
+    assert_eq(compute_merkle_root_poseidon2(leaf, 1, 0, [sibling]), expected_root);
+}
+
+#[test]
+fn test_compute_merkle_root_right_child() {
+    let leaf: Field = 123;
+    let sibling: Field = 456;
+
+    // index=1: leaf is the right child
+    let hash_state = perm::x5_2([sibling, leaf]);
+    let expected_root = hash_state[0] + sibling;
+
+    assert_eq(compute_merkle_root_poseidon2(leaf, 1, 1, [sibling]), expected_root);
+}
+
+#[test(should_fail_with = "Index must be less than 2^depth")]
+fn test_compute_merkle_root_index_out_of_range() {
+    let _ = compute_merkle_root_poseidon2(123, 1, 2, [456]);
+}

--- a/crates/proof/noir/deepface-query-proof/src/types.nr
+++ b/crates/proof/noir/deepface-query-proof/src/types.nr
@@ -10,10 +10,19 @@ pub struct MerkleProof<let MAX_DEPTH: u32> {
 
 /// The private part of a Proof of Human credential.
 ///
-/// `claims_hash` is deliberately absent: it is the `pcp_hash` public input, because the
-/// TEE has to compare it against the hash it derives from `hashes.json` itself.
+/// The aggregate `claims_hash` is absent by design: it is recomputed in-circuit from the
+/// `pcp_hash` public input plus `other_claims`, so the TEE checks the one claim it can
+/// derive from `hashes.json` rather than an aggregate it cannot.
 pub struct CredentialWitness {
+    /// The claim slots other than `PCP_CLAIM_INDEX`, in ascending slot order.
+    ///
+    /// Private, so the PCP claim can be opened without revealing what else the issuer
+    /// attested about this human.
+    pub other_claims: [Field; 15],
     /// The `associated_data_commitment`, i.e. `hashes[1]` of the credential.
+    ///
+    /// Issuer-private operational data per the `Credential` docs, so it is a witness and
+    /// deliberately not the PCP binding.
     pub associated_data_hash: Field,
     pub genesis_issued_at: Field,
     pub expires_at: Field,

--- a/crates/proof/noir/deepface-query-proof/src/types.nr
+++ b/crates/proof/noir/deepface-query-proof/src/types.nr
@@ -1,0 +1,42 @@
+pub struct PublicKey {
+    pub x: Field,
+    pub y: Field,
+}
+
+pub struct MerkleProof<let MAX_DEPTH: u32> {
+    pub mt_index: Field,
+    pub siblings: [Field; MAX_DEPTH],
+}
+
+/// The private part of a Proof of Human credential.
+///
+/// `claims_hash` is deliberately absent: it is the `pcp_hash` public input, because the
+/// TEE has to compare it against the hash it derives from `hashes.json` itself.
+pub struct CredentialWitness {
+    /// The `associated_data_commitment`, i.e. `hashes[1]` of the credential.
+    pub associated_data_hash: Field,
+    pub genesis_issued_at: Field,
+    pub expires_at: Field,
+    /// The `s` part of the issuer's EdDSA signature over the credential.
+    pub sig_s: Field,
+    /// The `r` part of the issuer's EdDSA signature over the credential.
+    pub sig_r: [Field; 2],
+    /// Blinding factor of the credential subject commitment (`sub`).
+    pub sub_blinding_factor: Field,
+    /// Packed credential `id` and `issuer_version`.
+    pub cred_id: Field,
+}
+
+pub struct DeepFaceQueryProofInputs<let BILLING_MAX_DEPTH: u32> {
+    /// Position of the World ID in the `WorldIDRegistry` tree, i.e. `leafIndex`.
+    ///
+    /// Private: publishing it would identify the human to the TEE.
+    pub mt_index: Field,
+    /// The session secret `r = OPRF(pk_rp_id, DS_C || leafIndex || oprf_seed)`.
+    ///
+    /// Private: it is what makes the billing leaf unlinkable across periods.
+    pub commitment_r: Field,
+    /// Inclusion path of the session id commitment in the billing tree.
+    pub billing_proof: MerkleProof<BILLING_MAX_DEPTH>,
+    pub credential: CredentialWitness,
+}

--- a/crates/proof/src/artifacts/embedded.rs
+++ b/crates/proof/src/artifacts/embedded.rs
@@ -268,7 +268,7 @@ pub mod noir {
     /// # Errors
     /// Returns an error if embedded Noir artifacts are missing or invalid.
     #[cfg(feature = "embed-ownership-prover")]
-    pub fn load_embedded_ownership_prover() -> eyre::Result<crate::OwnershipProver> {
+    pub fn load_embedded_ownership_prover() -> eyre::Result<crate::NoirProver> {
         crate::ownership_proof::load_ownership_prover_from_reader(PKP_BYTES)
     }
 
@@ -283,8 +283,47 @@ pub mod noir {
     /// # Errors
     /// Returns an error if embedded Noir artifacts are missing or invalid.
     #[cfg(feature = "embed-ownership-verifier")]
-    pub fn load_embedded_ownership_verifier() -> eyre::Result<crate::OwnershipVerifier> {
+    pub fn load_embedded_ownership_verifier() -> eyre::Result<crate::NoirVerifier> {
         crate::ownership_proof::load_ownership_verifier_from_reader(PKV_BYTES)
+    }
+}
+
+#[cfg(all(
+    not(target_arch = "wasm32"),
+    any(
+        feature = "embed-deepface-query-prover",
+        feature = "embed-deepface-query-verifier"
+    )
+))]
+pub mod deepface_query {
+    #[cfg(all(feature = "embed-deepface-query-prover", not(docsrs)))]
+    const PKP_BYTES: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/deepface_query_proof.pkp"));
+
+    #[cfg(all(feature = "embed-deepface-query-prover", docsrs))]
+    const PKP_BYTES: &[u8] = &[];
+
+    /// Loads the embedded DeepFace query proof prover.
+    ///
+    /// # Errors
+    /// Returns an error if embedded Noir artifacts are missing or invalid.
+    #[cfg(feature = "embed-deepface-query-prover")]
+    pub fn load_embedded_deepface_query_prover() -> eyre::Result<crate::NoirProver> {
+        crate::deepface_query_proof::load_deepface_query_prover_from_reader(PKP_BYTES)
+    }
+
+    #[cfg(all(feature = "embed-deepface-query-verifier", not(docsrs)))]
+    const PKV_BYTES: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/deepface_query_proof.pkv"));
+
+    #[cfg(all(feature = "embed-deepface-query-verifier", docsrs))]
+    const PKV_BYTES: &[u8] = &[];
+
+    /// Loads the embedded DeepFace query proof verifier.
+    ///
+    /// # Errors
+    /// Returns an error if embedded Noir artifacts are missing or invalid.
+    #[cfg(feature = "embed-deepface-query-verifier")]
+    pub fn load_embedded_deepface_query_verifier() -> eyre::Result<crate::NoirVerifier> {
+        crate::deepface_query_proof::load_deepface_query_verifier_from_reader(PKV_BYTES)
     }
 }
 

--- a/crates/proof/src/artifacts/mod.rs
+++ b/crates/proof/src/artifacts/mod.rs
@@ -36,7 +36,9 @@ pub mod dummy;
 #[cfg(any(
     feature = "embed-zkeys",
     feature = "embed-ownership-prover",
-    feature = "embed-ownership-verifier"
+    feature = "embed-ownership-verifier",
+    feature = "embed-deepface-query-prover",
+    feature = "embed-deepface-query-verifier"
 ))]
 pub mod embedded;
 pub mod error;

--- a/crates/proof/src/circuit_inputs.rs
+++ b/crates/proof/src/circuit_inputs.rs
@@ -243,3 +243,69 @@ pub struct OwnershipProofCircuitInput<const MAX_DEPTH: usize> {
     /// Private input. The commitment's `r` blinder
     pub commitment_blinder: FieldElement,
 }
+
+/// Maximum depth of the per-RP-per-period billing Merkle tree.
+///
+/// Must match `BILLING_MAX_DEPTH` in `noir/deepface-query-proof/src/constants.nr`.
+pub const BILLING_TREE_DEPTH: usize = 30;
+
+/// The input for the DeepFace Query Proof circuit.
+///
+/// The proof shows that the human is enrolled for billing under a `(rp_id, period)`
+/// billing tree and that the enrolled leaf belongs to the same World ID whose Proof of
+/// Human credential carries `pcp_hash`.
+///
+/// Only the fields marked **public input** reach the TEE in the clear. Everything else is
+/// a witness, which is what keeps requests from the same human unlinkable.
+#[derive(Debug, Clone)]
+pub struct DeepFaceQueryProofCircuitInput {
+    // SECTION: Public inputs
+    /// **Public input**. Root of the per-RP-per-period billing Merkle tree. The TEE
+    /// accepts it only if it is in the root map fed to it by the host, which is what ties
+    /// the proof to a specific `(rp_id, period)` without either being an explicit input.
+    pub billing_root: FieldElement,
+    /// **Public input**. Actual depth of the billing tree, at most [`BILLING_TREE_DEPTH`].
+    pub billing_depth: u64,
+    /// **Public input**. Hash of the PCP this query is for, i.e. the credential's
+    /// `claims_hash`. The TEE compares it with the hash it derives from `hashes.json`.
+    pub pcp_hash: FieldElement,
+    /// **Public input**. The `(issuer, schema)` pair as registered in the
+    /// `CredentialSchemaIssuerRegistry`.
+    pub issuer_schema_id: u64,
+    /// **Public input**. Public key of the credential issuer.
+    pub issuer_pk: Affine,
+    /// **Public input**. Timestamp the credential validity is judged against. The TEE
+    /// supplies this from its trusted clock.
+    pub current_timestamp: u64,
+    /// **Public input**. Minimum accepted `genesis_issued_at` of the credential.
+    pub genesis_issued_at_min: u64,
+    /// **Public input**. Nonce of the RP request, deduplicated by the host to stop
+    /// replays of a proof.
+    pub nonce: FieldElement,
+
+    // SECTION: Identity witnesses
+    /// Private input. Position of the World ID in the `WorldIDRegistry`, i.e. `leafIndex`.
+    pub mt_index: u64,
+    /// Private input. The session secret `r`, from which the billing leaf is derived.
+    pub commitment_r: FieldElement,
+
+    // SECTION: Billing inclusion witnesses
+    /// Private input. Position of the session id commitment in the billing tree.
+    pub billing_leaf_index: u64,
+    /// Private input. Sibling path of the session id commitment in the billing tree.
+    pub billing_siblings: [FieldElement; BILLING_TREE_DEPTH],
+
+    // SECTION: Credential witnesses
+    /// Private input. The credential's `associated_data_commitment`.
+    pub credential_associated_data_hash: FieldElement,
+    /// Private input. The credential's `genesis_issued_at`.
+    pub credential_genesis_issued_at: u64,
+    /// Private input. The credential's `expires_at`.
+    pub credential_expires_at: u64,
+    /// Private input. The issuer's EdDSA signature over the credential.
+    pub credential_signature: EdDSASignature,
+    /// Private input. Blinding factor of the credential subject commitment (`sub`).
+    pub credential_sub_blinding_factor: FieldElement,
+    /// Private input. Packed credential `id` and `issuer_version`.
+    pub credential_id: BaseField,
+}

--- a/crates/proof/src/circuit_inputs.rs
+++ b/crates/proof/src/circuit_inputs.rs
@@ -253,8 +253,12 @@ pub const BILLING_TREE_DEPTH: usize = 30;
 ///
 /// Must match `PCP_CLAIM_INDEX` in `noir/deepface-query-proof/src/constants.nr`.
 ///
-/// PROVISIONAL: no issuer populates `claims` yet, so no slot is spoken for. Changing it
-/// changes the circuit and therefore the proving/verifying keys.
+/// Slot 0 of the *iris* (orb signup) credential, which `signup-service` populates with
+/// `H(b"CLAIMS_HASH_V1" || hashes.json)`. Claim indices are scoped to the credential
+/// schema -- slot 0 of the *face* credential is a uniqueness flag -- so this is only
+/// meaningful alongside `issuer_schema_id`.
+///
+/// Changing it changes the circuit and therefore the proving/verifying keys.
 pub const PCP_CLAIM_INDEX: usize = 0;
 
 /// Number of credential claim slots other than the PCP one, i.e.

--- a/crates/proof/src/circuit_inputs.rs
+++ b/crates/proof/src/circuit_inputs.rs
@@ -249,6 +249,18 @@ pub struct OwnershipProofCircuitInput<const MAX_DEPTH: usize> {
 /// Must match `BILLING_MAX_DEPTH` in `noir/deepface-query-proof/src/constants.nr`.
 pub const BILLING_TREE_DEPTH: usize = 30;
 
+/// Which credential claim slot carries the PCP commitment.
+///
+/// Must match `PCP_CLAIM_INDEX` in `noir/deepface-query-proof/src/constants.nr`.
+///
+/// PROVISIONAL: no issuer populates `claims` yet, so no slot is spoken for. Changing it
+/// changes the circuit and therefore the proving/verifying keys.
+pub const PCP_CLAIM_INDEX: usize = 0;
+
+/// Number of credential claim slots other than the PCP one, i.e.
+/// `Credential::MAX_CLAIMS - 1`.
+pub const PCP_OTHER_CLAIMS: usize = 15;
+
 /// The input for the DeepFace Query Proof circuit.
 ///
 /// The proof shows that the human is enrolled for billing under a `(rp_id, period)`
@@ -266,8 +278,12 @@ pub struct DeepFaceQueryProofCircuitInput {
     pub billing_root: FieldElement,
     /// **Public input**. Actual depth of the billing tree, at most [`BILLING_TREE_DEPTH`].
     pub billing_depth: u64,
-    /// **Public input**. Hash of the PCP this query is for, i.e. the credential's
-    /// `claims_hash`. The TEE compares it with the hash it derives from `hashes.json`.
+    /// **Public input**. The credential claim that commits to the PCP this query is for,
+    /// i.e. `claims[PCP_CLAIM_INDEX]` = `H(b"CLAIMS_HASH_V1" || hashes_json)`.
+    ///
+    /// This is a single claim slot, not the aggregate `claims_hash`: the TEE can derive
+    /// one claim from the `hashes.json` it already holds, but not the aggregate, which
+    /// commits to claims it never sees.
     pub pcp_hash: FieldElement,
     /// **Public input**. The `(issuer, schema)` pair as registered in the
     /// `CredentialSchemaIssuerRegistry`.
@@ -296,7 +312,12 @@ pub struct DeepFaceQueryProofCircuitInput {
     pub billing_siblings: [FieldElement; BILLING_TREE_DEPTH],
 
     // SECTION: Credential witnesses
+    /// Private input. The credential's claim slots other than the PCP one, in ascending
+    /// slot order. Must match `MAX_CLAIMS - 1` in the circuit.
+    pub credential_other_claims: [FieldElement; PCP_OTHER_CLAIMS],
     /// Private input. The credential's `associated_data_commitment`.
+    ///
+    /// Issuer-private operational data per the `Credential` docs, hence a witness.
     pub credential_associated_data_hash: FieldElement,
     /// Private input. The credential's `genesis_issued_at`.
     pub credential_genesis_issued_at: u64,

--- a/crates/proof/src/deepface_query_proof.rs
+++ b/crates/proof/src/deepface_query_proof.rs
@@ -101,9 +101,14 @@ pub fn generate_deepface_query_proof_with_prover(
 /// # Note
 /// This only establishes that the proof is valid for the public inputs *it carries*. The
 /// TEE must separately check those public inputs: that `billing_root` is in its host-fed
-/// root map, that `pcp_hash` matches the hash it derives from `hashes.json`, that
+/// root map and that `billing_depth` is the depth it recorded for that root, that
+/// `pcp_hash` matches the hash it derives from `hashes.json`, that
 /// `issuer_schema_id`/`issuer_pk` are accepted, that `current_timestamp` is current
 /// against its trusted clock, and that `nonce` has not been seen.
+///
+/// A wrong `billing_depth` is not exploitable on its own — the recomputed root would have
+/// to collide with a root the host fed in — but checking it keeps `root unknown` and
+/// `inclusion proof invalid` distinguishable as reject reasons.
 ///
 /// # Errors
 /// Returns [`ProofError`] if verification fails.

--- a/crates/proof/src/deepface_query_proof.rs
+++ b/crates/proof/src/deepface_query_proof.rs
@@ -1,0 +1,223 @@
+//! DeepFace Query Proof: the billing gate presented to the Verifier TEE.
+//!
+//! Implements the prover/verifier side of `noir/deepface-query-proof`, the `Query Proof`
+//! of the YABS "Updated Design". The user proves it is enrolled for billing under some
+//! `(rp_id, period)` billing tree, that the enrolled leaf opens to its own World ID, and
+//! that a valid Proof of Human credential for that World ID carries the PCP hash the TEE
+//! is about to match against.
+//!
+//! Unlike the Circom circuits in this crate, the artifacts need no trusted setup: they are
+//! derived from the checked-in Noir source by the ProveKit R1CS compiler, exactly like the
+//! [`crate::ownership_proof`] artifacts.
+//!
+//! # Status
+//!
+//! UNAUDITED, and the circuit deliberately does not prove control of the World ID it opens
+//! the billing leaf to. See the module docs of `noir/deepface-query-proof/src/main.nr`.
+
+use std::{collections::BTreeMap, io::Read, path::Path};
+
+use ark_ff::{BigInteger as _, PrimeField as _};
+use provekit_common::{InputMap, InputValue, NoirElement, NoirProof};
+use provekit_prover::Prove;
+use provekit_verifier::Verify;
+
+use crate::{
+    NoirCircuitInput, NoirProver, NoirRepresentable, NoirVerifier, ProofError,
+    circuit_inputs::DeepFaceQueryProofCircuitInput,
+};
+
+/// Loads a DeepFace query proof prover from a reader containing PKP bytes.
+///
+/// # Errors
+/// Returns an error if the reader cannot be read or the prover cannot be deserialized.
+pub fn load_deepface_query_prover_from_reader(mut reader: impl Read) -> eyre::Result<NoirProver> {
+    provekit_common::register_ntt();
+
+    let mut bytes = Vec::new();
+    reader.read_to_end(&mut bytes)?;
+    provekit_common::file::deserialize(&bytes).map_err(|e| eyre::eyre!(e.to_string()))
+}
+
+/// Loads a DeepFace query proof prover from a PKP file path.
+///
+/// # Errors
+/// Returns an error if the file cannot be read or the prover cannot be deserialized.
+pub fn load_deepface_query_prover_from_path(path: impl AsRef<Path>) -> eyre::Result<NoirProver> {
+    provekit_common::register_ntt();
+    provekit_common::file::read(path.as_ref()).map_err(|e| eyre::eyre!(e.to_string()))
+}
+
+/// Loads a DeepFace query proof verifier from a reader containing PKV bytes.
+///
+/// # Errors
+/// Returns an error if the reader cannot be read or the verifier cannot be deserialized.
+pub fn load_deepface_query_verifier_from_reader(
+    mut reader: impl Read,
+) -> eyre::Result<NoirVerifier> {
+    provekit_common::register_ntt();
+
+    let mut bytes = Vec::new();
+    reader.read_to_end(&mut bytes)?;
+    provekit_common::file::deserialize(&bytes).map_err(|e| eyre::eyre!(e.to_string()))
+}
+
+/// Loads a DeepFace query proof verifier from a PKV file path.
+///
+/// # Errors
+/// Returns an error if the file cannot be read or the verifier cannot be deserialized.
+pub fn load_deepface_query_verifier_from_path(
+    path: impl AsRef<Path>,
+) -> eyre::Result<NoirVerifier> {
+    provekit_common::register_ntt();
+    provekit_common::file::read(path.as_ref()).map_err(|e| eyre::eyre!(e.to_string()))
+}
+
+/// Generates a DeepFace query proof with the provided prover.
+///
+/// The returned [`NoirProof`] carries its own public inputs, so the TEE verifies it
+/// without the caller having to restate them.
+///
+/// # Note
+/// [`provekit_prover::Prove::prove`] consumes the prover, so repeated proving needs a
+/// clone per call. This mirrors [`crate::ownership_proof::generate_ownership_proof_with_prover`].
+///
+/// # Errors
+/// Returns [`ProofError`] if witness generation or proving fails.
+pub fn generate_deepface_query_proof_with_prover(
+    input: DeepFaceQueryProofCircuitInput,
+    prover: NoirProver,
+) -> Result<NoirProof, ProofError> {
+    provekit_common::register_ntt();
+
+    let witness = input.into_witness()?;
+    prover
+        .prove(witness)
+        .map_err(|e| ProofError::GenerationError(e.to_string()))
+}
+
+/// Verifies a DeepFace query proof with the provided verifier.
+///
+/// # Note
+/// This only establishes that the proof is valid for the public inputs *it carries*. The
+/// TEE must separately check those public inputs: that `billing_root` is in its host-fed
+/// root map, that `pcp_hash` matches the hash it derives from `hashes.json`, that
+/// `issuer_schema_id`/`issuer_pk` are accepted, that `current_timestamp` is current
+/// against its trusted clock, and that `nonce` has not been seen.
+///
+/// # Errors
+/// Returns [`ProofError`] if verification fails.
+pub fn verify_deepface_query_proof_with_verifier(
+    proof: &NoirProof,
+    verifier: &mut NoirVerifier,
+) -> Result<(), ProofError> {
+    provekit_common::register_ntt();
+
+    verifier
+        .verify(proof)
+        .map_err(|e| ProofError::Verification(e.to_string()))
+}
+
+impl NoirCircuitInput for DeepFaceQueryProofCircuitInput {
+    fn into_witness(self) -> Result<InputMap, ProofError> {
+        let mut map = InputMap::new();
+
+        // Public inputs, in the declaration order of `main`.
+        map.insert("billing_root".into(), self.billing_root.into_noir_value());
+        map.insert(
+            "billing_depth".into(),
+            InputValue::Field(NoirElement::from(self.billing_depth)),
+        );
+        map.insert("pcp_hash".into(), self.pcp_hash.into_noir_value());
+        map.insert(
+            "issuer_schema_id".into(),
+            InputValue::Field(NoirElement::from(self.issuer_schema_id)),
+        );
+
+        let mut issuer_pk = BTreeMap::new();
+        issuer_pk.insert(
+            "x".into(),
+            InputValue::Field(NoirElement::from_repr(self.issuer_pk.x)),
+        );
+        issuer_pk.insert(
+            "y".into(),
+            InputValue::Field(NoirElement::from_repr(self.issuer_pk.y)),
+        );
+        map.insert("issuer_pk".into(), InputValue::Struct(issuer_pk));
+
+        map.insert(
+            "current_timestamp".into(),
+            InputValue::Field(NoirElement::from(self.current_timestamp)),
+        );
+        map.insert(
+            "genesis_issued_at_min".into(),
+            InputValue::Field(NoirElement::from(self.genesis_issued_at_min)),
+        );
+        map.insert("nonce".into(), self.nonce.into_noir_value());
+
+        // Private input struct.
+        let mut inputs: BTreeMap<String, InputValue> = BTreeMap::new();
+        inputs.insert(
+            "mt_index".into(),
+            InputValue::Field(NoirElement::from(self.mt_index)),
+        );
+        inputs.insert("commitment_r".into(), self.commitment_r.into_noir_value());
+
+        let siblings: Vec<InputValue> = self
+            .billing_siblings
+            .iter()
+            .map(|s| (*s).into_noir_value())
+            .collect();
+        let mut billing_proof = BTreeMap::new();
+        billing_proof.insert(
+            "mt_index".into(),
+            InputValue::Field(NoirElement::from(self.billing_leaf_index)),
+        );
+        billing_proof.insert("siblings".into(), InputValue::Vec(siblings));
+        inputs.insert("billing_proof".into(), InputValue::Struct(billing_proof));
+
+        // The credential's EdDSA `s` lives in the BabyJubJub scalar field; the circuit
+        // takes it as a bn254 base field element, same as the ownership proof.
+        let sig_s = ark_bn254::Fr::from_be_bytes_mod_order(
+            &self.credential_signature.s.into_bigint().to_bytes_be(),
+        );
+
+        let mut credential: BTreeMap<String, InputValue> = BTreeMap::new();
+        credential.insert(
+            "associated_data_hash".into(),
+            self.credential_associated_data_hash.into_noir_value(),
+        );
+        credential.insert(
+            "genesis_issued_at".into(),
+            InputValue::Field(NoirElement::from(self.credential_genesis_issued_at)),
+        );
+        credential.insert(
+            "expires_at".into(),
+            InputValue::Field(NoirElement::from(self.credential_expires_at)),
+        );
+        credential.insert(
+            "sig_s".into(),
+            InputValue::Field(NoirElement::from_repr(sig_s)),
+        );
+        credential.insert(
+            "sig_r".into(),
+            InputValue::Vec(vec![
+                InputValue::Field(NoirElement::from_repr(self.credential_signature.r.x)),
+                InputValue::Field(NoirElement::from_repr(self.credential_signature.r.y)),
+            ]),
+        );
+        credential.insert(
+            "sub_blinding_factor".into(),
+            self.credential_sub_blinding_factor.into_noir_value(),
+        );
+        credential.insert(
+            "cred_id".into(),
+            InputValue::Field(NoirElement::from_repr(self.credential_id)),
+        );
+        inputs.insert("credential".into(), InputValue::Struct(credential));
+
+        map.insert("inputs".into(), InputValue::Struct(inputs));
+
+        Ok(map)
+    }
+}

--- a/crates/proof/src/deepface_query_proof.rs
+++ b/crates/proof/src/deepface_query_proof.rs
@@ -189,6 +189,15 @@ impl NoirCircuitInput for DeepFaceQueryProofCircuitInput {
 
         let mut credential: BTreeMap<String, InputValue> = BTreeMap::new();
         credential.insert(
+            "other_claims".into(),
+            InputValue::Vec(
+                self.credential_other_claims
+                    .iter()
+                    .map(|c| (*c).into_noir_value())
+                    .collect(),
+            ),
+        );
+        credential.insert(
             "associated_data_hash".into(),
             self.credential_associated_data_hash.into_noir_value(),
         );

--- a/crates/proof/src/lib.rs
+++ b/crates/proof/src/lib.rs
@@ -34,9 +34,18 @@ use world_id_primitives::FieldElement;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod ownership_proof;
 
+// Shares the ProveKit stack with `ownership_proof`, so it has the same WASM limitation.
+#[cfg(not(target_arch = "wasm32"))]
+pub mod deepface_query_proof;
+
 pub use provekit_common::{
     NoirProof, Prover as OwnershipProver, Verifier as OwnershipVerifier, WhirR1CSProof,
 };
+
+// ProveKit has a single prover/verifier type, parameterized by the artifact it is built
+// from, so these are the same types as `OwnershipProver`/`OwnershipVerifier`. They are
+// re-exported under neutral names for circuits other than the ownership proof.
+pub use provekit_common::{Prover as NoirProver, Verifier as NoirVerifier};
 
 /// Error type for OPRF operations and proof generation.
 #[derive(Debug, thiserror::Error)]

--- a/crates/proof/tests/deepface_query_proof.rs
+++ b/crates/proof/tests/deepface_query_proof.rs
@@ -26,7 +26,9 @@ use world_id_proof::{
     artifacts::embedded::deepface_query::{
         load_embedded_deepface_query_prover, load_embedded_deepface_query_verifier,
     },
-    circuit_inputs::{BILLING_TREE_DEPTH, DeepFaceQueryProofCircuitInput},
+    circuit_inputs::{
+        BILLING_TREE_DEPTH, DeepFaceQueryProofCircuitInput, PCP_CLAIM_INDEX, PCP_OTHER_CLAIMS,
+    },
     deepface_query_proof::{
         generate_deepface_query_proof_with_prover, verify_deepface_query_proof_with_verifier,
     },
@@ -38,6 +40,17 @@ const EXPIRES_AT: u64 = 1_900_000_000;
 const CURRENT_TIMESTAMP: u64 = 1_800_000_000;
 const LEAF_INDEX: u64 = 1;
 const ISSUER_SCHEMA_ID: u64 = 1;
+
+/// The claim slots other than the PCP one, in ascending slot order.
+fn other_claims(claims: &[FieldElement]) -> [FieldElement; PCP_OTHER_CLAIMS] {
+    let mut rest = claims
+        .iter()
+        .enumerate()
+        .filter(|(slot, _)| *slot != PCP_CLAIM_INDEX)
+        .map(|(_, claim)| *claim);
+
+    std::array::from_fn(|_| rest.next().expect("credential has MAX_CLAIMS slots"))
+}
 
 /// Builds a fully valid circuit input.
 ///
@@ -58,8 +71,18 @@ fn valid_input(seed: u64) -> DeepFaceQueryProofCircuitInput {
     credential.expires_at = EXPIRES_AT;
     credential.associated_data_commitment = Fq::rand(&mut rng).into();
 
+    // The PCP claim is what the enclave derives from `hashes.json`. A second claim is set
+    // so the test actually exercises `other_claims` rather than an all-zero vector.
+    let credential = credential
+        .claim(PCP_CLAIM_INDEX, b"hashes.json stand-in for the PCP")
+        .expect("pcp claim")
+        .claim(3, b"an unrelated issuer claim")
+        .expect("other claim");
+
+    let pcp_hash = credential.claims[PCP_CLAIM_INDEX];
+    let credential_other_claims = other_claims(&credential.claims);
+
     let credential = credential.sign(&issuer_sk).expect("credential signing");
-    let pcp_hash = credential.claims_hash().expect("claims hash");
 
     let oprf_seed = SessionId::generate_oprf_seed(&mut rng);
     let commitment_r: FieldElement = Fq::rand(&mut rng).into();
@@ -81,6 +104,7 @@ fn valid_input(seed: u64) -> DeepFaceQueryProofCircuitInput {
         commitment_r,
         billing_leaf_index: LEAF_INDEX,
         billing_siblings,
+        credential_other_claims,
         credential_associated_data_hash: credential.associated_data_commitment,
         credential_genesis_issued_at: credential.genesis_issued_at,
         credential_expires_at: credential.expires_at,
@@ -140,12 +164,38 @@ fn rejects_credential_belonging_to_another_world_id() {
 fn rejects_pcp_hash_the_credential_does_not_carry() {
     let mut input = valid_input(42);
     // This is the binding that stops an enrolled World ID from being used to verify a
-    // different human: the PCP hash is inside the issuer-signed credential.
+    // different human: the PCP claim is inside the issuer-signed credential.
     input.pcp_hash = Fq::from(0x1234_u64).into();
 
     assert!(
         prove_and_verify(input).is_err(),
         "pcp_hash must be authenticated by the credential signature"
+    );
+}
+
+#[test]
+fn rejects_tampered_other_claims() {
+    let mut input = valid_input(42);
+    // The PCP claim is opened out of the aggregate `claims_hash`, so the remaining slots
+    // are still covered by the signature and cannot be swapped freely.
+    input.credential_other_claims[2] = Fq::from(0x9999_u64).into();
+
+    assert!(
+        prove_and_verify(input).is_err(),
+        "the non-PCP claim slots must stay bound by the credential signature"
+    );
+}
+
+#[test]
+fn rejects_pcp_hash_moved_to_another_slot() {
+    let mut input = valid_input(42);
+    // Presenting the real PCP claim in a different slot must not verify, otherwise the
+    // slot index would be meaningless and any claim could pose as the PCP.
+    std::mem::swap(&mut input.pcp_hash, &mut input.credential_other_claims[0]);
+
+    assert!(
+        prove_and_verify(input).is_err(),
+        "the PCP must be committed at PCP_CLAIM_INDEX specifically"
     );
 }
 

--- a/crates/proof/tests/deepface_query_proof.rs
+++ b/crates/proof/tests/deepface_query_proof.rs
@@ -1,0 +1,184 @@
+//! End-to-end tests for the DeepFace Query Proof.
+//!
+//! These are the correctness evidence behind the benchmark numbers in
+//! `noir/deepface-query-proof/docs/benchmarks.md`: a green proving run alone is not enough,
+//! because a proof over a witness that does not actually constrain anything would also be
+//! green. Each negative control therefore breaks exactly one constraint.
+//!
+//! Run with:
+//! ```sh
+//! cargo test -p world-id-proof --features embed-deepface-query-prover,embed-deepface-query-verifier
+//! ```
+
+#![cfg(all(
+    not(target_arch = "wasm32"),
+    feature = "embed-deepface-query-prover",
+    feature = "embed-deepface-query-verifier"
+))]
+
+use ark_babyjubjub::Fq;
+use ark_ff::{BigInt, UniformRand};
+use eddsa_babyjubjub::EdDSAPrivateKey;
+use rand::SeedableRng;
+use rand_chacha::ChaCha20Rng;
+use world_id_primitives::{Credential, FieldElement, SessionId};
+use world_id_proof::{
+    artifacts::embedded::deepface_query::{
+        load_embedded_deepface_query_prover, load_embedded_deepface_query_verifier,
+    },
+    circuit_inputs::{BILLING_TREE_DEPTH, DeepFaceQueryProofCircuitInput},
+    deepface_query_proof::{
+        generate_deepface_query_proof_with_prover, verify_deepface_query_proof_with_verifier,
+    },
+};
+use world_id_test_utils::merkle::first_leaf_merkle_path;
+
+const GENESIS_ISSUED_AT: u64 = 1_700_000_000;
+const EXPIRES_AT: u64 = 1_900_000_000;
+const CURRENT_TIMESTAMP: u64 = 1_800_000_000;
+const LEAF_INDEX: u64 = 1;
+const ISSUER_SCHEMA_ID: u64 = 1;
+
+/// Builds a fully valid circuit input.
+///
+/// Duplicated in spirit by `zk-mobile-bench`, which cannot depend on `world-id-test-utils`
+/// (it drags in anvil/alloy, which must not reach a mobile build).
+fn valid_input(seed: u64) -> DeepFaceQueryProofCircuitInput {
+    let mut rng = ChaCha20Rng::seed_from_u64(seed);
+
+    let issuer_sk = EdDSAPrivateKey::random(&mut rng);
+    let sub_blinding_factor: FieldElement = Fq::rand(&mut rng).into();
+
+    let mut credential = Credential::new();
+    credential.id = 0x1234_5678_9abc_def0;
+    credential.issuer_version = 0;
+    credential.issuer_schema_id = ISSUER_SCHEMA_ID;
+    credential.sub = Credential::compute_sub(LEAF_INDEX, sub_blinding_factor);
+    credential.genesis_issued_at = GENESIS_ISSUED_AT;
+    credential.expires_at = EXPIRES_AT;
+    credential.associated_data_commitment = Fq::rand(&mut rng).into();
+
+    let credential = credential.sign(&issuer_sk).expect("credential signing");
+    let pcp_hash = credential.claims_hash().expect("claims hash");
+
+    let oprf_seed = SessionId::generate_oprf_seed(&mut rng);
+    let commitment_r: FieldElement = Fq::rand(&mut rng).into();
+    let session_id =
+        SessionId::from_r_seed(LEAF_INDEX, commitment_r, oprf_seed).expect("session id");
+
+    let (billing_siblings, billing_root) = first_leaf_merkle_path(*session_id.commitment);
+
+    DeepFaceQueryProofCircuitInput {
+        billing_root,
+        billing_depth: BILLING_TREE_DEPTH as u64,
+        pcp_hash,
+        issuer_schema_id: ISSUER_SCHEMA_ID,
+        issuer_pk: issuer_sk.public().pk,
+        current_timestamp: CURRENT_TIMESTAMP,
+        genesis_issued_at_min: GENESIS_ISSUED_AT,
+        nonce: Fq::rand(&mut rng).into(),
+        mt_index: LEAF_INDEX,
+        commitment_r,
+        billing_leaf_index: LEAF_INDEX,
+        billing_siblings,
+        credential_associated_data_hash: credential.associated_data_commitment,
+        credential_genesis_issued_at: credential.genesis_issued_at,
+        credential_expires_at: credential.expires_at,
+        credential_signature: credential.signature.expect("signed credential"),
+        credential_sub_blinding_factor: sub_blinding_factor,
+        credential_id: Fq::from(BigInt([
+            credential.id,
+            u64::from(credential.issuer_version),
+            0,
+            0,
+        ])),
+    }
+}
+
+fn prove_and_verify(input: DeepFaceQueryProofCircuitInput) -> Result<(), String> {
+    let prover = load_embedded_deepface_query_prover().map_err(|e| format!("load prover: {e}"))?;
+    let proof = generate_deepface_query_proof_with_prover(input, prover)
+        .map_err(|e| format!("prove: {e}"))?;
+
+    let mut verifier =
+        load_embedded_deepface_query_verifier().map_err(|e| format!("load verifier: {e}"))?;
+    verify_deepface_query_proof_with_verifier(&proof, &mut verifier)
+        .map_err(|e| format!("verify: {e}"))
+}
+
+#[test]
+fn valid_proof_verifies() {
+    prove_and_verify(valid_input(42)).expect("a valid witness must prove and verify");
+}
+
+#[test]
+fn rejects_billing_root_the_leaf_is_not_under() {
+    let mut input = valid_input(42);
+    // Claim enrollment under a root this session id commitment is not in.
+    input.billing_root = Fq::from(0xdead_beef_u64).into();
+
+    assert!(
+        prove_and_verify(input).is_err(),
+        "an unenrolled human must not be able to prove billing inclusion"
+    );
+}
+
+#[test]
+fn rejects_credential_belonging_to_another_world_id() {
+    let mut input = valid_input(42);
+    // The billing leaf still opens to LEAF_INDEX, but the credential was issued to a
+    // different `mt_index`, so `sub` no longer matches the signed credential.
+    input.mt_index = LEAF_INDEX + 1;
+
+    assert!(
+        prove_and_verify(input).is_err(),
+        "the credential must be bound to the World ID the billing leaf opens to"
+    );
+}
+
+#[test]
+fn rejects_pcp_hash_the_credential_does_not_carry() {
+    let mut input = valid_input(42);
+    // This is the binding that stops an enrolled World ID from being used to verify a
+    // different human: the PCP hash is inside the issuer-signed credential.
+    input.pcp_hash = Fq::from(0x1234_u64).into();
+
+    assert!(
+        prove_and_verify(input).is_err(),
+        "pcp_hash must be authenticated by the credential signature"
+    );
+}
+
+#[test]
+fn rejects_expired_credential() {
+    let mut input = valid_input(42);
+    input.current_timestamp = EXPIRES_AT + 1;
+
+    assert!(
+        prove_and_verify(input).is_err(),
+        "an expired credential must not pass"
+    );
+}
+
+#[test]
+fn rejects_credential_older_than_genesis_minimum() {
+    let mut input = valid_input(42);
+    input.genesis_issued_at_min = GENESIS_ISSUED_AT + 1;
+
+    assert!(
+        prove_and_verify(input).is_err(),
+        "a credential issued before the minimum genesis time must not pass"
+    );
+}
+
+#[test]
+fn rejects_wrong_session_secret() {
+    let mut input = valid_input(42);
+    // Knowing the leaf is not enough: the prover must know the `r` it opens to.
+    input.commitment_r = Fq::rand(&mut ChaCha20Rng::seed_from_u64(7)).into();
+
+    assert!(
+        prove_and_verify(input).is_err(),
+        "the billing leaf must only be openable by the holder of r"
+    );
+}

--- a/crates/zk-mobile-bench/Cargo.toml
+++ b/crates/zk-mobile-bench/Cargo.toml
@@ -21,7 +21,10 @@ inventory = "0.3"
 # World ID
 world-id-core = { workspace = true, default-features = false, features = ["authenticator", "embed-zkeys", "issuer"] }
 world-id-primitives = { workspace = true }
-world-id-proof = { workspace = true }
+world-id-proof = { workspace = true, features = [
+    "embed-deepface-query-prover",
+    "embed-deepface-query-verifier",
+] }
 
 # ZK dependencies
 ark-babyjubjub = { workspace = true }

--- a/crates/zk-mobile-bench/docs/README.md
+++ b/crates/zk-mobile-bench/docs/README.md
@@ -79,7 +79,31 @@ Benchmark reports also preserve optional semantic `phases` emitted by
 | `bench_nullifier_proof_generation` | π2 nullifier | Full measured path: fixture/input generation, witness generation, and Groth16 proving |
 | `bench_nullifier_witness_generation_only` | π2 nullifier | Circom witness generation only, with cached input/material |
 | `bench_nullifier_proving_only` | π2 nullifier | Groth16 proving only, from a cached witness |
+| `bench_deepface_query_proof_generation` | DeepFace query | Full measured path: fixture generation, prover deserialization, witness generation and ProveKit proving |
+| `bench_deepface_query_cached_proof_generation` | DeepFace query | Witness generation plus ProveKit proving, with input and prover cached; includes one prover clone |
 
-CI runs all seven functions by default. The function list is specified directly
+CI runs the seven Circom functions by default. The function list is specified directly
 in the caller workflow (`mobile-bench.yml`) via the `functions` input to the
-reusable workflow.
+reusable workflow, so the two DeepFace functions must be added there before CI picks
+them up.
+
+## Running locally
+
+`run_local` takes benchmark names as arguments and runs all defaults when given none:
+
+```bash
+cargo run -p zk-mobile-bench --example run_local --release -- \
+  bench_deepface_query_proof_generation
+```
+
+Run **one benchmark per process** when you intend to quote the numbers. Benchmarks in the
+same process share the allocator and the process-wide ProveKit NTT tables, which inflated
+both DeepFace means by roughly 2.5x and quadrupled the spread. See
+`crates/proof/noir/deepface-query-proof/docs/benchmarks.md`.
+
+## ProveKit benchmarks
+
+The DeepFace query benchmarks are the first ProveKit/Noir benchmarks in this crate; the
+rest are Circom/Groth16. Their prover is embedded via `world-id-proof`'s
+`embed-deepface-query-prover` feature, which needs `nargo` 1.0.0-beta.11 on PATH at build
+time.

--- a/crates/zk-mobile-bench/examples/run_local.rs
+++ b/crates/zk-mobile-bench/examples/run_local.rs
@@ -1,81 +1,96 @@
 //! Local benchmark runner for testing without mobile devices.
 //!
 //! Run with: cargo run -p zk-mobile-bench --example run_local --release
+//!
+//! Pass benchmark names to run a subset, e.g.
+//! `cargo run -p zk-mobile-bench --example run_local --release -- bench_deepface_query_proof_generation`
 
 use zk_mobile_bench::{BenchSpec, run_benchmark};
+
+/// Benchmarks run when no names are given on the command line.
+const DEFAULT_BENCHMARKS: &[(&str, &str)] = &[
+    ("bench_query_proof_generation", "Query Proof pi1"),
+    ("bench_nullifier_proof_generation", "Nullifier Proof pi2"),
+    (
+        "bench_deepface_query_proof_generation",
+        "DeepFace Query Proof (cold, ProveKit)",
+    ),
+    (
+        "bench_deepface_query_cached_proof_generation",
+        "DeepFace Query Proof (cached prover)",
+    ),
+];
+
+fn run(name: &str, label: &str, iterations: u32, warmup: u32) {
+    println!("Running: {name}");
+    println!("  Warmup: {warmup} iteration(s)");
+    println!("  Measured: {iterations} iteration(s)");
+
+    let spec = BenchSpec {
+        name: format!("zk_mobile_bench::{name}"),
+        iterations,
+        warmup,
+    };
+
+    match run_benchmark(spec) {
+        Ok(report) => {
+            let durations: Vec<f64> = report
+                .samples
+                .iter()
+                .map(|s| s.duration_ns as f64 / 1_000_000_000.0)
+                .collect();
+
+            let mean = durations.iter().sum::<f64>() / durations.len() as f64;
+            let min = durations.iter().copied().fold(f64::INFINITY, f64::min);
+            let max = durations.iter().copied().fold(f64::NEG_INFINITY, f64::max);
+
+            println!("\n  Results ({label}):");
+            println!("    Samples: {durations:?} seconds");
+            println!("    Min: {min:.3}s");
+            println!("    Max: {max:.3}s");
+            println!("    Mean: {mean:.3}s");
+
+            if let Some(usage) = report.resource_usage {
+                if let Some(peak) = usage.process_peak_memory_kb {
+                    println!("    Process peak RSS: {:.1} MiB", peak as f64 / 1024.0);
+                }
+                if let Some(growth) = usage.peak_memory_growth_kb {
+                    println!("    Peak RSS growth: {:.1} MiB", growth as f64 / 1024.0);
+                }
+            }
+        }
+        Err(e) => {
+            eprintln!("  Error: {e}");
+        }
+    }
+}
 
 fn main() {
     println!("World ID Mobile Benchmarks - Local Runner");
     println!("==========================================\n");
 
-    // Run Query Proof benchmark
-    println!("Running: bench_query_proof_generation");
-    println!("  Warmup: 1 iteration");
-    println!("  Measured: 3 iterations");
+    let requested: Vec<String> = std::env::args().skip(1).collect();
 
-    let spec = BenchSpec {
-        name: "zk_mobile_bench::bench_query_proof_generation".to_string(),
-        iterations: 3,
-        warmup: 1,
+    let selected: Vec<(&str, &str)> = if requested.is_empty() {
+        DEFAULT_BENCHMARKS.to_vec()
+    } else {
+        requested
+            .iter()
+            .map(|name| {
+                let label = DEFAULT_BENCHMARKS
+                    .iter()
+                    .find(|(n, _)| n == name)
+                    .map_or("custom", |(_, l)| l);
+                (name.as_str(), label)
+            })
+            .collect()
     };
 
-    match run_benchmark(spec) {
-        Ok(report) => {
-            let durations: Vec<f64> = report
-                .samples
-                .iter()
-                .map(|s| s.duration_ns as f64 / 1_000_000_000.0)
-                .collect();
-
-            let mean = durations.iter().sum::<f64>() / durations.len() as f64;
-            let min = durations.iter().cloned().fold(f64::INFINITY, f64::min);
-            let max = durations.iter().cloned().fold(f64::NEG_INFINITY, f64::max);
-
-            println!("\n  Results (Query Proof π1):");
-            println!("    Samples: {:?} seconds", durations);
-            println!("    Min: {:.3}s", min);
-            println!("    Max: {:.3}s", max);
-            println!("    Mean: {:.3}s", mean);
+    for (i, (name, label)) in selected.iter().enumerate() {
+        if i > 0 {
+            println!("\n------------------------------------------\n");
         }
-        Err(e) => {
-            eprintln!("  Error: {}", e);
-        }
-    }
-
-    println!("\n------------------------------------------\n");
-
-    // Run Nullifier Proof benchmark
-    println!("Running: bench_nullifier_proof_generation");
-    println!("  Warmup: 1 iteration");
-    println!("  Measured: 3 iterations");
-
-    let spec = BenchSpec {
-        name: "zk_mobile_bench::bench_nullifier_proof_generation".to_string(),
-        iterations: 3,
-        warmup: 1,
-    };
-
-    match run_benchmark(spec) {
-        Ok(report) => {
-            let durations: Vec<f64> = report
-                .samples
-                .iter()
-                .map(|s| s.duration_ns as f64 / 1_000_000_000.0)
-                .collect();
-
-            let mean = durations.iter().sum::<f64>() / durations.len() as f64;
-            let min = durations.iter().cloned().fold(f64::INFINITY, f64::min);
-            let max = durations.iter().cloned().fold(f64::NEG_INFINITY, f64::max);
-
-            println!("\n  Results (Nullifier Proof π2):");
-            println!("    Samples: {:?} seconds", durations);
-            println!("    Min: {:.3}s", min);
-            println!("    Max: {:.3}s", max);
-            println!("    Mean: {:.3}s", mean);
-        }
-        Err(e) => {
-            eprintln!("  Error: {}", e);
-        }
+        run(name, label, 3, 1);
     }
 
     println!("\n==========================================");

--- a/crates/zk-mobile-bench/src/lib.rs
+++ b/crates/zk-mobile-bench/src/lib.rs
@@ -10,7 +10,7 @@ mod fixtures;
 
 use ark_babyjubjub::Fq;
 use ark_ec::CurveGroup;
-use ark_ff::BigInt;
+use ark_ff::{BigInt, UniformRand};
 use eddsa_babyjubjub::EdDSAPrivateKey;
 use groth16_material::circom::CircomGroth16Material;
 use rand::SeedableRng;
@@ -24,11 +24,17 @@ use taceo_oprf::core::{
     oprf::{BlindedOprfResponse, BlindingFactor},
 };
 use world_id_primitives::{
-    AuthenticatorPublicKeySet, FieldElement, TREE_DEPTH, authenticator::oprf_query_digest,
+    AuthenticatorPublicKeySet, Credential, FieldElement, SessionId, TREE_DEPTH,
+    authenticator::oprf_query_digest,
 };
 use world_id_proof::{
-    artifacts::embedded::zkeys,
-    circuit_inputs::{NullifierProofCircuitInput, QueryProofCircuitInput},
+    NoirProver as DeepFaceQueryProver,
+    artifacts::embedded::{deepface_query::load_embedded_deepface_query_prover, zkeys},
+    circuit_inputs::{
+        BILLING_TREE_DEPTH, DeepFaceQueryProofCircuitInput, NullifierProofCircuitInput,
+        QueryProofCircuitInput,
+    },
+    deepface_query_proof::generate_deepface_query_proof_with_prover,
 };
 
 use fixtures::{first_leaf_merkle_path, generate_rp_fixture};
@@ -224,6 +230,80 @@ fn generate_nullifier_input() -> (
     (nullifier_input, nullifier_material, rng)
 }
 
+/// Fixed timestamps for the credential fixture, chosen so the credential is valid at
+/// `CURRENT_TIMESTAMP` and reproducible across runs.
+const CREDENTIAL_GENESIS_ISSUED_AT: u64 = 1_700_000_000;
+const CREDENTIAL_EXPIRES_AT: u64 = 1_900_000_000;
+const CURRENT_TIMESTAMP: u64 = 1_800_000_000;
+
+/// Generate a valid `DeepFaceQueryProofCircuitInput` plus its ProveKit prover.
+///
+/// The billing tree is a depth-30 tree holding the human's session id commitment at
+/// index 1, which is the same shape `first_leaf_merkle_path` produces for the registry
+/// tree. The credential is signed by a freshly generated issuer key.
+fn generate_deepface_query_input() -> (DeepFaceQueryProofCircuitInput, DeepFaceQueryProver) {
+    let mut rng = deterministic_rng();
+
+    let prover = load_embedded_deepface_query_prover()
+        .expect("failed to load embedded DeepFace query prover");
+
+    let leaf_index = 1u64;
+    let issuer_schema_id = 1u64;
+
+    // Credential, signed by the issuer over `sub = H(DS_CS_C || leaf_index || blinder)`.
+    let issuer_sk = EdDSAPrivateKey::random(&mut rng);
+    let sub_blinding_factor: FieldElement = Fq::rand(&mut rng).into();
+
+    let mut credential = Credential::new();
+    credential.id = 0x1234_5678_9abc_def0;
+    credential.issuer_version = 0;
+    credential.issuer_schema_id = issuer_schema_id;
+    credential.sub = Credential::compute_sub(leaf_index, sub_blinding_factor);
+    credential.genesis_issued_at = CREDENTIAL_GENESIS_ISSUED_AT;
+    credential.expires_at = CREDENTIAL_EXPIRES_AT;
+    credential.associated_data_commitment = Fq::rand(&mut rng).into();
+
+    let credential = credential.sign(&issuer_sk).expect("credential signing");
+    let pcp_hash = credential.claims_hash().expect("credential claims hash");
+
+    // Billing leaf: the session id commitment `H(DS_C || leaf_index || r)`.
+    let oprf_seed = SessionId::generate_oprf_seed(&mut rng);
+    let commitment_r: FieldElement = Fq::rand(&mut rng).into();
+    let session_id =
+        SessionId::from_r_seed(leaf_index, commitment_r, oprf_seed).expect("session id derivation");
+
+    let (billing_siblings, billing_root) = first_leaf_merkle_path(*session_id.commitment);
+
+    let input = DeepFaceQueryProofCircuitInput {
+        billing_root,
+        billing_depth: BILLING_TREE_DEPTH as u64,
+        pcp_hash,
+        issuer_schema_id,
+        issuer_pk: issuer_sk.public().pk,
+        current_timestamp: CURRENT_TIMESTAMP,
+        genesis_issued_at_min: CREDENTIAL_GENESIS_ISSUED_AT,
+        nonce: Fq::rand(&mut rng).into(),
+        mt_index: leaf_index,
+        commitment_r,
+        billing_leaf_index: leaf_index,
+        billing_siblings,
+        credential_associated_data_hash: credential.associated_data_commitment,
+        credential_genesis_issued_at: credential.genesis_issued_at,
+        credential_expires_at: credential.expires_at,
+        credential_signature: credential.signature.expect("signed credential"),
+        credential_sub_blinding_factor: sub_blinding_factor,
+        // Packed as `BigInt([id, issuer_version, 0, 0])`, matching `Credential::hash`.
+        credential_id: Fq::from(BigInt([
+            credential.id,
+            u64::from(credential.issuer_version),
+            0,
+            0,
+        ])),
+    };
+
+    (input, prover)
+}
+
 // ============================================================================
 // Benchmark Functions
 // ============================================================================
@@ -255,6 +335,47 @@ thread_local! {
         const { RefCell::new(None) };
     static NULLIFIER_WITNESS_CACHE: RefCell<Option<(CircomGroth16Material, Vec<ark_bn254::Fr>)>> =
         const { RefCell::new(None) };
+    static DEEPFACE_QUERY_CACHE: RefCell<Option<(DeepFaceQueryProofCircuitInput, DeepFaceQueryProver)>> =
+        const { RefCell::new(None) };
+}
+
+/// Benchmark: DeepFace Query Proof generation (ProveKit/Noir)
+///
+/// Full measured path: fixture generation, loading the embedded ProveKit prover, witness
+/// generation and proving. This is the cold path a client hits on its first DeepFace
+/// request of a billing period.
+#[benchmark]
+pub fn bench_deepface_query_proof_generation() {
+    let (input, prover) = generate_deepface_query_input();
+
+    let proof = generate_deepface_query_proof_with_prover(input, prover)
+        .expect("DeepFace query proof generation");
+
+    std::hint::black_box(proof);
+}
+
+/// Benchmark: DeepFace Query Proof generation from cached input
+///
+/// Excludes fixture setup and prover deserialization, so it measures witness generation
+/// plus proving. It does include one clone of the prover, because
+/// `provekit_prover::Prove::prove` consumes it; see `docs/benchmarks.md` for that share.
+#[benchmark]
+pub fn bench_deepface_query_cached_proof_generation() {
+    DEEPFACE_QUERY_CACHE.with(|cache| {
+        if cache.borrow().is_none() {
+            *cache.borrow_mut() = Some(generate_deepface_query_input());
+        }
+
+        let cache_ref = cache.borrow();
+        let (input, prover) = cache_ref
+            .as_ref()
+            .expect("DeepFace query proof cache initialized");
+
+        let proof = generate_deepface_query_proof_with_prover(input.clone(), prover.clone())
+            .expect("DeepFace query proof generation");
+
+        std::hint::black_box(proof);
+    });
 }
 
 /// Benchmark: Query Proof (π1) generation from cached input

--- a/crates/zk-mobile-bench/src/lib.rs
+++ b/crates/zk-mobile-bench/src/lib.rs
@@ -32,7 +32,7 @@ use world_id_proof::{
     artifacts::embedded::{deepface_query::load_embedded_deepface_query_prover, zkeys},
     circuit_inputs::{
         BILLING_TREE_DEPTH, DeepFaceQueryProofCircuitInput, NullifierProofCircuitInput,
-        QueryProofCircuitInput,
+        PCP_CLAIM_INDEX, PCP_OTHER_CLAIMS, QueryProofCircuitInput,
     },
     deepface_query_proof::generate_deepface_query_proof_with_prover,
 };
@@ -263,8 +263,26 @@ fn generate_deepface_query_input() -> (DeepFaceQueryProofCircuitInput, DeepFaceQ
     credential.expires_at = CREDENTIAL_EXPIRES_AT;
     credential.associated_data_commitment = Fq::rand(&mut rng).into();
 
+    // The PCP claim is what the enclave derives from `hashes.json`; a second claim keeps
+    // `other_claims` from being an all-zero vector.
+    let credential = credential
+        .claim(PCP_CLAIM_INDEX, b"hashes.json stand-in for the PCP")
+        .expect("pcp claim")
+        .claim(3, b"an unrelated issuer claim")
+        .expect("other claim");
+
+    let pcp_hash = credential.claims[PCP_CLAIM_INDEX];
+    // The claim slots other than the PCP one, in ascending slot order.
+    let mut rest = credential
+        .claims
+        .iter()
+        .enumerate()
+        .filter(|(slot, _)| *slot != PCP_CLAIM_INDEX)
+        .map(|(_, claim)| *claim);
+    let credential_other_claims: [FieldElement; PCP_OTHER_CLAIMS] =
+        std::array::from_fn(|_| rest.next().expect("credential has MAX_CLAIMS slots"));
+
     let credential = credential.sign(&issuer_sk).expect("credential signing");
-    let pcp_hash = credential.claims_hash().expect("credential claims hash");
 
     // Billing leaf: the session id commitment `H(DS_C || leaf_index || r)`.
     let oprf_seed = SessionId::generate_oprf_seed(&mut rng);
@@ -287,6 +305,7 @@ fn generate_deepface_query_input() -> (DeepFaceQueryProofCircuitInput, DeepFaceQ
         commitment_r,
         billing_leaf_index: leaf_index,
         billing_siblings,
+        credential_other_claims,
         credential_associated_data_hash: credential.associated_data_commitment,
         credential_genesis_issued_at: credential.genesis_issued_at,
         credential_expires_at: credential.expires_at,


### PR DESCRIPTION
Implements the DeepFace `Query Proof` — the billing gate a user presents to the Verifier TEE — as a Noir circuit proved with ProveKit, together with the harness to cost it. Draft: the circuit is UNAUDITED and has one deliberate soundness gap plus one provisional constant, both described below.

## What the circuit proves

Without revealing which human is asking:

1. the session id commitment is enrolled in a per-RP-per-period billing Merkle tree, whose root the TEE holds in its host-fed root map (so `rp_id` and `period` need not be explicit inputs);
2. that billing leaf opens to the prover's own World ID (`mt_index`);
3. a valid, unexpired Proof of Human credential for that same World ID commits to `pcp_hash` — which is what stops one enrolled World ID from being used to verify a different human.

Everything identity-bearing (`mt_index`, the session secret `r`, the leaf, the path) is a witness. The public inputs are shared by everyone enrolled under that root.

## Noir/ProveKit rather than Circom

- No trusted setup: `.pkp`/`.pkv` are derived from the checked-in source by the ProveKit R1CS compiler at build time, same as `ownership_proof`.
- The prover artifact is **718 KiB**, against 26.7 MiB for the Circom nullifier material (`OPRFNullifier.arks.zkey` + witness graph).

## `pcp_hash` is claim slot 0 of the iris credential

The YABS doc names a public `PCP hash` and says the TEE must check it "matches the one derived from `hashes.json`", without naming the signed credential field. The PoH credential is not issued in this repo, so the schema comes from `signup-service`: `createClaimFromPcp` sets a single claim to `base64(hashes.json)`, and `Claims` entries are documented as "raw claim values (base64 encoded)" that "the signer will compute the Poseidon2 hash for", with "indices assigned automatically (0, 1, 2, ...)".

So the base64 is JSON transport, the pre-image is the `hashes.json` bytes, the value is `H(b"CLAIMS_HASH_V1" || hashes.json)`, and the slot is 0 — precisely what the enclave can derive from the `hashes.json` it already holds. `services/faux-issuer` sets no claims and is a stand-in, so it says nothing about the real schema.

Ruled out:

- **`associated_data_commitment`** — the `Credential` docs make it issuer-private ("never exposed to RPs or others") with a structure "solely determined by the issuer", so binding the protocol to it would misuse the field *and* let an issuer break this circuit by changing their own encoding.
- **The aggregate `claims_hash`** — the TEE cannot check it: deriving it needs every claim slot, and the TEE only sees the PCP. It would also leak a handle to claims the TEE has no business learning.

The circuit therefore takes the PCP claim as a public input, the other 15 slots as witnesses, and recomputes `claims_hash` around them.

Two consequences worth noting for reviewers:

- **Claim indices are schema-scoped.** The *face* credential, from the same service, uses slot 0 for a uniqueness flag and slot 1 for a score, written via `ClaimHashes` so they land verbatim instead of Poseidon2-hashed. A slot index only means something alongside `issuer_schema_id`, which the TEE must pin to the PoH schema.
- **`hashes.json` is version-dependent** — flattened and entry-sorted, with several PCP versions in circulation. The enclave has to canonicalise identically to the orb, or the claim will not match.

## Measurements

Apple M4 Max, `--release`, `nargo` 1.0.0-beta.11, ProveKit 0.1.4. Full detail and reproduction steps in `crates/proof/noir/deepface-query-proof/docs/benchmarks.md`.

| | |
|---|---|
| Circuit size | 26,520 ACIR opcodes (`ownership_proof` is 26,059 for comparison) |
| Cost model | 15,720 fixed + 360 per billing tree level, exactly linear |
| Opening one claim vs the aggregate | +868 opcodes (3.4%) |
| Proving, cold | 0.339 s mean, 117 MiB process peak RSS |
| Proving, cached prover | 0.234 s mean |

Billing depth is set to 30 here only to keep the comparison against registry-sized trees honest. The tree holds one `(rp_id, period)` pair, so `ceil(log2(n))` suffices — at 10,000 leaves that is depth 14 and 20,760 opcodes, 22% cheaper.

## Deliberate gap: control of the World ID is not proven

There is no `WorldIDRegistry` inclusion proof and no authenticator signature, so soundness rests on `r` and the credential being secrets only the holder has. Closing it *in this circuit* means adding the `ownership_proof` constraints, which by the two measured sizes roughly doubles it to ~52k opcodes. The cheaper alternative is to keep ownership on the cold path — enrollment already carries such a proof — and add a rotation operation so a compromised session secret can be revoked without re-enrolling. Flagged in the `src/main.nr` module docs and in the benchmark doc.

## Changes

- `crates/proof/noir/deepface-query-proof/` — the circuit, with 7 Noir unit tests.
- `crates/proof/src/deepface_query_proof.rs` — witness construction, prove and verify.
- `crates/proof/build.rs` — `noir_artifacts::setup` generalised over the Noir package, so it builds both circuits instead of only the ownership proof.
- New `embed-deepface-query-prover` / `-verifier` features, deliberately outside the `embed-noir-artifacts` umbrella so existing consumers do not grow by 718 KiB of unaudited prover.
- `crates/zk-mobile-bench` — two ProveKit benchmark functions, the first in that crate; `run_local` now takes benchmark names as arguments.
- `.github/workflows/noir-ci.yml` — matrix over both Noir packages; it previously hardcoded `ownership-proof`, so a new package's `nargo fmt`/`nargo test` would go unenforced.

## Test plan

- [ ] `cd crates/proof/noir/deepface-query-proof && nargo test` — 7 pass.
- [ ] `cargo test -p world-id-proof --all-features --release` — 21 pass, including `tests/deepface_query_proof.rs`: one valid proof verifies, and eight negative controls each break exactly one constraint (wrong billing root, credential bound to another World ID, unauthenticated `pcp_hash`, tampered non-PCP claim slots, PCP presented in the wrong slot, expired credential, credential older than the genesis minimum, wrong session secret).
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean.
- [ ] `cargo +nightly fmt --all -- --check` — clean.

The valid-proof test is also the cross-implementation check: if the in-circuit `claims_hash` layout did not match `Credential::claims_hash` byte for byte, the issuer signature would not verify.

Requires `nargo` exactly 1.0.0-beta.11 on PATH; `crates/proof/build.rs` fails the build otherwise.

## Follow-ups, not in this PR

- `Credential::claims_hash` has no domain separator: all 16 slots are data and the t16 output is taken at index 1 — the same permutation and output index as `MerkleLeaf` in `circom/client_side_proofs/oprf_query.circom`, which does reserve a capacity element for one. Not obviously exploitable, but there is no spare slot to add one without a credential version bump.
- `compute_merkle_root_poseidon2` is duplicated from `noir/ownership-proof`, which is a `bin` and so cannot be imported. Both must stay in sync with `circom/merkle_tree/binary_merkle_root.circom`; extracting a shared Noir lib would fix all three.
- `mobile-bench.yml` lists benchmark functions explicitly via the `functions` input, so the two new ones must be added there before CI runs them on device.
- An iOS/Android build of the ProveKit prover has not been exercised — the existing mobile benchmarks are all Circom/Groth16.
