### PR TITLE
refactor(noir): single entrypoint for attestation verification

### DIFF
--- a/crates/proof/noir/README.md
+++ b/crates/proof/noir/README.md
@@ -16,6 +16,39 @@
   signature under the key that TAKT attests. That key equality is the *only*
   binding — if you touch either verification path, preserve it.
 
+## Consuming `authenticator-attestation`
+
+`attestation::verify_attestation` is the only entrypoint. `verify_takt` and
+`verify_aat` are crate-private by design: a TAKT alone attests a key without
+saying what it signed, and an AAT alone proves only that *some* key signed the
+claims. Going through the composite is what binds them — it feeds `verify_aat`
+the `assertion_key` read from the TAKT it just verified, so the two cannot be
+mismatched. If you find yourself wanting one half, verify both and ignore what
+you don't need.
+
+The library cannot enforce the rest. A calling circuit MUST:
+
+- expose `trust_anchor_key_x`/`_y` and `now` as **public inputs**. The trust
+  anchor key is the RP's entire trust decision, taken from the provider's
+  Authenticator Metadata; left private, a prover signs its own TAKT and the
+  attestation proves nothing. A private `now` lets a prover pick a time at which
+  any token is fresh.
+- bind `aat.nonce` and `aat.cdh` to the surrounding proof.
+- expose whichever of `sec_flags` (via `takt::unpack_sec_flags`) and
+  `aat.authenticator_meta` the RP needs for its business rules.
+
+```rust
+fn main(
+    trust_anchor_key_x: pub Field,
+    trust_anchor_key_y: pub Field,
+    now: pub Field,
+    aat: AuthenticatorAssertionToken,
+    takt: TrustAnchorKeyToken,
+) {
+    verify_attestation(aat, takt, trust_anchor_key_x, trust_anchor_key_y, now);
+}
+```
+
 ## Development workflow
 
 Circuits are developed and tested with **nargo only** — no proving backend:

--- a/crates/proof/noir/authenticator-attestation/src/aat.nr
+++ b/crates/proof/noir/authenticator-attestation/src/aat.nr
@@ -1,7 +1,6 @@
 // Verification of an Authenticator Assertion Token (AAT): a token
 // representing integrity of a specific environment through an environment-bound
 // key which is attested by a Trust Anchor Key Token (TAKT).
-use super::takt::{TrustAnchorKeyToken, verify_takt};
 use super::utils::{assert_cbor_uint32, assert_not_expired};
 use bigcurve::curves::secp256r1::{Secp256r1_Fq, Secp256r1_Fr};
 use bignum::BigNum;
@@ -20,44 +19,48 @@ use noir_ecdsa::ecdsa::verify_secp256r1_ecdsa;
 /// length (`0x58 0x9f`), where the old 417-byte payload needed the 2-byte form.
 pub global AAT_SIG_STRUCTURE_LEN: u32 = 178;
 
+/// The claims and signature of an Authenticator Assertion Token, as parsed from
+/// its `COSE_Sign1` encoding. The accompanying TAKT is *not* part of the token:
+/// it rides in the unprotected header, outside this signature, and is verified
+/// separately (see `attestation::verify_attestation`).
 pub struct AuthenticatorAssertionToken {
     /// The `rpId` of the requesting RP (CWT `aud`). MUST require a 4-byte
     /// CBOR uint encoding (`2^16 <= aud < 2^32`) so offsets stay constant.
-    aud: Field,
+    pub aud: Field,
     /// Expiration as seconds since the Unix epoch (CWT `exp`). MUST require a
-    /// 4-byte CBOR uint encoding (holds for dates between 1971 and 2106).
-    exp: Field,
+    /// 4-byte CBOR uint encoding (`2^16 <= exp < 2^32`), i.e. any instant from
+    /// 1970-01-01T18:12:16Z up to 2106.
+    pub exp: Field,
     /// The `ProofRequest` nonce binding the token to a specific request.
-    nonce: Field,
+    pub nonce: Field,
     /// Client data hash (CWT `cdh`): an arbitrary commitment binding the token
     /// to its upstream use case. A nil value is 32 zero bytes.
-    cdh: Field,
+    pub cdh: Field,
     /// Structured integrity metadata: user presence (bits 0-2) and
     /// provider-defined bits (3-4); all other bits are reserved (zero).
-    authenticator_meta: Field,
-    /// The TAKT attesting the assertion key. It is carried outside the AAT
-    /// signature, so nothing here proves the pairing on its own -- the binding
-    /// is `verify_takt` plus the ES256 key equality enforced in `verify_aat`.
-    takt: TrustAnchorKeyToken,
+    pub authenticator_meta: Field,
     /// ES256 signature over the COSE `Sig_structure` (`r || s`, low-S).
-    signature: [u8; 64],
+    pub signature: [u8; 64],
 }
 
