### PR TITLE
chore: update OPRF mobile benchmark dependencies

### DIFF
--- a/.github/workflows/mobile-bench-reusable.yml
+++ b/.github/workflows/mobile-bench-reusable.yml
@@ -131,6 +131,7 @@ jobs:
     env:
       BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
       BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
+      RUSTUP_TOOLCHAIN: stable
       IPHONEOS_DEPLOYMENT_TARGET: "13.0"
       CFLAGS_aarch64_apple_ios: "-miphoneos-version-min=13.0"
       CFLAGS_aarch64_apple_ios_sim: "-mios-simulator-version-min=13.0"
@@ -156,10 +157,10 @@ jobs:
       - name: Ensure iOS Rust targets
         shell: bash
         run: |
-          rustup target add aarch64-apple-ios aarch64-apple-ios-sim x86_64-apple-ios
-          rustup component add rust-std --target aarch64-apple-ios
-          rustup component add rust-std --target aarch64-apple-ios-sim
-          rustup target list --installed | grep -E "ios|apple"
+          rustup +stable target add aarch64-apple-ios aarch64-apple-ios-sim x86_64-apple-ios
+          rustup +stable component add rust-std --target aarch64-apple-ios
+          rustup +stable component add rust-std --target aarch64-apple-ios-sim
+          rustup +stable target list --installed | grep -E "ios|apple"
 
       - uses: noir-lang/noirup@7dbe69ccc78877f0200ffa5a40836c953d2cfd8f # v0.1.4 https://github.com/noir-lang/noirup/releases/tag/v0.1.4
         with:
@@ -351,6 +352,7 @@ jobs:
     env:
       BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
       BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
+      RUSTUP_TOOLCHAIN: stable
 
     steps:
       - name: Checkout caller repo
@@ -369,11 +371,11 @@ jobs:
       - name: Ensure Android Rust targets
         shell: bash
         run: |
-          rustup target add aarch64-linux-android armv7-linux-androideabi x86_64-linux-android
-          rustup component add rust-std --target aarch64-linux-android
-          rustup component add rust-std --target armv7-linux-androideabi
-          rustup component add rust-std --target x86_64-linux-android
-          rustup target list --installed | grep -E "android"
+          rustup +stable target add aarch64-linux-android armv7-linux-androideabi x86_64-linux-android
+          rustup +stable component add rust-std --target aarch64-linux-android
+          rustup +stable component add rust-std --target armv7-linux-androideabi
+          rustup +stable component add rust-std --target x86_64-linux-android
+          rustup +stable target list --installed | grep -E "android"
 
       - name: Cache cargo registry/git
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0 https://github.com/actions/cache/releases/tag/v4.3.0

--- a/.github/workflows/mobile-bench.yml
+++ b/.github/workflows/mobile-bench.yml
@@ -110,7 +110,7 @@ jobs:
     with:
       crate_path: ./crates/zk-mobile-bench
       functions: '["zk_mobile_bench::bench_nullifier_proof_generation","zk_mobile_bench::bench_nullifier_witness_generation_only","zk_mobile_bench::bench_nullifier_proving_only","zk_mobile_bench::bench_query_proof_generation","zk_mobile_bench::bench_query_cached_proof_generation","zk_mobile_bench::bench_query_witness_generation_only","zk_mobile_bench::bench_query_proving_only"]'
-      mobench_version: "0.1.40"
+      mobench_version: "0.2.0"
       mobench_ref: ""
       platform: ${{ inputs.platform }}
       device_profile: ${{ inputs.device_profile }}

--- a/.github/workflows/mobile-bench.yml
+++ b/.github/workflows/mobile-bench.yml
@@ -116,8 +116,11 @@ jobs:
       device_profile: ${{ inputs.device_profile }}
       ios_device: ${{ inputs.ios_device }}
       ios_os_version: ${{ inputs.ios_os_version }}
