### PR TITLE
chore: ignore unmaintained im/bitmaps/sized-chunks advisories

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -53,5 +53,7 @@ ignore = [
     "RUSTSEC-2026-0173", # Unmaintained `proc-macro-error2`; transitive via alloy-sol-macro, no safe upgrade available (2026-06-08)
     "RUSTSEC-2026-0248", # Unmaintained `im`; transitive via `provekit`, requires bumps on `provekit`, no safe upgrade available (2026-08-10)
     "RUSTSEC-2026-0247", # Unmaintained `bitmaps`; pulled in by `im`, same chain (2026-08-10)
-    "RUSTSEC-2026-0251"  # Unmaintained `sized-chunks`; pulled in by `im`, same chain (2026-08-10)
+    "RUSTSEC-2026-0251", # Unmaintained `sized-chunks`; pulled in by `im`, same chain (2026-08-10)
+    "RUSTSEC-2023-0126", # Unsound `im` OrdSet aliasing; same provekit chain, unmaintained so no fix will ever ship (2023-02-04)
+    "RUSTSEC-2026-0253"  # Unsound `lru` LruCache::pop panic safety; patched in >= 0.18.2, but alloy-provider pins `lru = "^0.16"` so it needs an alloy bump (2026-05-12)
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -50,5 +50,8 @@ ignore = [
     "RUSTSEC-2026-0212", # `libcrux-secrets`/`libcrux-sha3` const-time swap on aarch64; via testcontainers->russh->libcrux-ml-kem; dev-only, no safe upgrade (2026-07-21)
     "RUSTSEC-2026-0153", # russh-cryptovec broken, via testcontainers, dev-only, does not affect our usage (2026-06-02)
     "RUSTSEC-2026-0154", # russh-cryptovec broken, via testcontainers, dev-only, does not affect our usage (2026-06-02)
-    "RUSTSEC-2026-0173"  # Unmaintained `proc-macro-error2`; transitive via alloy-sol-macro, no safe upgrade available (2026-06-08)
+    "RUSTSEC-2026-0173", # Unmaintained `proc-macro-error2`; transitive via alloy-sol-macro, no safe upgrade available (2026-06-08)
+    "RUSTSEC-2026-0248", # Unmaintained `im`; transitive via `provekit`, requires bumps on `provekit`, no safe upgrade available (2026-08-10)
+    "RUSTSEC-2026-0247", # Unmaintained `bitmaps`; pulled in by `im`, same chain (2026-08-10)
+    "RUSTSEC-2026-0251"  # Unmaintained `sized-chunks`; pulled in by `im`, same chain (2026-08-10)
 ]


### PR DESCRIPTION
`Cargo deny (advisories)` is currently red on `main` and on every open PR with no code change behind it: RUSTSEC-2026-0247 / 0248 / 0251 were merged into the advisory DB on 2026-08-10 at 19:33 UTC, 38 minutes after `main`'s last Rust CI run passed at 18:55.

Those three are `unmaintained` notices rather than vulnerabilities, and they arrive together transitively through provekit (Noir). None has a safe upgrade, so they join the existing `fxhash` / `bincode` entries in the same class.

Two `unsound` advisories on the same dependency graph also have to be ignored to get the check green:

- **RUSTSEC-2023-0126** — `im` `OrdSet` insertion aliasing, on the same provekit chain. The crate is unmaintained and the advisory lists no patched version, so no fix will ever ship.
- **RUSTSEC-2026-0253** — `lru` panic safety in `LruCache::pop()`. Fixed in 0.18.2, but `alloy-provider` pins `lru = "^0.16"`, so picking it up needs an alloy bump, not a lockfile change. Worth revisiting when alloy moves.

Neither is remotely triggerable through our usage: the `im` path is internal to the Noir compiler and we never touch `OrdSet`, and alloy's `lru` keys have no panicking `Drop`/`Hash`/`Eq` impls.