### PR TITLE
fix: set claims hash capacity

### DIFF
--- a/crates/primitives/src/credential.rs
+++ b/crates/primitives/src/credential.rs
@@ -22,7 +22,7 @@ pub enum CredentialVersion {
     /// - Curve (Base) Field (`Fq`): `BabyJubJub` Curve Field (also the BN254 Scalar Field)
     /// - Scalar Field (`Fr`): `BabyJubJub` Scalar Field
     ///
-    /// **NOTE**: In V1, the `claims_hash` uses the last element[15] of the Poseidon2
+    /// **NOTE**: In V1, the `claims_hash` uses the last element (`element[15]`) of the Poseidon2
     /// permutation as the capacity (value = `0`).
     #[default]
     V1 = 1,
@@ -153,6 +153,9 @@ pub struct Credential {
     /// the value directly (e.g. encoded date of birth).
     ///
     /// Currently these statements are not in use in proofs yet.
+    ///
+    /// Deserialization accepts at most [`Credential::MAX_CLAIMS`] claims.
+    #[serde(deserialize_with = "deserialize_claims")]
     pub claims: Vec<FieldElement>,
     /// The commitment to the Associated Data issued with the Credential.
     ///
@@ -257,10 +260,10 @@ impl Credential {
     /// Set a claim hash for the credential at an index.
     ///
     /// # Errors
-    /// Will error if the index is out of bounds. Note that for [`CredentialVersion::V1`], the
-    /// element[15] is reserved for the capacity.
+    /// Will error if `index` is outside `0..Self::MAX_CLAIMS`. Note that for
+    /// [`CredentialVersion::V1`], `element[15]` is reserved for the capacity.
     pub fn claim_hash(mut self, index: usize, claim: U256) -> Result<Self, PrimitiveError> {
-        if index >= self.claims.len() {
+        if index >= self.claims.len() || index >= Self::MAX_CLAIMS {
             return Err(PrimitiveError::OutOfBounds);
         }
         self.claims[index] = claim.try_into().map_err(|_| PrimitiveError::NotInField)?;
@@ -276,10 +279,10 @@ impl Credential {
     /// * `claim` - Arbitrary bytes to hash (any length).
     ///
     /// # Errors
-    /// Will error if the data is empty and if the index is out of bounds. Note that for
-    /// [`CredentialVersion::V1`], the element[15] is reserved for the capacity.
+    /// Will error if the data is empty and if `index` is outside `0..Self::MAX_CLAIMS`. Note that
+    /// for [`CredentialVersion::V1`], `element[15]` is reserved for the capacity.
     pub fn claim(mut self, index: usize, claim: &[u8]) -> Result<Self, PrimitiveError> {
-        if index >= self.claims.len() {
+        if index >= self.claims.len() || index >= Self::MAX_CLAIMS {
             return Err(PrimitiveError::OutOfBounds);
         }
         self.claims[index] = hash_bytes_to_field_element(CLAIMS_HASH_DS_TAG, claim)?;
@@ -341,7 +344,9 @@ impl Credential {
         for (i, claim) in self.claims.iter().enumerate() {
             input[i] = **claim;
         }
-        input[15] = *FieldElement::ZERO; // unnnecessary but adding it for explicitness
+
+        debug_assert!(input[15] == *FieldElement::ZERO);
+
         poseidon2::bn254::t16::permutation_in_place(&mut input);
         Ok(input[1].into())
     }
@@ -474,6 +479,29 @@ where
         .map_err(de::Error::custom)
 }
 
+/// Deserializes the credential claims, enforcing the [`Credential::MAX_CLAIMS`] boundary.
+fn deserialize_claims<'de, D>(deserializer: D) -> Result<Vec<FieldElement>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let mut claims = Vec::<FieldElement>::deserialize(deserializer)?;
+
+    // For V1, the `element[15]` is the capacity (`= 0`)
+    if claims.len() == Credential::MAX_CLAIMS + 1 && claims.last() == Some(&FieldElement::ZERO) {
+        claims.pop();
+    }
+
+    if claims.len() > Credential::MAX_CLAIMS {
+        return Err(de::Error::custom(format!(
+            "invalid credential: {} claims provided, at most {} are allowed",
+            claims.len(),
+            Credential::MAX_CLAIMS
+        )));
+    }
+
+    Ok(claims)
+}
+
 fn serialize_public_key<S>(public_key: &EdDSAPublicKey, serializer: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,
@@ -583,21 +611,93 @@ mod tests {
         Credential::new().claim_hash(14, U256::from(42)).unwrap();
     }
 
-    /// In [`CredentialVersion::V1`], the 15th-index is used for the sponge's
-    /// capacity and must equal to [`FieldElement::ZERO`]
     #[test]
-    fn test_v1_claims_hash_enforces_capacity_at_index_15() {
+    fn test_v1_cannot_set_reserved_element_via_oversized_claims_vec() {
         let mut cred = Credential::new();
-        cred.claims = vec![FieldElement::from(42u64); 15];
-        cred.claims_hash().unwrap(); // 15 is completely fine
+        cred.claims = vec![FieldElement::ZERO; Credential::MAX_CLAIMS + 5];
+
+        let err = cred.clone().claim_hash(15, U256::from(42)).unwrap_err();
+        assert!(matches!(err, PrimitiveError::OutOfBounds));
+
+        let err = cred.claim(15, b"out of bounds").unwrap_err();
+        assert!(matches!(err, PrimitiveError::OutOfBounds));
+    }
+
+    /// In [`CredentialVersion::V1`], the 15th-index is used for the sponge's
+    /// capacity and must be equal to [`FieldElement::ZERO`]
+    #[test]
+    fn test_claims_hash_rejects_more_than_15_claims_and_last_element_is_zero() {
+        let mut cred = Credential::new();
+        cred.claims = vec![FieldElement::from(42u64); Credential::MAX_CLAIMS];
+
+        // Reconstruct the permutation by hand: the 15 claims followed by a zero capacity element.
+        let mut expected = [*FieldElement::ZERO; Credential::MAX_CLAIMS + 1];
+        for element in expected.iter_mut().take(Credential::MAX_CLAIMS) {
+            *element = *FieldElement::from(42u64);
+        }
+        assert_eq!(expected[15], *FieldElement::ZERO);
+        poseidon2::bn254::t16::permutation_in_place(&mut expected);
+        assert_eq!(cred.claims_hash().unwrap(), FieldElement::from(expected[1]));
 
         let mut cred = Credential::new();
-        cred.claims = vec![FieldElement::from(42u64); 16];
+        cred.claims = vec![FieldElement::from(42u64); Credential::MAX_CLAIMS + 1];
         let err = cred.claims_hash().unwrap_err();
-        assert_eq!(
-            err.to_string(),
-            "There can be at most 15 claims".to_string()
+        assert!(
+            err.to_string().contains("at most"),
+            "unexpected error: {err}"
         );
+    }
+
+    #[test]
+    fn test_claim_hash_rejects_value_above_field_modulus() {
+        let err = Credential::new().claim_hash(0, U256::MAX).unwrap_err();
+        assert!(matches!(err, PrimitiveError::NotInField));
+    }
+
+    #[test]
+    fn test_claim_rejects_empty_data() {
+        let err = Credential::new().claim(0, &[]).unwrap_err();
+        assert!(matches!(err, PrimitiveError::InvalidInput { .. }));
+    }
+
+    #[test]
+    fn test_deserialize_rejects_too_many_claims() {
+        let mut credential = Credential::new();
+        credential.claims = vec![FieldElement::from(7u64); Credential::MAX_CLAIMS];
+        let mut json: serde_json::Value =
+            serde_json::from_str(&serde_json::to_string(&credential).unwrap()).unwrap();
+
+        json["claims"]
+            .as_array_mut()
+            .unwrap()
+            .push(serde_json::json!(FieldElement::from(7u64).to_string()));
+
+        let err = serde_json::from_value::<Credential>(json).unwrap_err();
+        assert!(
+            err.to_string().contains("at most"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_deserialize_accepts_legacy_trailing_zero_claim() {
+        let signer = EdDSAPrivateKey::random(&mut rand::thread_rng());
+        let mut credential = Credential::new();
+        credential.id = 1;
+        credential.claims = vec![FieldElement::from(7u64); Credential::MAX_CLAIMS];
+        let credential = credential.sign(&signer).unwrap();
+
+        let mut json: serde_json::Value =
+            serde_json::from_str(&serde_json::to_string(&credential).unwrap()).unwrap();
+        json["claims"]
+            .as_array_mut()
+            .unwrap()
+            .push(serde_json::json!(FieldElement::ZERO.to_string()));
+
+        let decoded: Credential = serde_json::from_value(json).unwrap();
+        assert_eq!(decoded.claims.len(), Credential::MAX_CLAIMS);
+        assert_eq!(decoded.hash().unwrap(), credential.hash().unwrap());
+        assert!(decoded.verify_signature(&signer.public()).unwrap());
     }
 
     #[test]

--- a/crates/primitives/src/credential.rs
+++ b/crates/primitives/src/credential.rs
@@ -178,6 +178,8 @@ pub struct Credential {
 
 impl Credential {
     /// The maximum number of claims that can be included in a credential.
+    ///
+    /// While the Poseidon2 permutation is t=16, one element is reserved for capacity.
     pub const MAX_CLAIMS: usize = 15;
 
     /// Initializes a new credential.
@@ -258,7 +260,7 @@ impl Credential {
     /// Will error if the index is out of bounds. Note that for [`CredentialVersion::V1`], the
     /// element[15] is reserved for the capacity.
     pub fn claim_hash(mut self, index: usize, claim: U256) -> Result<Self, PrimitiveError> {
-        if index >= self.claims.len() - 1 {
+        if index >= self.claims.len() {
             return Err(PrimitiveError::OutOfBounds);
         }
         self.claims[index] = claim.try_into().map_err(|_| PrimitiveError::NotInField)?;
@@ -277,7 +279,7 @@ impl Credential {
     /// Will error if the data is empty and if the index is out of bounds. Note that for
     /// [`CredentialVersion::V1`], the element[15] is reserved for the capacity.
     pub fn claim(mut self, index: usize, claim: &[u8]) -> Result<Self, PrimitiveError> {
-        if index >= self.claims.len() - 1 {
+        if index >= self.claims.len() {
             return Err(PrimitiveError::OutOfBounds);
         }
         self.claims[index] = hash_bytes_to_field_element(CLAIMS_HASH_DS_TAG, claim)?;
@@ -576,6 +578,26 @@ mod tests {
 
         let err = Credential::new().claim(15, b"out of bounds").unwrap_err();
         assert!(matches!(err, PrimitiveError::OutOfBounds));
+
+        // element[14] is valid
+        Credential::new().claim_hash(14, U256::from(42)).unwrap();
+    }
+
+    /// In [`CredentialVersion::V1`], the 15th-index is used for the sponge's
+    /// capacity and must equal to [`FieldElement::ZERO`]
+    #[test]
+    fn test_v1_claims_hash_enforces_capacity_at_index_15() {
+        let mut cred = Credential::new();
+        cred.claims = vec![FieldElement::from(42u64); 15];
+        cred.claims_hash().unwrap(); // 15 is completely fine
+
+        let mut cred = Credential::new();
+        cred.claims = vec![FieldElement::from(42u64); 16];
+        let err = cred.claims_hash().unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "There can be at most 15 claims".to_string()
+        );
     }
 
     #[test]

--- a/crates/primitives/src/credential.rs
+++ b/crates/primitives/src/credential.rs
@@ -21,6 +21,9 @@ pub enum CredentialVersion {
     /// - Signature scheme: `EdDSA` on `BabyJubJub` Curve
     /// - Curve (Base) Field (`Fq`): `BabyJubJub` Curve Field (also the BN254 Scalar Field)
     /// - Scalar Field (`Fr`): `BabyJubJub` Scalar Field
+    ///
+    /// **NOTE**: In V1, the `claims_hash` uses the last element[15] of the Poseidon2
+    /// permutation as the capacity (value = `0`).
     #[default]
     V1 = 1,
 }
@@ -147,9 +150,9 @@ pub struct Credential {
     /// **For Future Use**. Concrete statements that the issuer attests about the receiver.
     ///
     /// They can be just commitments to data (e.g. passport image) or
-    /// the value directly (e.g. date of birth).
+    /// the value directly (e.g. encoded date of birth).
     ///
-    /// Currently these statements are not in use in the Proofs yet.
+    /// Currently these statements are not in use in proofs yet.
     pub claims: Vec<FieldElement>,
     /// The commitment to the Associated Data issued with the Credential.
     ///
@@ -175,7 +178,7 @@ pub struct Credential {
 
 impl Credential {
     /// The maximum number of claims that can be included in a credential.
-    pub const MAX_CLAIMS: usize = 16;
+    pub const MAX_CLAIMS: usize = 15;
 
     /// Initializes a new credential.
     ///
@@ -252,9 +255,10 @@ impl Credential {
     /// Set a claim hash for the credential at an index.
     ///
     /// # Errors
-    /// Will error if the index is out of bounds.
+    /// Will error if the index is out of bounds. Note that for [`CredentialVersion::V1`], the
+    /// element[15] is reserved for the capacity.
     pub fn claim_hash(mut self, index: usize, claim: U256) -> Result<Self, PrimitiveError> {
-        if index >= self.claims.len() {
+        if index >= self.claims.len() - 1 {
             return Err(PrimitiveError::OutOfBounds);
         }
         self.claims[index] = claim.try_into().map_err(|_| PrimitiveError::NotInField)?;
@@ -270,9 +274,10 @@ impl Credential {
     /// * `claim` - Arbitrary bytes to hash (any length).
     ///
     /// # Errors
-    /// Will error if the data is empty and if the index is out of bounds.
+    /// Will error if the data is empty and if the index is out of bounds. Note that for
+    /// [`CredentialVersion::V1`], the element[15] is reserved for the capacity.
     pub fn claim(mut self, index: usize, claim: &[u8]) -> Result<Self, PrimitiveError> {
-        if index >= self.claims.len() {
+        if index >= self.claims.len() - 1 {
             return Err(PrimitiveError::OutOfBounds);
         }
         self.claims[index] = hash_bytes_to_field_element(CLAIMS_HASH_DS_TAG, claim)?;
@@ -330,10 +335,11 @@ impl Credential {
         if self.claims.len() > Self::MAX_CLAIMS {
             eyre::bail!("There can be at most {} claims", Self::MAX_CLAIMS);
         }
-        let mut input = [*FieldElement::ZERO; Self::MAX_CLAIMS];
+        let mut input = [*FieldElement::ZERO; Self::MAX_CLAIMS + 1]; // +1 is the capacity value
         for (i, claim) in self.claims.iter().enumerate() {
             input[i] = **claim;
         }
+        input[15] = *FieldElement::ZERO; // unnnecessary but adding it for explicitness
         poseidon2::bn254::t16::permutation_in_place(&mut input);
         Ok(input[1].into())
     }
@@ -559,6 +565,17 @@ mod tests {
 
         // Both should produce the same hash
         assert_eq!(credential.claims[0], direct_hash);
+    }
+
+    #[test]
+    fn test_v1_cannot_set_last_element_of_claims() {
+        let err = Credential::new()
+            .claim_hash(15, U256::from(42))
+            .unwrap_err();
+        assert!(matches!(err, PrimitiveError::OutOfBounds));
+
+        let err = Credential::new().claim(15, b"out of bounds").unwrap_err();
+        assert!(matches!(err, PrimitiveError::OutOfBounds));
     }
 
     #[test]

--- a/crates/primitives/src/credential.rs
+++ b/crates/primitives/src/credential.rs
@@ -336,16 +336,16 @@ impl Credential {
     /// # Errors
     /// Will error if there are more claims than the maximum allowed.
     /// Will error if the claims cannot be lowered into the field. Should not occur in practice.
-    pub fn claims_hash(&self) -> Result<FieldElement, eyre::Error> {
+    pub fn claims_hash(&self) -> Result<FieldElement, PrimitiveError> {
         if self.claims.len() > Self::MAX_CLAIMS {
-            eyre::bail!("There can be at most {} claims", Self::MAX_CLAIMS);
+            return Err(PrimitiveError::OutOfBounds);
         }
         let mut input = [*FieldElement::ZERO; Self::MAX_CLAIMS + 1]; // +1 is the capacity value
         for (i, claim) in self.claims.iter().enumerate() {
             input[i] = **claim;
         }
 
-        debug_assert!(input[15] == *FieldElement::ZERO);
+        debug_assert_eq!(input[15], *FieldElement::ZERO);
 
         poseidon2::bn254::t16::permutation_in_place(&mut input);
         Ok(input[1].into())
@@ -642,10 +642,7 @@ mod tests {
         let mut cred = Credential::new();
         cred.claims = vec![FieldElement::from(42u64); Credential::MAX_CLAIMS + 1];
         let err = cred.claims_hash().unwrap_err();
-        assert!(
-            err.to_string().contains("at most"),
-            "unexpected error: {err}"
-        );
+        assert!(matches!(err, PrimitiveError::OutOfBounds));
     }
 
     #[test]

--- a/crates/primitives/src/credential.rs
+++ b/crates/primitives/src/credential.rs
@@ -334,8 +334,7 @@ impl Credential {
     /// Get the claims hash of the credential.
     ///
     /// # Errors
-    /// Will error if there are more claims than the maximum allowed.
-    /// Will error if the claims cannot be lowered into the field. Should not occur in practice.
+    /// - Returns [`PrimitiveError::OutOfBounds`] if the credential has more claims than the maximum allowed.
     pub fn claims_hash(&self) -> Result<FieldElement, PrimitiveError> {
         if self.claims.len() > Self::MAX_CLAIMS {
             return Err(PrimitiveError::OutOfBounds);

--- a/crates/proof/src/lib.rs
+++ b/crates/proof/src/lib.rs
@@ -65,6 +65,9 @@ pub enum ProofError {
     /// Error verifying a Noir Proof with ProveKit. This usually means the proof is invalid.
     #[error("proof verification error: {0}")]
     Verification(String),
+    /// The proof cannot be generated because the credential has an error
+    #[error("credential error: {0}")]
+    CredentialError(String),
     /// Catch-all for other internal errors.
     #[error(transparent)]
     InternalError(#[from] eyre::Report),

--- a/crates/proof/src/lib.rs
+++ b/crates/proof/src/lib.rs
@@ -4,7 +4,7 @@ use eddsa_babyjubjub::EdDSAPrivateKey;
 use groth16_material::Groth16Error;
 
 use world_id_primitives::{
-    AuthenticatorPublicKeySet, TREE_DEPTH, merkle::MerkleInclusionProof,
+    AuthenticatorPublicKeySet, PrimitiveError, TREE_DEPTH, merkle::MerkleInclusionProof,
     oprf::WorldIdRequestAuthError,
 };
 use zeroize::{Zeroize, ZeroizeOnDrop};

--- a/crates/proof/src/lib.rs
+++ b/crates/proof/src/lib.rs
@@ -66,8 +66,8 @@ pub enum ProofError {
     #[error("proof verification error: {0}")]
     Verification(String),
     /// The proof cannot be generated because the credential has an error
-    #[error("credential error: {0}")]
-    CredentialError(String),
+    #[error(transparent)]
+    CredentialError(#[from] PrimitiveError),
     /// Catch-all for other internal errors.
     #[error(transparent)]
     InternalError(#[from] eyre::Report),

--- a/crates/proof/src/nullifier_proof.rs
+++ b/crates/proof/src/nullifier_proof.rs
@@ -122,7 +122,7 @@ pub fn generate_nullifier_proof<R: Rng + CryptoRng>(
         cred_hashes: [
             *credential
                 .claims_hash()
-                .map_err(|e| ProofError::CredentialError(e.to_string()))?,
+                .map_err(ProofError::CredentialError)?,
             *credential.associated_data_commitment,
         ],
         cred_genesis_issued_at: credential.genesis_issued_at.into(),

--- a/crates/proof/src/nullifier_proof.rs
+++ b/crates/proof/src/nullifier_proof.rs
@@ -120,7 +120,9 @@ pub fn generate_nullifier_proof<R: Rng + CryptoRng>(
         issuer_schema_id: credential.issuer_schema_id.into(),
         cred_pk: credential.issuer.pk,
         cred_hashes: [
-            *credential.claims_hash()?,
+            *credential
+                .claims_hash()
+                .map_err(|e| ProofError::CredentialError(e.to_string()))?,
             *credential.associated_data_commitment,
         ],
         cred_genesis_issued_at: credential.genesis_issued_at.into(),


### PR DESCRIPTION
### Motivation
The `claims_hash` didn't have a capacity element which would allow for finding second pre-images. This is not a practical issue today because the credential's `claims` are reserved for future use, and in practice no known issuer is pre-registering more than 5 claims, but this is unsound and could affect the claims' guarantees if it were in use. This change is added to prevent future issues using claims.

### Changes
Explicitly sets the 15th-index of the `claims_hash` as the sponge's capacity (using `0` as value). 

### Future Improvements
In the next credential version, the capacity should be added with an explicit ds at element[0] following Protocol conventions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the cryptographic definition of `claims_hash` for V1 credentials; impact is limited today because claims are unused in production proofs, but any issuer or test relying on the old 16-slot hash or index 15 would diverge.
> 
> **Overview**
> Fixes **unsound V1 `claims_hash` computation** by reserving Poseidon2 `t=16` **element[15] as sponge capacity (0)** instead of treating all 16 slots as claim inputs, which could allow second preimages once claims are used in proofs.
> 
> **`Credential::MAX_CLAIMS` drops from 16 to 15**; `claim` / `claim_hash` reject index 15 and oversized claim vectors. **`claims_hash`** builds a 16-word state (claims in `0..14`, zero capacity at 15), returns **`PrimitiveError`** on overflow, and serde **`deserialize_claims`** enforces the limit while **stripping a legacy trailing zero 16th claim** so old serialized credentials still verify.
> 
> **`world_id_proof`** surfaces credential errors via **`ProofError::CredentialError`** when assembling nullifier circuit inputs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7382c9bba3b3bf9725b0829f7232052e8fd7435e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->