-      android_device: ${{ inputs.android_device }}
-      android_os_version: ${{ inputs.android_os_version }}
+      # mobench's low-spec profile still resolves to Moto G9 Play-10.0, which
+      # the current BrowserStack inventory no longer exposes. Keep manual
+      # overrides intact and use the available low-spec replacement by default.
+      android_device: ${{ inputs.android_device != '' && inputs.android_device || 'Motorola Moto G71 5G' }}
+      android_os_version: ${{ inputs.android_os_version != '' && inputs.android_os_version || '11.0' }}
       iterations: ${{ inputs.iterations }}
       warmup: ${{ inputs.warmup }}
       fetch_timeout_secs: ${{ inputs.fetch_timeout_secs }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1643,11 +1643,11 @@ dependencies = [
 
 [[package]]
 name = "askama"
-version = "0.14.0"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f75363874b771be265f4ffe307ca705ef6f3baa19011c149da8674a87f1b75c4"
+checksum = "08e1676b346cadfec169374f949d7490fd80a24193d37d2afce0c047cf695e57"
 dependencies = [
- "askama_derive 0.14.0",
+ "askama_macros 0.15.4",
  "itoa",
  "percent-encoding",
  "serde",
@@ -1656,32 +1656,15 @@ dependencies = [
 
 [[package]]
 name = "askama"
-version = "0.15.4"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08e1676b346cadfec169374f949d7490fd80a24193d37d2afce0c047cf695e57"
+checksum = "f1bf825125edd887a019d0a3a837dcc5499a68b0d034cc3eb594070c3e18addc"
 dependencies = [
- "askama_macros",
+ "askama_macros 0.16.0",
  "itoa",
  "percent-encoding",
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "askama_derive"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "129397200fe83088e8a68407a8e2b1f826cf0086b21ccdb866a722c8bcd3a94f"
-dependencies = [
- "askama_parser 0.14.0",
- "basic-toml",
- "memchr",
- "proc-macro2",
- "quote",
- "rustc-hash",
- "serde",
- "serde_derive",
- "syn 2.0.116",
 ]
 
 [[package]]
@@ -1702,6 +1685,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "askama_derive"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1c7065972a130eafa84215f21352ae15b4a7393da48c1f5e103904490736738"
+dependencies = [
+ "askama_parser 0.16.0",
+ "basic-toml",
+ "glob",
+ "memchr",
+ "proc-macro2",
+ "quote",
+ "rustc-hash",
+ "serde",
+ "serde_derive",
+ "syn 2.0.116",
+]
+
+[[package]]
 name = "askama_macros"
 version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1711,15 +1712,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "askama_parser"
-version = "0.14.0"
+name = "askama_macros"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6ab5630b3d5eaf232620167977f95eb51f3432fc76852328774afbd242d4358"
+checksum = "0e23b1d2c4bd39a41971f6124cef4cc6fd0540913ecb90919b69ab3bbe44ae1a"
 dependencies = [
- "memchr",
- "serde",
- "serde_derive",
- "winnow 0.7.14",
+ "askama_derive 0.16.0",
 ]
 
 [[package]]
@@ -1733,6 +1731,19 @@ dependencies = [
  "serde_derive",
  "unicode-ident",
  "winnow 0.7.14",
+]
+
+[[package]]
+name = "askama_parser"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7db09fde9143e7ac4513358fb32ee32847125b63b18ea715afd487956da715da"
+dependencies = [
+ "rustc-hash",
+ "serde",
+ "serde_derive",
+ "unicode-ident",
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -2843,18 +2854,19 @@ dependencies = [
 
 [[package]]
 name = "cargo-platform"
-version = "0.1.9"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
+checksum = "dd0061da739915fae12ea00e16397555ed4371a6bb285431aab930f61b0aa4ba"
 dependencies = [
  "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "cargo_metadata"
-version = "0.19.2"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba"
+checksum = "ef987d17b0a113becdd19d3d0022d04d7ef41f9efe4f3fb63ac44ba61df3ade9"
 dependencies = [
  "camino",
  "cargo-platform",
@@ -3147,7 +3159,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4212,9 +4224,9 @@ dependencies = [
 
 [[package]]
 name = "fs-err"
-version = "2.11.0"
+version = "3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88a41f105fe1d5b6b34b2055e3dc59bb79b46b48b2040b9e6c7b4b5de097aa41"
+checksum = "b91aa448ca50d7e79433bdf3ee8d99215430d2ec02ade5aefab2a073a1822e8a"
 dependencies = [
  "autocfg",
 ]
@@ -5966,9 +5978,9 @@ dependencies = [
 
 [[package]]
 name = "mobench-macros"
-version = "0.1.40"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82a2620949467f1c0f7c468958fea01ee6b5d7aff67c42b35ca589e430881482"
+checksum = "9292a29a0a348a45a2dffdd17b1314b72753d86f3982573cbcd27e2e7a45a753"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5976,19 +5988,38 @@ dependencies = [
 ]
 
 [[package]]
-name = "mobench-sdk"
-version = "0.1.40"
+name = "mobench-process"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29cb9d7ff25e436fb310b428e81edee219a65b6414720c335a8c882ddcc29994"
+checksum = "d41aaad14d702725b6b79f390958da19a36a7c111a7944c6c71cba0b58d5edf4"
+dependencies = [
+ "libc",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "mobench-runtime"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "576579c727954c9f7f384e33c0602a8c49ef9634a7c91aa2d33e2fd17010c085"
+
+[[package]]
+name = "mobench-sdk"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4032d49ec97aab649d1a4d3f973631b7279b38ed91db8e595c7a3135dae3841"
 dependencies = [
  "include_dir",
  "inventory",
  "libc",
  "mobench-macros",
+ "mobench-process",
+ "mobench-runtime",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
  "toml 0.8.23",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -7179,7 +7210,7 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -11412,9 +11443,9 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "uniffi"
-version = "0.31.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc5f2297ee5b893405bed1a6929faec4713a061df158ecf5198089f23910d470"
+checksum = "a782a48d72cfd7a2d65cfc7c691dbf5375c43104b3c195f7eccc716dcc3540c8"
 dependencies = [
  "anyhow",
  "camino",
@@ -11428,12 +11459,12 @@ dependencies = [
 
 [[package]]
 name = "uniffi_bindgen"
-version = "0.31.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bc0c60a9607e7ab77a2ad47ec5530178015014839db25af7512447d2238016c"
+checksum = "533b0312c73e3b54eb78a4b257ceae390962dd4767995778309a74644643f9ac"
 dependencies = [
  "anyhow",
- "askama 0.14.0",
+ "askama 0.16.0",
  "camino",
  "cargo_metadata",
  "fs-err",
@@ -11454,9 +11485,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_core"
-version = "0.31.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77baf5d539fe2e1ad6805e942dbc5dbdeb2b83eb5f2b3a6535d422ca4b02a12f"
+checksum = "8e32e261c5b0dfaba6488f536e71957dddd6b1a498ac7eb791bee56b60a086be"
 dependencies = [
  "anyhow",
  "bytes",
@@ -11466,9 +11497,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_internal_macros"
-version = "0.31.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4b42137524f4be6400fcaca9d02c1d4ecb6ad917e4013c0b93235526d8396e5"
+checksum = "84ae78069a5e6772ef694fd5bdb628532c88d2c2f0e7142bf6a384636eadb1af"
 dependencies = [
  "anyhow",
  "indexmap 2.13.0",
@@ -11479,9 +11510,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_macros"
-version = "0.31.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9273ec45330d8fe9a3701b7b983cea7a4e218503359831967cb95d26b873561"
+checksum = "330be6770532e86320df31f54c70bb0be67588594e8e77fa56e9083a3fed5d0d"
 dependencies = [
  "camino",
  "fs-err",
@@ -11496,9 +11527,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_meta"
-version = "0.31.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "431d2f443e7828a6c29d188de98b6771a6491ee98bba2d4372643bf93f988a18"
+checksum = "78de021f5547e56ab16c665a49d67d4fd3d31e77422f7739a2e9359d328cd9e7"
 dependencies = [
  "anyhow",
  "siphasher",
@@ -11508,9 +11539,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_pipeline"
-version = "0.31.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "761ef74f6175e15603d0424cc5f98854c5baccfe7bf4ccb08e5816f9ab8af689"
+checksum = "3f8201bb1907ed8a42d80e11cbc25c8a033e7a31c3cff1d911f56eedb81d4948"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
@@ -11521,9 +11552,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_udl"
-version = "0.31.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68773ec0e1c067b6505a73bbf6a5782f31a7f9209333a0df97b87565c46bf370"
+checksum = "a6e57996bc58009cc29bf04845d627ae313c2547b87171c1c349d6c51a1656c0"
 dependencies = [
  "anyhow",
  "textwrap",
@@ -11961,7 +11992,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12391,6 +12422,15 @@ name = "winnow"
 version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,8 +52,8 @@ alloy-node-bindings = "2.0.1"
 
 anyhow = "1"
 ark-ec = "0.5"
-ark-babyjubjub = { package = "taceo-ark-babyjubjub", version = "0.5" }
-ark-serde-compat = { package = "taceo-ark-serde-compat", version = "0.5", default-features = false, features = [
+ark-babyjubjub = { package = "taceo-ark-babyjubjub", version = "0.5.3" }
+ark-serde-compat = { package = "taceo-ark-serde-compat", version = "0.5.0", default-features = false, features = [
   "babyjubjub",
 ] }
 ark-bn254 = "0.5"
@@ -62,12 +62,12 @@ ark-groth16 = "0.5"
 ark-serialize = "0.5"
 backon = "1"
 base64 = "0.22"
-circom-types = { package = "taceo-circom-types", version = "0.2", default-features = false }
+circom-types = { package = "taceo-circom-types", version = "0.2.5", default-features = false }
 coset = "0.4.2"
 eddsa-babyjubjub = { package = "taceo-eddsa-babyjubjub", version = "0.5.5" }
 eyre = "0.6"
 futures = "0.3"
-groth16-material = { package = "taceo-groth16-material", version = "0.3", default-features = false }
+groth16-material = { package = "taceo-groth16-material", version = "0.3.0", default-features = false }
 hex = { version = "0.4" }
 ohttp = { version = "0.7", default-features = false }
 bhttp = "0.7"
@@ -80,7 +80,7 @@ taceo-oprf-test-utils = { version = "0.14", default-features = false }
 telemetry-batteries = "0.3"
 tikv-jemallocator = "0.6"
 ruint = { version = "1.17", features = ["ark-ff-05"] }
-poseidon2 = { package = "taceo-poseidon2", version = "0.2" }
+poseidon2 = { package = "taceo-poseidon2", version = "0.2.1" }
 rand = "0.8.6"
 rand_chacha = "0.3"
 rustls = { version = "0.23", features = ["ring"] }

--- a/crates/zk-mobile-bench/Cargo.toml
+++ b/crates/zk-mobile-bench/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/bin/uniffi-bindgen.rs"
 
 [dependencies]
 # Benchmarking
-mobench-sdk = "0.1.40"
+mobench-sdk = "0.2.0"
 inventory = "0.3"
 
 # World ID
@@ -45,4 +45,4 @@ rand_chacha = { workspace = true }
 thiserror = { workspace = true }
 
 # UniFFI for mobile bindings
-uniffi = { version = "0.31", features = ["cli"] }
+uniffi = { version = "0.32", features = ["cli"] }

--- a/crates/zk-mobile-bench/docs/README.md
+++ b/crates/zk-mobile-bench/docs/README.md
@@ -7,7 +7,7 @@ Mobile benchmarks for World ID ZK proof generation using [mobench](https://githu
 Install mobench:
 
 ```bash
-cargo install mobench --version 0.1.40 --locked
+cargo install mobench --version 0.2.0 --locked
 ```
 
 Build and run locally:
@@ -33,7 +33,7 @@ cargo-mobench run \
 ```
 
 BrowserStack runs remain the right path for timing and memory benchmarks.
-BrowserStack native profiling is unsupported in `mobench` `0.1.40`; use the
+BrowserStack native profiling is unsupported in `mobench` `0.2.0`; use the
 local provider for native capture.
 
 Capture a local native profile:

--- a/deny.toml
+++ b/deny.toml
@@ -44,6 +44,11 @@ ignore = [
     "RUSTSEC-2023-0089", # Unmaintained `atomic-polyfill` (2025-04-29)
     "RUSTSEC-2025-0057", # Unmaintained `fxhash` (2026-04-10), requires bumps on `provekit`
     "RUSTSEC-2025-0141", # Unmaintained `bincode` (2026-04-10), requires bumps on `provekit`
+    "RUSTSEC-2023-0126", # Unsound `im::OrdSet`; transitive via `provekit`, no safe upgrade available (2026-08-11)
+    "RUSTSEC-2026-0247", # Unmaintained `bitmaps`; transitive via `provekit`, no safe upgrade available (2026-08-11)
+    "RUSTSEC-2026-0248", # Unmaintained `im`; transitive via `provekit`, no safe upgrade available (2026-08-11)
+    "RUSTSEC-2026-0251", # Unmaintained `sized-chunks`; transitive via `provekit`, no safe upgrade available (2026-08-11)
+    "RUSTSEC-2026-0253", # Unsound `lru` 0.16.x; `alloy-provider` needs an upgrade before lru 0.18.2 (2026-08-11)
     "RUSTSEC-2026-0074", # `libcrux-sha3` via testcontainers->russh; dev-only, does not affect our usage (2026-03-26)
     "RUSTSEC-2026-0207", # `libcrux-sha3` SHAKE incremental API; via testcontainers->russh->libcrux-ml-kem; dev-only, no safe upgrade (2026-07-21)
     "RUSTSEC-2026-0208", # `libcrux-sha3` AVX2 SHAKE-256 panic; via testcontainers->russh->libcrux-ml-kem; dev-only, no safe upgrade (2026-07-21)


### PR DESCRIPTION
## Summary

- Update `zk-mobile-bench` to `mobench-sdk` 0.2.0 and UniFFI 0.32.
- Bump the Rust 1.85-compatible TACEO Circom/Groth16/Poseidon dependencies and lockfile.
- Keep all seven query/nullifier OPRF benchmarks enabled.
- Use the currently available BrowserStack Android device when the low-spec profile is selected.

## Validation

- `cargo test -p zk-mobile-bench --lib`
- `git diff --check`
- BrowserStack mobile benchmark workflow dispatched for the final commit.