-/// Verifies the full WIP-106 attestation chain:
-/// 1. the TAKT attests the assertion key (`BabyJubJub-EdDSA-Poseidon2`), and
-/// 2. the attested assertion key signs the AAT (`ES256` over the COSE
-///    `Sig_structure`).
+/// Verifies that `assertion_key` signed this AAT (`ES256` over the COSE
+/// `Sig_structure`) and that the token is unexpired.
 ///
-/// `now` is the verifier-supplied Unix time (seconds) used for CWT `exp`
-/// freshness on both the AAT and its accompanying TAKT (`now < exp`). It MUST be a
-/// public input of any outer proof that calls this function.
+/// Crate-private on purpose: this proves only that *some* key signed these
+/// claims. Nothing here says the key is genuine -- that requires a TAKT
+/// attesting it, which is why consumers go through
+/// `attestation::verify_attestation` instead.
 ///
-/// This is the primary entrypoint; the TAKT digest is computed exactly once
-/// along this path (inside `verify_takt`).
-pub fn verify_aat(aat: AuthenticatorAssertionToken, now: Field) {
+/// `now` is the verifier-supplied Unix time (seconds) checked against CWT `exp`
+/// (`now < exp`), and MUST be a public input of the outer circuit.
+pub(crate) fn verify_aat(
+    aat: AuthenticatorAssertionToken,
+    assertion_key_x: [u8; 32],
+    assertion_key_y: [u8; 32],
+    now: Field,
+) {
     // CBOR uint32 encoding of `exp` is checked later in `aat_sig_structure`.
     assert_not_expired(aat.exp, now);
-    verify_takt(aat.takt, now);
 
     let message = aat_sig_structure(aat);
     let digest = sha256::digest(message);
@@ -66,8 +69,8 @@ pub fn verify_aat(aat: AuthenticatorAssertionToken, now: Field) {
     // `ecdsa_secp256r1` black box: provekit does not implement it, so the
     // black box passes `nargo test` but cannot be proven. Only black boxes
     // from provekit's allowlist may be used here; see crates/proof/noir/README.md.
-    let public_key_x = Secp256r1_Fq::from_be_bytes(aat.takt.assertion_key_x);
-    let public_key_y = Secp256r1_Fq::from_be_bytes(aat.takt.assertion_key_y);
+    let public_key_x = Secp256r1_Fq::from_be_bytes(assertion_key_x);
+    let public_key_y = Secp256r1_Fq::from_be_bytes(assertion_key_y);
     let r = signature_scalar(aat.signature, 0);
     let s = signature_scalar(aat.signature, 32);
 
@@ -179,11 +182,10 @@ fn aat_sig_structure(input: AuthenticatorAssertionToken) -> [u8; AAT_SIG_STRUCTU
     msg
 }
 
-/// Known-answer test companion to `test_deterministic_takt`: the same TAKT,
-/// wrapped in an AAT signed by the assertion key (`ES256`, RFC 6979
-/// deterministic, low-S normalized). Values generated by the Rust
-/// implementation.
-fn test_deterministic_aat() -> AuthenticatorAssertionToken {
+/// Known-answer test companion to `test_deterministic_takt`: an AAT signed by
+/// the key that fixture attests (`ES256`, RFC 6979 deterministic, low-S
+/// normalized). Values generated by the Rust implementation.
+pub(crate) fn test_deterministic_aat() -> AuthenticatorAssertionToken {
     AuthenticatorAssertionToken {
         aud: 1928118,
         exp: super::takt::TEST_EXP,
@@ -191,7 +193,6 @@ fn test_deterministic_aat() -> AuthenticatorAssertionToken {
         cdh: 0x9f2c1abc,
         // presence PresentBiometric (0b010) | provider 0b01 << 3
         authenticator_meta: 10,
-        takt: super::takt::test_deterministic_takt(),
         signature: [
             0x33, 0x07, 0x2e, 0x05, 0x70, 0x4c, 0x92, 0x7b, 0x97, 0x54, 0xdc, 0x49, 0x4c, 0x0d,
             0x31, 0xbc, 0x87, 0x5e, 0x03, 0xa2, 0x03, 0x35, 0x83, 0xc2, 0xa6, 0x03, 0x46, 0xee,
@@ -202,26 +203,44 @@ fn test_deterministic_aat() -> AuthenticatorAssertionToken {
     }
 }
 
+/// The assertion key attested by `test_deterministic_takt`, which signed
+/// `test_deterministic_aat`.
+fn test_assertion_key() -> ([u8; 32], [u8; 32]) {
+    let takt = super::takt::test_deterministic_takt();
+    (takt.assertion_key_x, takt.assertion_key_y)
+}
+
 #[test]
 fn test_deterministic_aat_verification() {
-    verify_aat(test_deterministic_aat(), super::takt::TEST_NOW);
+    let (key_x, key_y) = test_assertion_key();
+    verify_aat(
+        test_deterministic_aat(),
+        key_x,
+        key_y,
+        super::takt::TEST_NOW,
+    );
 }
 
 #[test(should_fail_with = "invalid AAT signature")]
 fn test_aat_tampered_claim() {
+    let (key_x, key_y) = test_assertion_key();
     let mut aat = test_deterministic_aat();
     aat.nonce += 1;
-    verify_aat(aat, super::takt::TEST_NOW);
+    verify_aat(aat, key_x, key_y, super::takt::TEST_NOW);
 }
 
 #[test(should_fail_with = "invalid AAT signature")]
-fn test_aat_key_not_attested() {
-    // A valid TAKT attesting a different assertion key must not verify this
-    // AAT: the embedded TAKT bytes and the ES256 verification key are both
-    // derived from the (wrong) attested key.
-    let mut aat = test_deterministic_aat();
-    aat.takt = super::takt::test_deterministic_takt_unrelated_key();
-    verify_aat(aat, super::takt::TEST_NOW);
+fn test_aat_wrong_assertion_key() {
+    // Verifying under any key other than the one that signed must fail. The
+    // composite entrypoint is what guarantees the key came from a TAKT; see
+    // `attestation::test_aat_key_not_attested`.
+    let unrelated = super::takt::test_deterministic_takt_unrelated_key();
+    verify_aat(
+        test_deterministic_aat(),
+        unrelated.assertion_key_x,
+        unrelated.assertion_key_y,
+        super::takt::TEST_NOW,
+    );
 }
 
 #[test(should_fail_with = "AAT signature r value is zero")]
@@ -229,22 +248,30 @@ fn test_aat_zero_r_rejected() {
     // Guards the check `noir_ecdsa` only gained in v0.4.1; we pin v0.2.9, so
     // without our explicit assertion an `r = 0` signature would verify against
     // any public key. Delete this test only if the pin moves to >= v0.4.1.
+    let (key_x, key_y) = test_assertion_key();
     let mut aat = test_deterministic_aat();
     for i in 0..32 {
         aat.signature[i] = 0;
     }
-    verify_aat(aat, super::takt::TEST_NOW);
+    verify_aat(aat, key_x, key_y, super::takt::TEST_NOW);
 }
 
 #[test(should_fail_with = "authenticator_meta bits 5+ are reserved")]
 fn test_aat_reserved_meta_bits_rejected() {
+    let (key_x, key_y) = test_assertion_key();
     let mut aat = test_deterministic_aat();
     aat.authenticator_meta = 32; // bit 5 set
-    verify_aat(aat, super::takt::TEST_NOW);
+    verify_aat(aat, key_x, key_y, super::takt::TEST_NOW);
 }
 
 #[test(should_fail)]
 fn test_expired_aat_rejected() {
     // At `exp` the token is already expired (RFC 8392: "on or after").
-    verify_aat(test_deterministic_aat(), super::takt::TEST_EXP);
+    let (key_x, key_y) = test_assertion_key();
+    verify_aat(
+        test_deterministic_aat(),
+        key_x,
+        key_y,
+        super::takt::TEST_EXP,
+    );
 }

--- a/crates/proof/noir/authenticator-attestation/src/attestation.nr
+++ b/crates/proof/noir/authenticator-attestation/src/attestation.nr
@@ -1,0 +1,82 @@
+// The WIP-106 Authenticator Attestation: the pair of tokens that together
+// prove a World ID proof was produced in an environment the Authenticator
+// Provider vouches for. This is the only entrypoint consumers can reach.
+use super::aat::{AuthenticatorAssertionToken, verify_aat};
+use super::takt::{TrustAnchorKeyToken, verify_takt};
+
+/// Verifies a complete Authenticator Attestation:
+/// 1. the TAKT is signed by the Authenticator Provider's `trust_anchor_key`
+///    (`BabyJubJub-EdDSA-Poseidon2`), attesting an `assertion_key`, and
+/// 2. that attested `assertion_key` signed the AAT (`ES256` over the COSE
+///    `Sig_structure`).
+///
+/// Both tokens must be unexpired at `now`.
+///
+/// The two tokens are bound *solely* by the shared `assertion_key`: the TAKT
+/// travels in the AAT's `COSE_Sign1` unprotected header and so is not covered by
+/// the AAT signature. That binding is enforced here by construction -- the key
+/// handed to `verify_aat` is read from the TAKT this function just verified, and
+/// there is no other way to supply it. `verify_takt` and `verify_aat` are
+/// crate-private for exactly this reason: neither half proves anything alone.
+///
+/// # Public inputs
+/// `trust_anchor_key_x` / `_y` and `now` are verifier-supplied and MUST be
+/// public inputs of the calling circuit. `trust_anchor_key` carries the RP's
+/// trust decision (allowlisted from the provider's Authenticator Metadata), and
+/// a private `now` would let the prover pick a time at which any token is fresh.
+/// Neither can be enforced from inside this library -- see
+/// crates/proof/noir/README.md.
+///
+/// Callers are additionally responsible for binding `aat.nonce` and `aat.cdh`
+/// to the surrounding proof, and for exposing whichever of `sec_flags` (via
+/// `takt::unpack_sec_flags`) and `aat.authenticator_meta` their RP needs.
+pub fn verify_attestation(
+    aat: AuthenticatorAssertionToken,
+    takt: TrustAnchorKeyToken,
+    trust_anchor_key_x: Field,
+    trust_anchor_key_y: Field,
+    now: Field,
+) {
+    verify_takt(takt, trust_anchor_key_x, trust_anchor_key_y, now);
+    verify_aat(aat, takt.assertion_key_x, takt.assertion_key_y, now);
+}
+
+#[test]
+fn test_deterministic_attestation() {
+    verify_attestation(
+        super::aat::test_deterministic_aat(),
+        super::takt::test_deterministic_takt(),
+        super::takt::TEST_TRUST_ANCHOR_KEY_X,
+        super::takt::TEST_TRUST_ANCHOR_KEY_Y,
+        super::takt::TEST_NOW,
+    );
+}
+
+#[test(should_fail_with = "invalid AAT signature")]
+fn test_aat_key_not_attested() {
+    // A TAKT that is itself valid, but attests an unrelated assertion key, must
+    // not verify this AAT: the ES256 key comes from the TAKT, so swapping the
+    // TAKT swaps the key the AAT is checked against.
+    verify_attestation(
+        super::aat::test_deterministic_aat(),
+        super::takt::test_deterministic_takt_unrelated_key(),
+        super::takt::TEST_TRUST_ANCHOR_KEY_X,
+        super::takt::TEST_TRUST_ANCHOR_KEY_Y,
+        super::takt::TEST_NOW,
+    );
+}
+
+#[test(should_fail_with = "invalid signature")]
+fn test_untrusted_trust_anchor_key_rejected() {
+    // The verifier's key is what the whole chain rests on: a TAKT signed by
+    // anyone else must not verify, even though every claim in it is well formed.
+    // Checked against the BabyJubJub prime-order subgroup generator, so the
+    // failure is the signature check and not a point validity assert.
+    verify_attestation(
+        super::aat::test_deterministic_aat(),
+        super::takt::test_deterministic_takt(),
+        5299619240641551281634865583518297030282874472190772894086521144482721001553,
+        16950150798460657717958625567821834550301663161624707787222815936182638968203,
+        super::takt::TEST_NOW,
+    );
+}

--- a/crates/proof/noir/authenticator-attestation/src/lib.nr
+++ b/crates/proof/noir/authenticator-attestation/src/lib.nr
@@ -1,4 +1,5 @@
 pub mod aat;
+pub mod attestation;
 pub(crate) mod constants;
 pub mod takt;
 pub(crate) mod utils;

--- a/crates/proof/noir/authenticator-attestation/src/takt.nr
+++ b/crates/proof/noir/authenticator-attestation/src/takt.nr
@@ -3,37 +3,46 @@ use super::utils::{assert_cbor_uint32, assert_not_expired, p256_be_coord_to_fiel
 use eddsa_poseidon2::verify_eddsa_poseidon2;
 use poseidon2::bn254::perm;
 
+/// The claims and signature of a Trust Anchor Key Token, as parsed from its
+/// `COSE_Sign1` encoding. The `trust_anchor_key` that signed it is *not* part of
+/// the token: it is identified only by the `kid` protected-header parameter,
+/// which WIP-106 leaves outside the signature, so verifiers supply the key they
+/// trust out of band (see `verify_takt`).
 pub struct TrustAnchorKeyToken {
     /// Expiration as seconds since the Unix epoch (CWT `exp`).
-    exp: Field,
+    pub exp: Field,
     /// Big-endian affine x coordinate of the attested assertion key (`cnf`).
-    pub(crate) assertion_key_x: [u8; 32],
+    pub assertion_key_x: [u8; 32],
     /// Big-endian affine y coordinate of the attested assertion key (`cnf`).
-    pub(crate) assertion_key_y: [u8; 32],
+    pub assertion_key_y: [u8; 32],
     /// Packed security attributes (`sec_flags`, LSB-first): platform
     /// (bits 0-7), sec_level (8-15), build_version (16-47), sec_meta (48-51).
-    sec_flags: Field,
+    pub sec_flags: Field,
     /// EdDSA signature scalar component.
-    sig_s: Field,
+    pub sig_s: Field,
     /// EdDSA signature point component (affine x, y).
-    sig_r: [Field; 2],
-    /// Affine x coordinate of the Authenticator Provider's `trust_anchor_key`.
-    trust_anchor_key_x: Field,
-    /// Affine y coordinate of the Authenticator Provider's `trust_anchor_key`.
-    trust_anchor_key_y: Field,
+    pub sig_r: [Field; 2],
 }
 
-/// Verifies a Trust Anchor Key Token.
+/// Verifies a Trust Anchor Key Token under the Authenticator Provider's
+/// `trust_anchor_key`.
 ///
-/// `now` is the verifier-supplied Unix time (seconds) against which CWT `exp`
-/// freshness is checked (`now < exp`). It MUST be a public input of any outer
-/// proof that calls this function.
-pub fn verify_takt(input: TrustAnchorKeyToken, now: Field) {
-    // WIP-106 fixes `exp` to a 4-byte CBOR uint. The circuit no longer
-    // serializes the TAKT (it rides in the AAT's unprotected header), so this
-    // is the only place that constraint is still enforced -- the Rust
-    // constructor only range-checks the CWT numeric date. Must precede the
-    // freshness check so an out-of-range `exp` reports the encoding error.
+/// Crate-private on purpose: a TAKT on its own attests a key, but says nothing
+/// about the request that key signed. Consumers go through
+/// `attestation::verify_attestation`, which cannot be called without both
+/// tokens.
+///
+/// Both `trust_anchor_key_x` / `_y` and `now` are verifier-supplied and MUST be
+/// public inputs of the outer circuit. `trust_anchor_key` is the RP's entire
+/// trust decision -- taken from the provider's Authenticator Metadata and
+/// allowlisted by the RP. Left private, a prover could sign a TAKT with a key of
+/// its own choosing and the attestation would prove nothing.
+pub(crate) fn verify_takt(
+    input: TrustAnchorKeyToken,
+    trust_anchor_key_x: Field,
+    trust_anchor_key_y: Field,
+    now: Field,
+) {
     assert_cbor_uint32(input.exp);
     assert_not_expired(input.exp, now);
 
@@ -43,8 +52,8 @@ pub fn verify_takt(input: TrustAnchorKeyToken, now: Field) {
     let digest = takt_digest(input);
 
     let is_valid = verify_eddsa_poseidon2(
-        input.trust_anchor_key_x,
-        input.trust_anchor_key_y,
+        trust_anchor_key_x,
+        trust_anchor_key_y,
         input.sig_s,
         input.sig_r,
         digest,
@@ -111,6 +120,15 @@ pub(crate) global TEST_EXP: Field = 1783446925;
 /// Verifier time used by happy-path tests: strictly before `TEST_EXP`.
 pub(crate) global TEST_NOW: Field = 1700000000;
 
+/// The `trust_anchor_key` (BabyJubJub, affine x) that signed both deterministic
+/// TAKT fixtures. Supplied by the verifier, so it is no longer part of the token.
+pub(crate) global TEST_TRUST_ANCHOR_KEY_X: Field =
+    19037598474602150174935475944965340829216795940473064039209388058233204431288;
+
+/// Affine y of `TEST_TRUST_ANCHOR_KEY_X`.
+pub(crate) global TEST_TRUST_ANCHOR_KEY_Y: Field =
+    3549932221586364715003722955756497910920276078443163728621283280434115857197;
+
 pub(crate) fn test_deterministic_takt() -> TrustAnchorKeyToken {
     // P-256 coordinates as (hi, lo) 128-bit limbs. A whole coordinate cannot
     // be a single Field literal: it may exceed the BN254 modulus (y does here).
@@ -131,8 +149,6 @@ pub(crate) fn test_deterministic_takt() -> TrustAnchorKeyToken {
             3038940160993341489764135949086927490288273871352067753480373103236792890019,
             3575406791906717862024209997991679600338512115093140550225375654630093303539,
         ],
-        trust_anchor_key_x: 19037598474602150174935475944965340829216795940473064039209388058233204431288,
-        trust_anchor_key_y: 3549932221586364715003722955756497910920276078443163728621283280434115857197,
     }
 }
 
@@ -156,8 +172,6 @@ pub(crate) fn test_deterministic_takt_unrelated_key() -> TrustAnchorKeyToken {
             2497510479714884033897370712372642880357637781552444460856656911402405468283,
             6160154892924888407590390789330876549069607663319416268142058127129410358139,
         ],
-        trust_anchor_key_x: 19037598474602150174935475944965340829216795940473064039209388058233204431288,
-        trust_anchor_key_y: 3549932221586364715003722955756497910920276078443163728621283280434115857197,
     }
 }
 
@@ -169,7 +183,12 @@ fn test_deterministic_takt_verification() {
         13841652385841404096687877664637984932218603617558109472176126865842396474985,
         "digest mismatch",
     );
-    verify_takt(candidate, TEST_NOW);
+    verify_takt(
+        candidate,
+        TEST_TRUST_ANCHOR_KEY_X,
+        TEST_TRUST_ANCHOR_KEY_Y,
+        TEST_NOW,
+    );
 }
 
 #[test(should_fail_with = "invalid signature")]
@@ -177,20 +196,35 @@ fn test_digest_mismatch() {
     let mut candidate = test_deterministic_takt();
     // platform sub-field: 2 -> 4
     candidate.sec_flags = 0x0003000007D60104;
-    verify_takt(candidate, TEST_NOW);
+    verify_takt(
+        candidate,
+        TEST_TRUST_ANCHOR_KEY_X,
+        TEST_TRUST_ANCHOR_KEY_Y,
+        TEST_NOW,
+    );
 }
 
 #[test(should_fail_with = "sec_flags bits 52-55 are reserved and must be 0")]
 fn test_reserved_sec_flags_bits_rejected() {
     let mut candidate = test_deterministic_takt();
     candidate.sec_flags = 0x0013000007D60102;
-    verify_takt(candidate, TEST_NOW);
+    verify_takt(
+        candidate,
+        TEST_TRUST_ANCHOR_KEY_X,
+        TEST_TRUST_ANCHOR_KEY_Y,
+        TEST_NOW,
+    );
 }
 
 #[test(should_fail)]
 fn test_expired_takt_rejected() {
     // At `exp` the token is already expired (RFC 8392: "on or after").
-    verify_takt(test_deterministic_takt(), TEST_EXP);
+    verify_takt(
+        test_deterministic_takt(),
+        TEST_TRUST_ANCHOR_KEY_X,
+        TEST_TRUST_ANCHOR_KEY_Y,
+        TEST_EXP,
+    );
 }
 
 #[test(should_fail_with = "value must require a 4-byte CBOR uint encoding")]
@@ -198,5 +232,10 @@ fn test_exp_too_small_for_cbor_uint32_rejected() {
     let mut candidate = test_deterministic_takt();
     // Fits in a 2-byte CBOR uint; violates the WIP-106 encoding profile.
     candidate.exp = 0xffff;
-    verify_takt(candidate, TEST_NOW);
+    verify_takt(
+        candidate,
+        TEST_TRUST_ANCHOR_KEY_X,
+        TEST_TRUST_ANCHOR_KEY_Y,
+        TEST_NOW,
+    );
 }


### PR DESCRIPTION
Makes the attestation library consumable, and makes it impossible to consume unsafely. Stacked on #884 — review that one first.

## The problem

Two things were wrong with the API, both surfaced while sketching how the DeepFace circuits would call it.

**The library could not be used at all.** Every field of `TrustAnchorKeyToken` and `AuthenticatorAssertionToken` was module-private, so no external Noir package could construct either token. I confirmed this with a throwaway consumer package: `error: exp is private and not visible from the current module`, and the same for all eight fields. `verify_aat` was reachable but uncallable.

**The binding was carried by struct nesting.** Since #884 un-nested the TAKT, the shared `assertion_key` is the *sole* thing tying the two tokens together — the spec says so explicitly ("This equality is the sole binding between the two tokens"). That made it more important, not less, that neither token can be verified in isolation. But the AAT held the TAKT as a field, which mirrors the old nested wire format rather than the current one.

## The shape

```rust
verify_takt(takt, trust_anchor_key_x, trust_anchor_key_y, now)   // pub(crate)
verify_aat(aat, assertion_key_x, assertion_key_y, now)           // pub(crate)
verify_attestation(aat, takt, trust_anchor_key_x, _y, now)       // pub
```

The composite feeds `verify_aat` the `assertion_key` read from the TAKT it just verified. The binding therefore holds *by construction* — no equality assert, no second witness for the same key, nothing a refactor can drop. And because the primitives are crate-private, a consumer cannot verify one half and skip the other. From the same external package:

```
error: verify_aat is private and not visible from the current module
error: verify_takt is private and not visible from the current module
```

That is the bypass — verify an AAT under a prover-chosen key, never check a TAKT — failing at compile time.

Each primitive is also independently testable now. Previously every AAT test had to drag in a full valid TAKT fixture.

## Two structural fixes that fall out

**The AAT no longer carries the TAKT, and the TAKT no longer carries the `trust_anchor_key`.** Neither was part of the token it sat in. The TAKT travels in the AAT's unprotected header. And the trust anchor key is not a TAKT claim — the token identifies its signer only by the `kid` protected-header parameter, which WIP-106 leaves outside the signature and the Security section says to treat as an untrusted hint. It is a verifier-supplied input, exactly like `now`; `takt_digest` never hashed it. The signature now reflects that.

**Struct fields are `pub`**, so tokens can be constructed. This is the fix for "not consumable," and it is orthogonal to the guarantee above: the prover supplies the token witnesses either way — what matters is that it cannot skip a verification step.

## Tests

- `attestation::test_untrusted_trust_anchor_key_rejected` — new. A well-formed TAKT signed by anyone other than the RP's allowlisted key must fail. Checked against the BabyJubJub prime-order subgroup generator so the failure is the signature check, not a point-validity assert (an off-curve key trips `Public key must be on curve` first, which would have made the test pass for the wrong reason).
- `test_aat_key_not_attested` moved to the composite, where the binding now lives.
- `aat::test_aat_wrong_assertion_key` — the primitive-level counterpart.

## What the library still cannot enforce

Documented in `crates/proof/noir/README.md` with a worked `main` example, because no API shape can enforce it: the calling circuit must expose `trust_anchor_key` and `now` as **public inputs** (a private `now` lets the prover pick a time at which any token is fresh; a private anchor key lets it sign its own TAKT), must bind `aat.nonce`/`aat.cdh` to the surrounding proof, and must expose whichever of `sec_flags` and `authenticator_meta` its RP needs. A CI check over each consumer's compiled ABI would catch the public-input half; worth adding alongside the first consumer.

## Test plan

- [ ] `cd crates/proof/noir/authenticator-attestation && nargo test` — 14 passing (was 11)
- [ ] `cargo test -p world-id-proof authenticator_attestation` — 16 passing, unchanged (the Rust encoder is untouched)
- [ ] `nargo fmt --check` clean
- [ ] External consumer package compiles against `verify_attestation`, with `trust_anchor_key_x`/`_y` and `now` reported as `public` in the emitted ABI
- [ ] Same package fails to compile when calling `verify_aat` or `verify_takt` directly
