### PR TITLE
docs: correct the tracing-subscriber advisory rationale

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -40,7 +40,7 @@ allow = [
 ignore = [
     "RUSTSEC-2024-0388", # Unmaintained `derivative` (2024-11-22)
     "RUSTSEC-2024-0436", # Unmaintained `paste` (2025-04-04)
-    "RUSTSEC-2025-0055", # `tracing-subscriber` < 0.3.20, requires bumps on `semaphore-rs` (and Ark deps) (2025-09-09)
+    "RUSTSEC-2025-0055", # ANSI injection in `tracing-subscriber` < 0.3.20; our own logging is on the patched 0.3.x — the flagged 0.2.25 is only reachable via `ark-relations`' opt-in `ConstraintLayer`, which this repo never installs; clearing it needs Ark bumps (2025-09-09)
     "RUSTSEC-2023-0089", # Unmaintained `atomic-polyfill` (2025-04-29)
     "RUSTSEC-2025-0057", # Unmaintained `fxhash` (2026-04-10), requires bumps on `provekit`
     "RUSTSEC-2025-0141", # Unmaintained `bincode` (2026-04-10), requires bumps on `provekit`


### PR DESCRIPTION
Comment-only change to one `deny.toml` ignore entry. No policy change — the advisory stays ignored.

The existing comment reads as though RUSTSEC-2025-0055 (CVE-2025-58160, ANSI escape injection when logging untrusted input) were wholly unfixable pending `semaphore-rs` and Ark bumps. What is actually in the tree:

- Our services log through `tracing-subscriber` **0.3.22**, already patched — the advisory needs `>= 0.3.20`. The workspace pins `tracing-subscriber = "0.3"`.
- The vulnerable **0.2.25** arrives as `ark-relations`' *optional* dependency, enabled through its `std` feature, reaching `world-id-indexer` on normal (non-dev) edges via `semaphore-rs`.
- `ark-relations` uses it in exactly one place, `src/r1cs/trace.rs`, for the opt-in `ConstraintLayer` R1CS-debugging layer. Nothing in this repo references `ConstraintLayer` or `TracingMode`, so that code is linked but never installed.

So there is no live exposure, but the reason is "our logging is already on the patched version and the residual copy is an unused debug layer" — not "we are waiting on Ark". Given the advisory is specifically about logging untrusted input and the indexer does log request data, that distinction seemed worth recording where the next person will look.

`Cargo deny (advisories)` will be red here until #909 merges — this branch is cut from `main`, which is currently red for the unrelated RUSTSEC-2026-0247/0248/0251 publications. Verified locally that this change introduces no new advisory hit and the TOML still deserializes.