### PR TITLE
refactor: declare InvalidAction on a V2 interface

### DIFF
--- a/contracts/src/core/WorldIDVerifierV2.sol
+++ b/contracts/src/core/WorldIDVerifierV2.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.13;
 
 import {WorldIDVerifier} from "./WorldIDVerifier.sol";
 import {IWorldIDVerifier} from "./interfaces/IWorldIDVerifier.sol";
+import {IWorldIDVerifierV2} from "./interfaces/IWorldIDVerifierV2.sol";
 
 /**
  * @title WorldIDVerifier
@@ -12,14 +13,7 @@ import {IWorldIDVerifier} from "./interfaces/IWorldIDVerifier.sol";
  *  circuits through checks with the WorldIDRegistry, CredentialSchemaIssuerRegistry, and OprfKeyRegistry.
  * @custom:repo https://github.com/world-id/world-id-protocol
  */
-contract WorldIDVerifierV2 is WorldIDVerifier {
-    /**
-     * @dev Thrown when the action is not valid for the type of proof. The prefix is enforced
-     *  to ensure any nullifier request for a Uniqueness Proof is signed by the RP (actions
-     *  without this prefix, i.e. for sessions, it doesn't need to be signed).
-     */
-    error InvalidAction();
-
+contract WorldIDVerifierV2 is IWorldIDVerifierV2, WorldIDVerifier {
     /// @inheritdoc IWorldIDVerifier
     function verify(
         uint256 nullifier,
@@ -31,7 +25,7 @@ contract WorldIDVerifierV2 is WorldIDVerifier {
         uint64 issuerSchemaId,
         uint256 credentialGenesisIssuedAtMin,
         uint256[5] calldata zeroKnowledgeProof
-    ) external view virtual override onlyProxy onlyInitialized {
+    ) external view virtual override(IWorldIDVerifier, WorldIDVerifier) onlyProxy onlyInitialized {
         if (uint8(action >> 248) != uint8(0)) {
             revert InvalidAction();
         }
@@ -63,7 +57,7 @@ contract WorldIDVerifierV2 is WorldIDVerifier {
         uint256 sessionId,
         uint256[2] calldata sessionNullifier,
         uint256[5] calldata zeroKnowledgeProof
-    ) external view virtual override onlyProxy onlyInitialized {
+    ) external view virtual override(IWorldIDVerifier, WorldIDVerifier) onlyProxy onlyInitialized {
         uint256 action = sessionNullifier[1];
         if (uint8(action >> 248) != uint8(2)) {
             revert InvalidAction();

--- a/contracts/src/core/interfaces/IWorldIDVerifierV2.sol
+++ b/contracts/src/core/interfaces/IWorldIDVerifierV2.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import {IWorldIDVerifier} from "./IWorldIDVerifier.sol";
+
+/**
+ * @title IWorldIDVerifierV2
+ * @author World Contributors
+ * @notice Interface for verifying World ID proofs (Uniqueness and Session proofs).
+ * @dev V2 enforces the action-prefix convention on the convenience entry points: `verify` requires
+ *  the action's most significant byte to be `0x00`, `verifySession` requires `0x02`.
+ */
+interface IWorldIDVerifierV2 is IWorldIDVerifier {
+    ////////////////////////////////////////////////////////////
+    //                        ERRORS                          //
+    ////////////////////////////////////////////////////////////
+
+    /**
+     * @dev Thrown when the action is not valid for the type of proof. The prefix is enforced
+     *  to ensure any nullifier request for a Uniqueness Proof is signed by the RP (actions
+     *  without this prefix, i.e. for sessions, it doesn't need to be signed).
+     */
+    error InvalidAction();
+}

--- a/contracts/test/core/WorldIDVerifierV2Test.t.sol
+++ b/contracts/test/core/WorldIDVerifierV2Test.t.sol
@@ -5,6 +5,7 @@ import {Test} from "forge-std/Test.sol";
 import {WorldIDVerifierV2} from "../../src/core/WorldIDVerifierV2.sol";
 import {WorldIDVerifier} from "../../src/core/WorldIDVerifier.sol";
 import {IWorldIDVerifier} from "../../src/core/interfaces/IWorldIDVerifier.sol";
+import {IWorldIDVerifierV2} from "../../src/core/interfaces/IWorldIDVerifierV2.sol";
 import {BabyJubJub} from "oprf-key-registry/src/BabyJubJub.sol";
 import {Verifier} from "../../src/core/Verifier.sol";
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
@@ -60,7 +61,7 @@ contract WorldIDVerifierV2Test is Test {
         uint256 action = 0x15d4b66e5417cb9875f6a2b5be9814dca80651d7c74b3b21685fdd494566e79f;
 
         vm.warp(expiresAtMin + 1 hours);
-        vm.expectRevert(abi.encodeWithSelector(WorldIDVerifierV2.InvalidAction.selector));
+        vm.expectRevert(abi.encodeWithSelector(IWorldIDVerifierV2.InvalidAction.selector));
         verifier.verify(
             nullifier, action, rpIdCorrect, nonce, signalHash, expiresAtMin, credentialIssuerIdCorrect, 0, proof
         );
@@ -71,7 +72,7 @@ contract WorldIDVerifierV2Test is Test {
         vm.assume(uint8(action >> 248) != 0);
 
         vm.warp(expiresAtMin + 1 hours);
-        vm.expectRevert(abi.encodeWithSelector(WorldIDVerifierV2.InvalidAction.selector));
+        vm.expectRevert(abi.encodeWithSelector(IWorldIDVerifierV2.InvalidAction.selector));
         verifier.verify(
             nullifier, action, rpIdCorrect, nonce, signalHash, expiresAtMin, credentialIssuerIdCorrect, 0, proof
         );
@@ -83,7 +84,7 @@ contract WorldIDVerifierV2Test is Test {
         uint256 sessionId = 1;
 
         vm.warp(expiresAtMin + 1 hours);
-        vm.expectRevert(abi.encodeWithSelector(WorldIDVerifierV2.InvalidAction.selector));
+        vm.expectRevert(abi.encodeWithSelector(IWorldIDVerifierV2.InvalidAction.selector));
         verifier.verifySession(
             rpIdCorrect,
             nonce,
@@ -102,7 +103,7 @@ contract WorldIDVerifierV2Test is Test {
         uint256 sessionId = 1;
 
         vm.warp(expiresAtMin + 1 hours);
-        vm.expectRevert(abi.encodeWithSelector(WorldIDVerifierV2.InvalidAction.selector));
+        vm.expectRevert(abi.encodeWithSelector(IWorldIDVerifierV2.InvalidAction.selector));
         verifier.verifySession(
             rpIdCorrect,
             nonce,


### PR DESCRIPTION
`WorldIDVerifierV2` declares `InvalidAction` inline in the contract body, while every other verifier error is declared on `IWorldIDVerifier`. An integrator holding only an interface can decode `ExpirationTooOld`, `InvalidMerkleRoot` and `UnregisteredIssuerSchemaId`, but has to import the implementation contract to decode `InvalidAction`.

Adds `IWorldIDVerifierV2` and moves the declaration there.

Note: This also fills the gap of the missing v2 interface.

### Changes

- new `contracts/src/core/interfaces/IWorldIDVerifierV2.sol` holding `InvalidAction`
- `WorldIDVerifierV2` inherits it; the inline declaration is removed and the two `override` lists widen to `override(IWorldIDVerifier, WorldIDVerifier)` because `verify`/`verifySession` are now reachable through two bases
- `WorldIDVerifierV2Test` references `IWorldIDVerifierV2.InvalidAction.selector` (4 call sites)