### PR TITLE
docs: clarify WIP-103 proof format

### DIFF
--- a/docs/WIPs/wip-103.md
+++ b/docs/WIPs/wip-103.md
@@ -135,11 +135,11 @@ A keen observer would notice the Ownership Proof circuit is very similar to the 
 
 ## Reference Verification
 An Issuer will be able to know a specific user is the legitimate owner of a `sub` by performing the following validations:
-1. Ensuring the received Ownership Groth16 Proof verifies correctly. 
-2. The root hash (public input) matches a root hash for a valid Merkle tree of the `WorldIDRegistry`, as well as the expected depth. The `WorldIDRegistry` already implements a function to determine which roots are valid and all verifiers MUST honor it. A verifier MUST NOT cache valid roots for more than 1 hour.
+1. Ensuring the received Ownership Proof verifies correctly.
+2. The root hash (public input) matches a root hash for a valid Merkle tree of the `WorldIDRegistry`, as well as the expected depth.
 3. The `expected_commitment` public input matches the expected `sub` being verified. This value MAY also be used for lookups when the `sub` is not known in advance.
 
-Steps [1] & [2] SHALL be offered for reference in the `WorldIDVerifier` contract under the `verifyOwnership` function. 
+Implementations MUST verify the Ownership Proof using a proof format and verification method supported by ProveKit.
 
 ## Security
 


### PR DESCRIPTION
Clarify that the ownership proof can be transmitted in 2 formats:

1. regular ProveKit WHIR Proof output
2. Recursively proven Groth16 proof

both have different use cases

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only spec edits with no runtime or contract changes.
> 
> **Overview**
> **Reference Verification** in WIP-103 is updated so issuers validate an **Ownership Proof** (not an “Ownership Groth16 Proof”) and step 2 only requires matching the public `merkle_root` and depth, without the prior `WorldIDRegistry` root-policy and 1-hour cache rules.
> 
> The section no longer points to `WorldIDVerifier.verifyOwnership` for steps 1–2. A new **MUST** requires implementations to verify using a **proof format and verification method supported by ProveKit**, aligning the spec with ProveKit (e.g. native WHIR vs recursively proven Groth16) instead of naming a single proof system.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8fcb1d5ab4dc53e92f07ba759c94f050d7722b8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->