### PR TITLE
refactor!: unify field element domain prefixes into FePrefix

### DIFF
--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -46,6 +46,7 @@ pub mod api_types;
 
 /// Contains types specifically related to the OPRF services.
 pub mod oprf;
+pub use oprf::{OprfPrefix, OprfPrefixedFieldElement};
 
 /// A nullifier is a unique, one-time identifier. See [`Nullifier`] for more details.
 mod nullifier;
@@ -53,7 +54,7 @@ pub use nullifier::Nullifier;
 
 /// Contains types relevant for Session Proofs.
 mod session;
-pub use session::{FePrefix, PrefixedFieldElement, SessionId, SessionNullifier, SessionRef};
+pub use session::{SessionId, SessionNullifier, SessionRef};
 
 /// Contains the quintessential zero-knowledge proof type.
 pub mod proof;

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -53,7 +53,7 @@ pub use nullifier::Nullifier;
 
 /// Contains types relevant for Session Proofs.
 mod session;
-pub use session::{SessionFeType, SessionFieldElement, SessionId, SessionNullifier, SessionRef};
+pub use session::{FePrefix, PrefixedFieldElement, SessionId, SessionNullifier, SessionRef};
 
 /// Contains the quintessential zero-knowledge proof type.
 pub mod proof;

--- a/crates/primitives/src/oprf.rs
+++ b/crates/primitives/src/oprf.rs
@@ -14,8 +14,7 @@ use crate::{FieldElement, rp::RpId};
 /// their outputs from colliding. The variants are exhaustive for the nullifier and
 /// session OPRF inputs.
 ///
-/// [`ProofType::action_prefix`](crate::ProofType::action_prefix) maps each proof
-/// flow to one of these authoritative OPRF input domains.
+/// These variants are the authoritative OPRF input domains.
 #[repr(u8)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum OprfPrefix {

--- a/crates/primitives/src/oprf.rs
+++ b/crates/primitives/src/oprf.rs
@@ -7,8 +7,65 @@ use taceo_oprf::types::api::{CloseFrameMessage, OprfRequestAuthenticatorError};
 
 use crate::{FieldElement, rp::RpId};
 
-#[expect(unused_imports, reason = "used in doc comments")]
-use crate::FePrefix;
+/// The most significant byte (MSB) of an OPRF input field element, which separates
+/// the domains in which the input may be used.
+///
+/// All three prefixes share one OPRF key and query structure, so the MSB is what keeps
+/// their outputs from colliding. The variants are exhaustive for the nullifier and
+/// session OPRF inputs.
+///
+/// The values match the [`crate::ProofType`] discriminants — see
+/// [`ProofType::action_prefix`](crate::ProofType::action_prefix), which is the
+/// authoritative mapping.
+#[repr(u8)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OprfPrefix {
+    /// The default domain: uniqueness actions, and any other OPRF input that is not
+    /// session-scoped.
+    ///
+    /// Unlike the session prefixes, `0x00` elements are not minted by the protocol —
+    /// uniqueness actions are chosen freely by the RP. Checking for this prefix
+    /// therefore only rules out session reuse; it implies nothing else about the value.
+    Uniqueness = 0x00,
+    /// The [`crate::SessionId::oprf_seed`].
+    SessionOprfSeed = 0x01,
+    /// The action used to compute the inner nullifier in a [`crate::SessionNullifier`].
+    SessionAction = 0x02,
+}
+
+/// Generation and validation of domain-prefixed OPRF inputs. See [`OprfPrefix`].
+pub trait OprfPrefixedFieldElement {
+    /// Generate a randomized field element carrying the given OPRF prefix.
+    ///
+    /// # Panics
+    /// Never — any 32-byte value whose MSB is one of the [`OprfPrefix`] variants is
+    /// below the babyjubjub modulus.
+    fn random_with_prefix<R: rand::CryptoRng + rand::RngCore>(
+        rng: &mut R,
+        prefix: OprfPrefix,
+    ) -> FieldElement;
+
+    /// Returns whether the field element carries the given OPRF prefix.
+    fn has_prefix(&self, prefix: OprfPrefix) -> bool;
+}
+
+impl OprfPrefixedFieldElement for FieldElement {
+    fn random_with_prefix<R: rand::CryptoRng + rand::RngCore>(
+        rng: &mut R,
+        prefix: OprfPrefix,
+    ) -> FieldElement {
+        let mut bytes = [0u8; 32];
+        rng.fill_bytes(&mut bytes);
+        bytes[0] = prefix as u8;
+        Self::from_be_bytes(&bytes).expect(
+            "should always fit in the field because with 0x02 or lower as the MSB, the field element < babyjubjub modulus",
+        )
+    }
+
+    fn has_prefix(&self, prefix: OprfPrefix) -> bool {
+        self.to_be_bytes()[0] == prefix as u8
+    }
+}
 
 /// A module identifier for OPRF evaluations.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
@@ -86,7 +143,7 @@ pub struct NullifierOprfRequestAuthV1 {
     /// Additional data needed to reconstruct the RP-signed message.
     ///
     /// Currently only valid on create-and-bind session-seed queries (see
-    /// [`FePrefix::SessionOprfSeed`]) from EOA-backed RPs.
+    /// [`OprfPrefix::SessionOprfSeed`]) from EOA-backed RPs.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub rp_signature_verification: Option<RpSignatureVerification>,
 }
@@ -187,7 +244,7 @@ pub enum WorldIdRequestAuthError {
     InvalidActionNullifier,
     /// **Only valid for Session Proofs**.
     ///
-    /// The provided action for the Session Proof is invalid. See [`FePrefix`] for the valid action
+    /// The provided action for the Session Proof is invalid. See [`OprfPrefix`] for the valid action
     /// prefixes.
     #[error("invalid_action_for_session")]
     InvalidActionSession,
@@ -531,6 +588,38 @@ impl From<WorldIdRequestAuthError> for OprfRequestAuthenticatorError {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    const ALL_PREFIXES: [OprfPrefix; 3] = [
+        OprfPrefix::Uniqueness,
+        OprfPrefix::SessionOprfSeed,
+        OprfPrefix::SessionAction,
+    ];
+
+    #[test]
+    fn prefix_bytes_are_stable() {
+        assert_eq!(OprfPrefix::Uniqueness as u8, 0x00);
+        assert_eq!(OprfPrefix::SessionOprfSeed as u8, 0x01);
+        assert_eq!(OprfPrefix::SessionAction as u8, 0x02);
+    }
+
+    #[test]
+    fn random_with_prefix_is_recognized_only_by_its_own_prefix() {
+        let mut rng = rand::rngs::OsRng;
+        for prefix in ALL_PREFIXES {
+            let field_element = FieldElement::random_with_prefix(&mut rng, prefix);
+            assert_eq!(field_element.to_be_bytes()[0], prefix as u8);
+            for other in ALL_PREFIXES {
+                assert_eq!(field_element.has_prefix(other), other == prefix);
+            }
+        }
+    }
+
+    #[test]
+    fn zero_carries_the_uniqueness_prefix() {
+        // The default domain is the absence of a session prefix, so it holds for values
+        // the protocol never mints — including zero.
+        assert!(FieldElement::ZERO.has_prefix(OprfPrefix::Uniqueness));
+    }
 
     /// A structurally valid Groth16 proof (BN254 generator points) for serde tests.
     fn test_proof() -> Proof<Bn254> {

--- a/crates/primitives/src/oprf.rs
+++ b/crates/primitives/src/oprf.rs
@@ -8,7 +8,7 @@ use taceo_oprf::types::api::{CloseFrameMessage, OprfRequestAuthenticatorError};
 use crate::{FieldElement, rp::RpId};
 
 #[expect(unused_imports, reason = "used in doc comments")]
-use crate::SessionFeType;
+use crate::FePrefix;
 
 /// A module identifier for OPRF evaluations.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
@@ -86,7 +86,7 @@ pub struct NullifierOprfRequestAuthV1 {
     /// Additional data needed to reconstruct the RP-signed message.
     ///
     /// Currently only valid on create-and-bind session-seed queries (see
-    /// [`SessionFeType::OprfSeed`]) from EOA-backed RPs.
+    /// [`FePrefix::SessionOprfSeed`]) from EOA-backed RPs.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub rp_signature_verification: Option<RpSignatureVerification>,
 }
@@ -187,7 +187,7 @@ pub enum WorldIdRequestAuthError {
     InvalidActionNullifier,
     /// **Only valid for Session Proofs**.
     ///
-    /// The provided action for the Session Proof is invalid. See [`SessionFeType`] for the valid action
+    /// The provided action for the Session Proof is invalid. See [`FePrefix`] for the valid action
     /// prefixes.
     #[error("invalid_action_for_session")]
     InvalidActionSession,

--- a/crates/primitives/src/oprf.rs
+++ b/crates/primitives/src/oprf.rs
@@ -14,9 +14,8 @@ use crate::{FieldElement, rp::RpId};
 /// their outputs from colliding. The variants are exhaustive for the nullifier and
 /// session OPRF inputs.
 ///
-/// The values match the [`crate::ProofType`] discriminants — see
-/// [`ProofType::action_prefix`](crate::ProofType::action_prefix), which is the
-/// authoritative mapping.
+/// [`ProofType::action_prefix`](crate::ProofType::action_prefix) maps each proof
+/// flow to one of these authoritative OPRF input domains.
 #[repr(u8)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum OprfPrefix {
@@ -36,10 +35,6 @@ pub enum OprfPrefix {
 /// Generation and validation of domain-prefixed OPRF inputs. See [`OprfPrefix`].
 pub trait OprfPrefixedFieldElement {
     /// Generate a randomized field element carrying the given OPRF prefix.
-    ///
-    /// # Panics
-    /// Never — any 32-byte value whose MSB is one of the [`OprfPrefix`] variants is
-    /// below the babyjubjub modulus.
     fn random_with_prefix<R: rand::CryptoRng + rand::RngCore>(
         rng: &mut R,
         prefix: OprfPrefix,
@@ -596,13 +591,6 @@ mod tests {
     ];
 
     #[test]
-    fn prefix_bytes_are_stable() {
-        assert_eq!(OprfPrefix::Uniqueness as u8, 0x00);
-        assert_eq!(OprfPrefix::SessionOprfSeed as u8, 0x01);
-        assert_eq!(OprfPrefix::SessionAction as u8, 0x02);
-    }
-
-    #[test]
     fn random_with_prefix_is_recognized_only_by_its_own_prefix() {
         let mut rng = rand::rngs::OsRng;
         for prefix in ALL_PREFIXES {
@@ -612,13 +600,6 @@ mod tests {
                 assert_eq!(field_element.has_prefix(other), other == prefix);
             }
         }
-    }
-
-    #[test]
-    fn zero_carries_the_uniqueness_prefix() {
-        // The default domain is the absence of a session prefix, so it holds for values
-        // the protocol never mints — including zero.
-        assert!(FieldElement::ZERO.has_prefix(OprfPrefix::Uniqueness));
     }
 
     /// A structurally valid Groth16 proof (BN254 generator points) for serde tests.

--- a/crates/primitives/src/request/mod.rs
+++ b/crates/primitives/src/request/mod.rs
@@ -6,8 +6,8 @@ mod constraints;
 pub use constraints::{ConstraintExpr, ConstraintKind, ConstraintNode, MAX_CONSTRAINT_NODES};
 
 use crate::{
-    FieldElement, Nullifier, PrimitiveError, SessionId, SessionNullifier, SessionRef,
-    ZeroKnowledgeProof, rp::RpId,
+    FePrefix, FieldElement, Nullifier, PrefixedFieldElement as _, PrimitiveError, SessionId,
+    SessionNullifier, SessionRef, ZeroKnowledgeProof, rp::RpId,
 };
 use serde::{Deserialize, Serialize, de::Error as _};
 use std::collections::HashSet;
@@ -51,9 +51,9 @@ impl<'de> serde::Deserialize<'de> for RequestVersion {
 /// Explicit discriminants reserve a stable one-byte protocol encoding for future
 /// signed request payloads. JSON serialization remains the snake_case variant name.
 ///
-/// The values match the action prefixes (see [`crate::SessionFeType`]): `0x00` for a
-/// uniqueness action, `0x02` for a session action. `0x01` is skipped because it prefixes
-/// the session `oprf_seed`, which is not a proof flow of its own.
+/// The discriminants are the action prefixes the flow's action must carry — see
+/// [`Self::action_prefix`]. [`FePrefix::SessionOprfSeed`] (`0x01`) has no variant here
+/// because the session `oprf_seed` is not a proof flow of its own.
 #[repr(u8)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -71,6 +71,18 @@ pub enum ProofType {
 }
 
 impl ProofType {
+    /// The prefix the OPRF action must carry for this proof flow.
+    ///
+    /// This is the authoritative mapping between a proof flow and its action domain;
+    /// the matching discriminants are an encoding convenience, not the contract.
+    #[must_use]
+    pub const fn action_prefix(&self) -> FePrefix {
+        match self {
+            Self::Uniqueness => FePrefix::Uniqueness,
+            Self::Session => FePrefix::SessionAction,
+        }
+    }
+
     /// Returns true for the default uniqueness proof flow.
     #[must_use]
     pub const fn is_uniqueness(&self) -> bool {
@@ -468,6 +480,10 @@ impl ProofRequest {
     /// If `proof_type` was omitted during deserialization, it defaults to
     /// [`ProofType::Uniqueness`]. Session flows must opt in explicitly.
     ///
+    /// A present `action` must also carry the prefix its flow requires
+    /// ([`ProofType::action_prefix`]), so that an action from another domain is rejected
+    /// here rather than by the OPRF nodes after a round trip.
+    ///
     /// # Errors
     /// Returns [`PrimitiveError::InvalidInput`] when the request has an invalid
     /// combination of `proof_type`, `session_id`, and `action`.
@@ -495,7 +511,21 @@ impl ProofRequest {
                 })
             }
             _ => Ok(()),
+        }?;
+
+        // Only reached with an `action` the flow actually scopes by; the arms above
+        // already rejected the flows that must omit it.
+        if let Some(action) = self.action {
+            let prefix = self.proof_type.action_prefix();
+            if !action.has_prefix(prefix) {
+                return Err(PrimitiveError::InvalidInput {
+                    attribute: "action".to_string(),
+                    reason: format!("MSB must be 0x{:02x}", prefix as u8),
+                });
+            }
         }
+
+        Ok(())
     }
 
     /// Returns true if this request produces a Session proof.
@@ -861,12 +891,16 @@ mod tests {
         FieldElement::from(n)
     }
 
+    /// Creates a field element carrying the given domain prefix in its MSB
+    fn test_action_with_prefix(prefix: FePrefix, n: u64) -> FieldElement {
+        use ruint::aliases::U256;
+        let v = U256::from(n) | (U256::from(prefix as u8) << 248);
+        FieldElement::try_from(v).expect("test value fits in field")
+    }
+
     /// Creates an action with the required `0x02` session prefix
     fn test_action(n: u64) -> FieldElement {
-        use ruint::{aliases::U256, uint};
-        let v = U256::from(n)
-            | uint!(0x0200000000000000000000000000000000000000000000000000000000000000_U256);
-        FieldElement::try_from(v).expect("test value fits in field")
+        test_action_with_prefix(FePrefix::SessionAction, n)
     }
 
     /// Creates a session id with a non-zero commitment and a `0x01`-prefixed oprf seed
@@ -2455,6 +2489,18 @@ mod tests {
         assert!(plain_uniqueness.validate_proof_type().is_ok());
         assert!(!plain_uniqueness.binds_session());
 
+        // a uniqueness action must live in the uniqueness domain, not a session one
+        for prefix in [FePrefix::SessionOprfSeed, FePrefix::SessionAction] {
+            let session_prefixed_action = ProofRequest {
+                action: Some(test_action_with_prefix(prefix, 42)),
+                ..uniqueness_with_create.clone()
+            };
+            assert!(matches!(
+                session_prefixed_action.validate_proof_type(),
+                Err(PrimitiveError::InvalidInput { attribute, .. }) if attribute == "action"
+            ));
+        }
+
         // uniqueness cannot bind an already existing session
         let uniqueness_with_existing = ProofRequest {
             session_id: SessionRef::Existing(test_session_id(1)),
@@ -2661,6 +2707,15 @@ mod tests {
         // `oprf_seed` rather than a proof flow.
         assert_eq!(ProofType::Uniqueness as u8, 0x00);
         assert_eq!(ProofType::Session as u8, 0x02);
+    }
+
+    #[test]
+    fn proof_type_action_prefix_matches_discriminant() {
+        for proof_type in [ProofType::Uniqueness, ProofType::Session] {
+            assert_eq!(proof_type.action_prefix() as u8, proof_type as u8);
+        }
+        assert_eq!(ProofType::Uniqueness.action_prefix(), FePrefix::Uniqueness);
+        assert_eq!(ProofType::Session.action_prefix(), FePrefix::SessionAction);
     }
 
     #[test]

--- a/crates/primitives/src/request/mod.rs
+++ b/crates/primitives/src/request/mod.rs
@@ -48,8 +48,8 @@ impl<'de> serde::Deserialize<'de> for RequestVersion {
 
 /// The high-level proof flow requested by an RP.
 ///
-/// Explicit discriminants reserve a stable one-byte protocol encoding for future
-/// signed request payloads. JSON serialization remains the snake_case variant name.
+/// Reserved for a possible future one-byte protocol encoding. Currently, JSON uses
+/// snake_case variant names and these discriminants are not serialized.
 ///
 /// The discriminants are the action prefixes the flow's action must carry — see
 /// [`Self::action_prefix`]. [`FePrefix::SessionOprfSeed`] (`0x01`) has no variant here
@@ -64,10 +64,10 @@ pub enum ProofType {
     /// or omit session involvement entirely — see [`ProofRequest::binds_session`].
     /// Binding to an already existing session is not supported.
     #[default]
-    Uniqueness = 0x00,
+    Uniqueness = FePrefix::Uniqueness as u8,
     /// Prove an RP-scoped session — either minting a fresh one
     /// (`session_id: "create"`) or an existing one (`session_id: "session_<hex>"`).
-    Session = 0x02,
+    Session = FePrefix::SessionAction as u8,
 }
 
 impl ProofType {

--- a/crates/primitives/src/request/mod.rs
+++ b/crates/primitives/src/request/mod.rs
@@ -503,13 +503,13 @@ impl ProofRequest {
 
         // Only uniqueness flows can reach this point with an action; session flows
         // carrying one were rejected above.
-        if let Some(action) = self.action {
-            if !action.has_prefix(OprfPrefix::Uniqueness) {
-                return Err(PrimitiveError::InvalidInput {
-                    attribute: "action".to_string(),
-                    reason: format!("MSB must be 0x{:02x}", OprfPrefix::Uniqueness as u8),
-                });
-            }
+        if let Some(action) = self.action
+            && !action.has_prefix(OprfPrefix::Uniqueness)
+        {
+            return Err(PrimitiveError::InvalidInput {
+                attribute: "action".to_string(),
+                reason: format!("MSB must be 0x{:02x}", OprfPrefix::Uniqueness as u8),
+            });
         }
 
         Ok(())

--- a/crates/primitives/src/request/mod.rs
+++ b/crates/primitives/src/request/mod.rs
@@ -6,7 +6,7 @@ mod constraints;
 pub use constraints::{ConstraintExpr, ConstraintKind, ConstraintNode, MAX_CONSTRAINT_NODES};
 
 use crate::{
-    FePrefix, FieldElement, Nullifier, PrefixedFieldElement as _, PrimitiveError, SessionId,
+    FieldElement, Nullifier, OprfPrefix, OprfPrefixedFieldElement as _, PrimitiveError, SessionId,
     SessionNullifier, SessionRef, ZeroKnowledgeProof, rp::RpId,
 };
 use serde::{Deserialize, Serialize, de::Error as _};
@@ -52,7 +52,7 @@ impl<'de> serde::Deserialize<'de> for RequestVersion {
 /// snake_case variant names and these discriminants are not serialized.
 ///
 /// The discriminants are the action prefixes the flow's action must carry — see
-/// [`Self::action_prefix`]. [`FePrefix::SessionOprfSeed`] (`0x01`) has no variant here
+/// [`Self::action_prefix`]. [`OprfPrefix::SessionOprfSeed`] (`0x01`) has no variant here
 /// because the session `oprf_seed` is not a proof flow of its own.
 #[repr(u8)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
@@ -64,10 +64,10 @@ pub enum ProofType {
     /// or omit session involvement entirely — see [`ProofRequest::binds_session`].
     /// Binding to an already existing session is not supported.
     #[default]
-    Uniqueness = FePrefix::Uniqueness as u8,
+    Uniqueness = OprfPrefix::Uniqueness as u8,
     /// Prove an RP-scoped session — either minting a fresh one
     /// (`session_id: "create"`) or an existing one (`session_id: "session_<hex>"`).
-    Session = FePrefix::SessionAction as u8,
+    Session = OprfPrefix::SessionAction as u8,
 }
 
 impl ProofType {
@@ -76,10 +76,10 @@ impl ProofType {
     /// This is the authoritative mapping between a proof flow and its action domain;
     /// the matching discriminants are an encoding convenience, not the contract.
     #[must_use]
-    pub const fn action_prefix(&self) -> FePrefix {
+    pub const fn action_prefix(&self) -> OprfPrefix {
         match self {
-            Self::Uniqueness => FePrefix::Uniqueness,
-            Self::Session => FePrefix::SessionAction,
+            Self::Uniqueness => OprfPrefix::Uniqueness,
+            Self::Session => OprfPrefix::SessionAction,
         }
     }
 
@@ -892,7 +892,7 @@ mod tests {
     }
 
     /// Creates a field element carrying the given domain prefix in its MSB
-    fn test_action_with_prefix(prefix: FePrefix, n: u64) -> FieldElement {
+    fn test_action_with_prefix(prefix: OprfPrefix, n: u64) -> FieldElement {
         use ruint::aliases::U256;
         let v = U256::from(n) | (U256::from(prefix as u8) << 248);
         FieldElement::try_from(v).expect("test value fits in field")
@@ -900,7 +900,7 @@ mod tests {
 
     /// Creates an action with the required `0x02` session prefix
     fn test_action(n: u64) -> FieldElement {
-        test_action_with_prefix(FePrefix::SessionAction, n)
+        test_action_with_prefix(OprfPrefix::SessionAction, n)
     }
 
     /// Creates a session id with a non-zero commitment and a `0x01`-prefixed oprf seed
@@ -2490,7 +2490,7 @@ mod tests {
         assert!(!plain_uniqueness.binds_session());
 
         // a uniqueness action must live in the uniqueness domain, not a session one
-        for prefix in [FePrefix::SessionOprfSeed, FePrefix::SessionAction] {
+        for prefix in [OprfPrefix::SessionOprfSeed, OprfPrefix::SessionAction] {
             let session_prefixed_action = ProofRequest {
                 action: Some(test_action_with_prefix(prefix, 42)),
                 ..uniqueness_with_create.clone()
@@ -2714,8 +2714,14 @@ mod tests {
         for proof_type in [ProofType::Uniqueness, ProofType::Session] {
             assert_eq!(proof_type.action_prefix() as u8, proof_type as u8);
         }
-        assert_eq!(ProofType::Uniqueness.action_prefix(), FePrefix::Uniqueness);
-        assert_eq!(ProofType::Session.action_prefix(), FePrefix::SessionAction);
+        assert_eq!(
+            ProofType::Uniqueness.action_prefix(),
+            OprfPrefix::Uniqueness
+        );
+        assert_eq!(
+            ProofType::Session.action_prefix(),
+            OprfPrefix::SessionAction
+        );
     }
 
     #[test]

--- a/crates/primitives/src/request/mod.rs
+++ b/crates/primitives/src/request/mod.rs
@@ -51,9 +51,9 @@ impl<'de> serde::Deserialize<'de> for RequestVersion {
 /// Reserved for a possible future one-byte protocol encoding. Currently, JSON uses
 /// snake_case variant names and these discriminants are not serialized.
 ///
-/// The discriminants are the action prefixes the flow's action must carry — see
-/// [`Self::action_prefix`]. [`OprfPrefix::SessionOprfSeed`] (`0x01`) has no variant here
-/// because the session `oprf_seed` is not a proof flow of its own.
+/// The discriminants mirror the OPRF domains used by each proof flow.
+/// [`OprfPrefix::SessionOprfSeed`] (`0x01`) has no variant here because the session
+/// `oprf_seed` is not a proof flow of its own.
 #[repr(u8)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -71,18 +71,6 @@ pub enum ProofType {
 }
 
 impl ProofType {
-    /// The prefix the OPRF action must carry for this proof flow.
-    ///
-    /// This is the authoritative mapping between a proof flow and its action domain;
-    /// the matching discriminants are an encoding convenience, not the contract.
-    #[must_use]
-    pub const fn action_prefix(&self) -> OprfPrefix {
-        match self {
-            Self::Uniqueness => OprfPrefix::Uniqueness,
-            Self::Session => OprfPrefix::SessionAction,
-        }
-    }
-
     /// Returns true for the default uniqueness proof flow.
     #[must_use]
     pub const fn is_uniqueness(&self) -> bool {
@@ -480,9 +468,9 @@ impl ProofRequest {
     /// If `proof_type` was omitted during deserialization, it defaults to
     /// [`ProofType::Uniqueness`]. Session flows must opt in explicitly.
     ///
-    /// A present `action` must also carry the prefix its flow requires
-    /// ([`ProofType::action_prefix`]), so that an action from another domain is rejected
-    /// here rather than by the OPRF nodes after a round trip.
+    /// A uniqueness `action` must also carry [`OprfPrefix::Uniqueness`], so that an
+    /// action from another domain is rejected here rather than by the OPRF nodes after
+    /// a round trip.
     ///
     /// # Errors
     /// Returns [`PrimitiveError::InvalidInput`] when the request has an invalid
@@ -513,14 +501,13 @@ impl ProofRequest {
             _ => Ok(()),
         }?;
 
-        // Only reached with an `action` the flow actually scopes by; the arms above
-        // already rejected the flows that must omit it.
+        // Only uniqueness flows can reach this point with an action; session flows
+        // carrying one were rejected above.
         if let Some(action) = self.action {
-            let prefix = self.proof_type.action_prefix();
-            if !action.has_prefix(prefix) {
+            if !action.has_prefix(OprfPrefix::Uniqueness) {
                 return Err(PrimitiveError::InvalidInput {
                     attribute: "action".to_string(),
-                    reason: format!("MSB must be 0x{:02x}", prefix as u8),
+                    reason: format!("MSB must be 0x{:02x}", OprfPrefix::Uniqueness as u8),
                 });
             }
         }
@@ -2707,21 +2694,6 @@ mod tests {
         // `oprf_seed` rather than a proof flow.
         assert_eq!(ProofType::Uniqueness as u8, 0x00);
         assert_eq!(ProofType::Session as u8, 0x02);
-    }
-
-    #[test]
-    fn proof_type_action_prefix_matches_discriminant() {
-        for proof_type in [ProofType::Uniqueness, ProofType::Session] {
-            assert_eq!(proof_type.action_prefix() as u8, proof_type as u8);
-        }
-        assert_eq!(
-            ProofType::Uniqueness.action_prefix(),
-            OprfPrefix::Uniqueness
-        );
-        assert_eq!(
-            ProofType::Session.action_prefix(),
-            OprfPrefix::SessionAction
-        );
     }
 
     #[test]

--- a/crates/primitives/src/session.rs
+++ b/crates/primitives/src/session.rs
@@ -1,67 +1,10 @@
-use crate::{FieldElement, PrimitiveError};
+use crate::{
+    FieldElement, PrimitiveError,
+    oprf::{OprfPrefix, OprfPrefixedFieldElement as _},
+};
 use embed_doc_image::embed_doc_image;
 use ruint::aliases::U256;
 use serde::{Deserialize, Deserializer, Serialize, Serializer, de::Error as _};
-
-/// The most significant byte (MSB) of a protocol field element, which separates the
-/// domains a field element may be used in.
-///
-/// All three prefixes share one OPRF key and query structure, so the MSB is what keeps
-/// their outputs from colliding. The variants are exhaustive: every valid protocol
-/// field element carries one of these as its MSB.
-///
-/// The values match the [`crate::ProofType`] discriminants — see
-/// [`ProofType::action_prefix`](crate::ProofType::action_prefix), which is the
-/// authoritative mapping.
-#[repr(u8)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum FePrefix {
-    /// The default domain: uniqueness actions, and any other field element that is not
-    /// session-scoped.
-    ///
-    /// Unlike the session prefixes, `0x00` elements are not minted by the protocol —
-    /// uniqueness actions are chosen freely by the RP. Checking for this prefix
-    /// therefore only rules out session reuse; it implies nothing else about the value.
-    Uniqueness = 0x00,
-    /// The [`SessionId::oprf_seed`]
-    SessionOprfSeed = 0x01,
-    /// The action used to compute the inner nullifier (in a [`SessionNullifier`]) for a Session Proof.
-    SessionAction = 0x02,
-}
-
-/// Generation and validation of domain-prefixed field elements. See [`FePrefix`].
-pub trait PrefixedFieldElement {
-    /// Generate a randomized field element carrying the given prefix.
-    ///
-    /// # Panics
-    /// Never — any 32-byte value whose MSB is one of the [`FePrefix`] variants is below
-    /// the babyjubjub modulus.
-    fn random_with_prefix<R: rand::CryptoRng + rand::RngCore>(
-        rng: &mut R,
-        prefix: FePrefix,
-    ) -> FieldElement;
-    /// Returns whether the field element carries the given prefix.
-    fn has_prefix(&self, prefix: FePrefix) -> bool;
-}
-
-impl PrefixedFieldElement for FieldElement {
-    fn random_with_prefix<R: rand::CryptoRng + rand::RngCore>(
-        rng: &mut R,
-        prefix: FePrefix,
-    ) -> FieldElement {
-        let mut bytes = [0u8; 32];
-        rng.fill_bytes(&mut bytes);
-        bytes[0] = prefix as u8;
-        let seed = U256::from_be_bytes(bytes);
-        Self::try_from(seed).expect(
-            "should always fit in the field because with 0x02 or lower as the MSB, the field element < babyjubjub modulus",
-        )
-    }
-
-    fn has_prefix(&self, prefix: FePrefix) -> bool {
-        self.to_be_bytes()[0] == prefix as u8
-    }
-}
 
 /// An identifier for a session (can be re-used).
 ///
@@ -123,7 +66,7 @@ impl SessionId {
         // OPRF Seeds must always start with a byte of `0x01`. See [`Self::oprf_seed`]
         // for details. Panic is acceptable as `oprf_seed` generation should
         // generally be done with `Self::from_r_seed`
-        if !oprf_seed.has_prefix(FePrefix::SessionOprfSeed) {
+        if !oprf_seed.has_prefix(OprfPrefix::SessionOprfSeed) {
             return Err(PrimitiveError::InvalidInput {
                 attribute: "session_id".to_string(),
                 reason: "inner oprf_seed is not valid".to_string(),
@@ -154,7 +97,7 @@ impl SessionId {
     ) -> Result<Self, PrimitiveError> {
         let sub_ds = FieldElement::from_be_bytes_mod_order(Self::DS_C);
 
-        if !oprf_seed.has_prefix(FePrefix::SessionOprfSeed) {
+        if !oprf_seed.has_prefix(OprfPrefix::SessionOprfSeed) {
             return Err(PrimitiveError::InvalidInput {
                 attribute: "session_id".to_string(),
                 reason: "inner oprf_seed is not valid".to_string(),
@@ -172,7 +115,7 @@ impl SessionId {
 
     /// Generates a new [`Self::oprf_seed`] to initialize a new Session.
     pub fn generate_oprf_seed<R: rand::CryptoRng + rand::RngCore>(rng: &mut R) -> FieldElement {
-        FieldElement::random_with_prefix(rng, FePrefix::SessionOprfSeed)
+        FieldElement::random_with_prefix(rng, OprfPrefix::SessionOprfSeed)
     }
 
     /// Returns the 64-byte big-endian representation (2 x 32-byte field elements).
@@ -201,7 +144,7 @@ impl SessionId {
         let oprf_seed = FieldElement::from_be_bytes(bytes[32..].try_into().unwrap())
             .map_err(|e| format!("invalid oprf_seed: {e}"))?;
 
-        if bytes[32] != FePrefix::SessionOprfSeed as u8 {
+        if bytes[32] != OprfPrefix::SessionOprfSeed as u8 {
             return Err("invalid prefix for oprf_seed".to_string());
         }
 
@@ -215,7 +158,7 @@ impl SessionId {
 impl Default for SessionId {
     fn default() -> Self {
         let mut oprf_seed = [0u8; 32];
-        oprf_seed[0] = FePrefix::SessionOprfSeed as u8;
+        oprf_seed[0] = OprfPrefix::SessionOprfSeed as u8;
         let oprf_seed = U256::from_be_bytes(oprf_seed)
             .try_into()
             .expect("always fits in the field");
@@ -427,7 +370,7 @@ impl SessionNullifier {
 
     /// Creates a new session nullifier.
     pub fn new(nullifier: FieldElement, action: FieldElement) -> Result<Self, PrimitiveError> {
-        if !action.has_prefix(FePrefix::SessionAction) {
+        if !action.has_prefix(OprfPrefix::SessionAction) {
             return Err(PrimitiveError::InvalidInput {
                 attribute: "session_nullifier".to_string(),
                 reason: "inner action is not valid".to_string(),
@@ -466,7 +409,7 @@ impl SessionNullifier {
         let action =
             FieldElement::try_from(value[1]).map_err(|e| format!("invalid action: {e}"))?;
 
-        if !action.has_prefix(FePrefix::SessionAction) {
+        if !action.has_prefix(OprfPrefix::SessionAction) {
             return Err("inner action is not valid".to_string());
         }
         Ok(Self { nullifier, action })
@@ -498,7 +441,7 @@ impl SessionNullifier {
         let action = FieldElement::from_be_bytes(bytes[32..].try_into().unwrap())
             .map_err(|e| format!("invalid action: {e}"))?;
 
-        if bytes[32] != FePrefix::SessionAction as u8 {
+        if bytes[32] != OprfPrefix::SessionAction as u8 {
             return Err("invalid action. missing expected prefix.".to_string());
         }
 
@@ -509,7 +452,7 @@ impl SessionNullifier {
 impl Default for SessionNullifier {
     fn default() -> Self {
         let mut action = [0u8; 32];
-        action[0] = FePrefix::SessionAction as u8;
+        action[0] = OprfPrefix::SessionAction as u8;
         let action = U256::from_be_bytes(action)
             .try_into()
             .expect("always fits in the field");
@@ -561,43 +504,6 @@ impl<'de> Deserialize<'de> for SessionNullifier {
 impl From<SessionNullifier> for [U256; 2] {
     fn from(value: SessionNullifier) -> Self {
         value.as_ethereum_representation()
-    }
-}
-
-#[cfg(test)]
-mod fe_prefix_tests {
-    use super::*;
-
-    const ALL: [FePrefix; 3] = [
-        FePrefix::Uniqueness,
-        FePrefix::SessionOprfSeed,
-        FePrefix::SessionAction,
-    ];
-
-    #[test]
-    fn prefix_bytes_are_stable() {
-        assert_eq!(FePrefix::Uniqueness as u8, 0x00);
-        assert_eq!(FePrefix::SessionOprfSeed as u8, 0x01);
-        assert_eq!(FePrefix::SessionAction as u8, 0x02);
-    }
-
-    #[test]
-    fn random_with_prefix_is_recognized_only_by_its_own_prefix() {
-        let mut rng = rand::rngs::OsRng;
-        for prefix in ALL {
-            let fe = FieldElement::random_with_prefix(&mut rng, prefix);
-            assert_eq!(fe.to_be_bytes()[0], prefix as u8);
-            for other in ALL {
-                assert_eq!(fe.has_prefix(other), other == prefix);
-            }
-        }
-    }
-
-    #[test]
-    fn zero_carries_the_uniqueness_prefix() {
-        // The default domain is the absence of a session prefix, so it holds for values
-        // the protocol never mints — including zero.
-        assert!(FieldElement::ZERO.has_prefix(FePrefix::Uniqueness));
     }
 }
 

--- a/crates/primitives/src/session.rs
+++ b/crates/primitives/src/session.rs
@@ -3,44 +3,63 @@ use embed_doc_image::embed_doc_image;
 use ruint::aliases::U256;
 use serde::{Deserialize, Deserializer, Serialize, Serializer, de::Error as _};
 
-/// Type of field elements for Session Proofs
+/// The most significant byte (MSB) of a protocol field element, which separates the
+/// domains a field element may be used in.
+///
+/// All three prefixes share one OPRF key and query structure, so the MSB is what keeps
+/// their outputs from colliding. The variants are exhaustive: every valid protocol
+/// field element carries one of these as its MSB.
+///
+/// The values match the [`crate::ProofType`] discriminants — see
+/// [`ProofType::action_prefix`](crate::ProofType::action_prefix), which is the
+/// authoritative mapping.
 #[repr(u8)]
-pub enum SessionFeType {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FePrefix {
+    /// The default domain: uniqueness actions, and any other field element that is not
+    /// session-scoped.
+    ///
+    /// Unlike the session prefixes, `0x00` elements are not minted by the protocol —
+    /// uniqueness actions are chosen freely by the RP. Checking for this prefix
+    /// therefore only rules out session reuse; it implies nothing else about the value.
+    Uniqueness = 0x00,
     /// The [`SessionId::oprf_seed`]
-    OprfSeed = 0x01,
+    SessionOprfSeed = 0x01,
     /// The action used to compute the inner nullifier (in a [`SessionNullifier`]) for a Session Proof.
-    Action = 0x02,
+    SessionAction = 0x02,
 }
 
-/// Allows field element generation for Session Proofs
-pub trait SessionFieldElement {
-    /// Generate a randomized field element with a specific prefix used
-    /// only for Session Proofs. See [`SessionFeType`] for details.
-    fn random_for_session<R: rand::CryptoRng + rand::RngCore>(
+/// Generation and validation of domain-prefixed field elements. See [`FePrefix`].
+pub trait PrefixedFieldElement {
+    /// Generate a randomized field element carrying the given prefix.
+    ///
+    /// # Panics
+    /// Never — any 32-byte value whose MSB is one of the [`FePrefix`] variants is below
+    /// the babyjubjub modulus.
+    fn random_with_prefix<R: rand::CryptoRng + rand::RngCore>(
         rng: &mut R,
-        element_type: SessionFeType,
+        prefix: FePrefix,
     ) -> FieldElement;
-    /// Returns whether a Field Element is valid for Session Proof use, i.e. it has
-    /// the right prefix
-    fn is_valid_for_session(&self, element_type: SessionFeType) -> bool;
+    /// Returns whether the field element carries the given prefix.
+    fn has_prefix(&self, prefix: FePrefix) -> bool;
 }
 
-impl SessionFieldElement for FieldElement {
-    fn random_for_session<R: rand::CryptoRng + rand::RngCore>(
+impl PrefixedFieldElement for FieldElement {
+    fn random_with_prefix<R: rand::CryptoRng + rand::RngCore>(
         rng: &mut R,
-        element_type: SessionFeType,
+        prefix: FePrefix,
     ) -> FieldElement {
         let mut bytes = [0u8; 32];
         rng.fill_bytes(&mut bytes);
-        bytes[0] = element_type as u8;
+        bytes[0] = prefix as u8;
         let seed = U256::from_be_bytes(bytes);
         Self::try_from(seed).expect(
-            "should always fit in the field because with 0x01 as the MSB, the field element < babyjubjub modulus",
+            "should always fit in the field because with 0x02 or lower as the MSB, the field element < babyjubjub modulus",
         )
     }
 
-    fn is_valid_for_session(&self, element_type: SessionFeType) -> bool {
-        self.to_be_bytes()[0] == element_type as u8
+    fn has_prefix(&self, prefix: FePrefix) -> bool {
+        self.to_be_bytes()[0] == prefix as u8
     }
 }
 
@@ -104,7 +123,7 @@ impl SessionId {
         // OPRF Seeds must always start with a byte of `0x01`. See [`Self::oprf_seed`]
         // for details. Panic is acceptable as `oprf_seed` generation should
         // generally be done with `Self::from_r_seed`
-        if !oprf_seed.is_valid_for_session(SessionFeType::OprfSeed) {
+        if !oprf_seed.has_prefix(FePrefix::SessionOprfSeed) {
             return Err(PrimitiveError::InvalidInput {
                 attribute: "session_id".to_string(),
                 reason: "inner oprf_seed is not valid".to_string(),
@@ -135,7 +154,7 @@ impl SessionId {
     ) -> Result<Self, PrimitiveError> {
         let sub_ds = FieldElement::from_be_bytes_mod_order(Self::DS_C);
 
-        if !oprf_seed.is_valid_for_session(SessionFeType::OprfSeed) {
+        if !oprf_seed.has_prefix(FePrefix::SessionOprfSeed) {
             return Err(PrimitiveError::InvalidInput {
                 attribute: "session_id".to_string(),
                 reason: "inner oprf_seed is not valid".to_string(),
@@ -153,7 +172,7 @@ impl SessionId {
 
     /// Generates a new [`Self::oprf_seed`] to initialize a new Session.
     pub fn generate_oprf_seed<R: rand::CryptoRng + rand::RngCore>(rng: &mut R) -> FieldElement {
-        FieldElement::random_for_session(rng, SessionFeType::OprfSeed)
+        FieldElement::random_with_prefix(rng, FePrefix::SessionOprfSeed)
     }
 
     /// Returns the 64-byte big-endian representation (2 x 32-byte field elements).
@@ -182,7 +201,7 @@ impl SessionId {
         let oprf_seed = FieldElement::from_be_bytes(bytes[32..].try_into().unwrap())
             .map_err(|e| format!("invalid oprf_seed: {e}"))?;
 
-        if bytes[32] != SessionFeType::OprfSeed as u8 {
+        if bytes[32] != FePrefix::SessionOprfSeed as u8 {
             return Err("invalid prefix for oprf_seed".to_string());
         }
 
@@ -196,7 +215,7 @@ impl SessionId {
 impl Default for SessionId {
     fn default() -> Self {
         let mut oprf_seed = [0u8; 32];
-        oprf_seed[0] = SessionFeType::OprfSeed as u8;
+        oprf_seed[0] = FePrefix::SessionOprfSeed as u8;
         let oprf_seed = U256::from_be_bytes(oprf_seed)
             .try_into()
             .expect("always fits in the field");
@@ -408,7 +427,7 @@ impl SessionNullifier {
 
     /// Creates a new session nullifier.
     pub fn new(nullifier: FieldElement, action: FieldElement) -> Result<Self, PrimitiveError> {
-        if !action.is_valid_for_session(SessionFeType::Action) {
+        if !action.has_prefix(FePrefix::SessionAction) {
             return Err(PrimitiveError::InvalidInput {
                 attribute: "session_nullifier".to_string(),
                 reason: "inner action is not valid".to_string(),
@@ -447,7 +466,7 @@ impl SessionNullifier {
         let action =
             FieldElement::try_from(value[1]).map_err(|e| format!("invalid action: {e}"))?;
 
-        if !action.is_valid_for_session(SessionFeType::Action) {
+        if !action.has_prefix(FePrefix::SessionAction) {
             return Err("inner action is not valid".to_string());
         }
         Ok(Self { nullifier, action })
@@ -479,7 +498,7 @@ impl SessionNullifier {
         let action = FieldElement::from_be_bytes(bytes[32..].try_into().unwrap())
             .map_err(|e| format!("invalid action: {e}"))?;
 
-        if bytes[32] != SessionFeType::Action as u8 {
+        if bytes[32] != FePrefix::SessionAction as u8 {
             return Err("invalid action. missing expected prefix.".to_string());
         }
 
@@ -490,7 +509,7 @@ impl SessionNullifier {
 impl Default for SessionNullifier {
     fn default() -> Self {
         let mut action = [0u8; 32];
-        action[0] = SessionFeType::Action as u8;
+        action[0] = FePrefix::SessionAction as u8;
         let action = U256::from_be_bytes(action)
             .try_into()
             .expect("always fits in the field");
@@ -542,6 +561,43 @@ impl<'de> Deserialize<'de> for SessionNullifier {
 impl From<SessionNullifier> for [U256; 2] {
     fn from(value: SessionNullifier) -> Self {
         value.as_ethereum_representation()
+    }
+}
+
+#[cfg(test)]
+mod fe_prefix_tests {
+    use super::*;
+
+    const ALL: [FePrefix; 3] = [
+        FePrefix::Uniqueness,
+        FePrefix::SessionOprfSeed,
+        FePrefix::SessionAction,
+    ];
+
+    #[test]
+    fn prefix_bytes_are_stable() {
+        assert_eq!(FePrefix::Uniqueness as u8, 0x00);
+        assert_eq!(FePrefix::SessionOprfSeed as u8, 0x01);
+        assert_eq!(FePrefix::SessionAction as u8, 0x02);
+    }
+
+    #[test]
+    fn random_with_prefix_is_recognized_only_by_its_own_prefix() {
+        let mut rng = rand::rngs::OsRng;
+        for prefix in ALL {
+            let fe = FieldElement::random_with_prefix(&mut rng, prefix);
+            assert_eq!(fe.to_be_bytes()[0], prefix as u8);
+            for other in ALL {
+                assert_eq!(fe.has_prefix(other), other == prefix);
+            }
+        }
+    }
+
+    #[test]
+    fn zero_carries_the_uniqueness_prefix() {
+        // The default domain is the absence of a session prefix, so it holds for values
+        // the protocol never mints — including zero.
+        assert!(FieldElement::ZERO.has_prefix(FePrefix::Uniqueness));
     }
 }
 

--- a/crates/proof/src/oprf_query.rs
+++ b/crates/proof/src/oprf_query.rs
@@ -21,7 +21,7 @@ use taceo_oprf::{
 };
 
 use world_id_primitives::{
-    FieldElement, ProofRequest, ProofType, SessionFeType, SessionFieldElement, TREE_DEPTH,
+    FePrefix, FieldElement, PrefixedFieldElement, ProofRequest, ProofType, TREE_DEPTH,
     oprf::{
         CredentialBlindingFactorOprfRequestAuthV1, NullifierOprfRequestAuthV1, OprfModule,
         RpSignatureVerification,
@@ -212,7 +212,7 @@ impl<'a> OprfEntrypoint<'a> {
         let (action, module) = if proof_request.is_session_proof() {
             // For session proofs a random action is used internally. This is opaque to RPs who receive
             // it within the encoded `SessionNullifier`
-            let action = FieldElement::random_for_session(rng, SessionFeType::Action);
+            let action = FieldElement::random_with_prefix(rng, FePrefix::SessionAction);
             (action, OprfModule::Session)
         } else {
             // If the RP didn't provide an action, we provide a default.

--- a/crates/proof/src/oprf_query.rs
+++ b/crates/proof/src/oprf_query.rs
@@ -21,7 +21,7 @@ use taceo_oprf::{
 };
 
 use world_id_primitives::{
-    FePrefix, FieldElement, PrefixedFieldElement, ProofRequest, ProofType, TREE_DEPTH,
+    FieldElement, OprfPrefix, OprfPrefixedFieldElement, ProofRequest, ProofType, TREE_DEPTH,
     oprf::{
         CredentialBlindingFactorOprfRequestAuthV1, NullifierOprfRequestAuthV1, OprfModule,
         RpSignatureVerification,
@@ -212,7 +212,7 @@ impl<'a> OprfEntrypoint<'a> {
         let (action, module) = if proof_request.is_session_proof() {
             // For session proofs a random action is used internally. This is opaque to RPs who receive
             // it within the encoded `SessionNullifier`
-            let action = FieldElement::random_with_prefix(rng, FePrefix::SessionAction);
+            let action = FieldElement::random_with_prefix(rng, OprfPrefix::SessionAction);
             (action, OprfModule::Session)
         } else {
             // If the RP didn't provide an action, we provide a default.

--- a/services/oprf-dev-client/src/bin/world-id-dev-client-rp.rs
+++ b/services/oprf-dev-client/src/bin/world-id-dev-client-rp.rs
@@ -22,7 +22,7 @@ use world_id_core::{
 };
 use world_id_oprf_dev_client::{SharedDevClientComponents, WorldDevClientConfig};
 use world_id_primitives::{
-    AuthenticatorPublicKeySet, FePrefix, PrefixedFieldElement as _, ProofRequest, ProofType,
+    AuthenticatorPublicKeySet, OprfPrefix, OprfPrefixedFieldElement as _, ProofRequest, ProofType,
     RequestItem, RequestVersion, SessionId, SessionRef, TREE_DEPTH,
     merkle::MerkleInclusionProof,
     oprf::{NullifierOprfRequestAuthV1, OprfModule},
@@ -171,7 +171,7 @@ impl DevClient for WorldIdRpDevClient {
         let request_id = Uuid::new_v4();
         let action = proof_request
             .action
-            .unwrap_or_else(|| FieldElement::random_with_prefix(rng, FePrefix::SessionAction));
+            .unwrap_or_else(|| FieldElement::random_with_prefix(rng, OprfPrefix::SessionAction));
         let query_hash = world_id_primitives::authenticator::oprf_query_digest(
             leaf_index,
             action,
@@ -282,7 +282,7 @@ fn create_proof_request<R: Rng + CryptoRng>(
             let session_id = SessionId::from_r_seed(
                 setup.key_index,
                 FieldElement::random(rng),
-                FieldElement::random_with_prefix(rng, FePrefix::SessionOprfSeed),
+                FieldElement::random_with_prefix(rng, OprfPrefix::SessionOprfSeed),
             )
             .context("while building SessionId")?;
             (ProofType::Session, None, SessionRef::Existing(session_id))

--- a/services/oprf-dev-client/src/bin/world-id-dev-client-rp.rs
+++ b/services/oprf-dev-client/src/bin/world-id-dev-client-rp.rs
@@ -22,8 +22,8 @@ use world_id_core::{
 };
 use world_id_oprf_dev_client::{SharedDevClientComponents, WorldDevClientConfig};
 use world_id_primitives::{
-    AuthenticatorPublicKeySet, ProofRequest, ProofType, RequestItem, RequestVersion, SessionFeType,
-    SessionFieldElement as _, SessionId, SessionRef, TREE_DEPTH,
+    AuthenticatorPublicKeySet, FePrefix, PrefixedFieldElement as _, ProofRequest, ProofType,
+    RequestItem, RequestVersion, SessionId, SessionRef, TREE_DEPTH,
     merkle::MerkleInclusionProof,
     oprf::{NullifierOprfRequestAuthV1, OprfModule},
     rp::RpId,
@@ -171,7 +171,7 @@ impl DevClient for WorldIdRpDevClient {
         let request_id = Uuid::new_v4();
         let action = proof_request
             .action
-            .unwrap_or_else(|| FieldElement::random_for_session(rng, SessionFeType::Action));
+            .unwrap_or_else(|| FieldElement::random_with_prefix(rng, FePrefix::SessionAction));
         let query_hash = world_id_primitives::authenticator::oprf_query_digest(
             leaf_index,
             action,
@@ -282,7 +282,7 @@ fn create_proof_request<R: Rng + CryptoRng>(
             let session_id = SessionId::from_r_seed(
                 setup.key_index,
                 FieldElement::random(rng),
-                FieldElement::random_for_session(rng, SessionFeType::OprfSeed),
+                FieldElement::random_with_prefix(rng, FePrefix::SessionOprfSeed),
             )
             .context("while building SessionId")?;
             (ProofType::Session, None, SessionRef::Existing(session_id))

--- a/services/oprf-node/src/auth/rp_module.rs
+++ b/services/oprf-node/src/auth/rp_module.rs
@@ -2,7 +2,8 @@
 //!
 //! Both the session and uniqueness modules share identical struct fields, init
 //! logic, and query-proof verification. They differ only in:
-//! - how the action field is validated (`MSB == 0x00` for uniqueness vs `0x01/0x02` for sessions depending on the [`SessionFeType`])
+//! - which [`FePrefix`] the action field must carry ([`FePrefix::Uniqueness`] for uniqueness vs
+//!   [`FePrefix::SessionOprfSeed`]/[`FePrefix::SessionAction`] for sessions)
 //! - whether the action is included in the RP signature. Some for uniqueness, none for session. For session-seed queries initiated by an RP request for a uniqueness proof,
 //!   the action of the uniqueness proof is part of the data the RP signs over and is included in the `rp_signature_verification` field.
 //! - which [`WorldIdRequestAuthError`] variant is returned for an invalid action
@@ -31,7 +32,7 @@ use taceo_oprf::types::{
 };
 use tracing::instrument;
 use world_id_primitives::{
-    FieldElement, SessionFeType, SessionFieldElement as _,
+    FePrefix, FieldElement, PrefixedFieldElement as _,
     oprf::{NullifierOprfRequestAuthV1, RpSignatureVerification, WorldIdRequestAuthError},
     rp::RpId,
 };
@@ -388,20 +389,18 @@ impl RpModuleAuth {
         let nonce_scope = match self.kind {
             RpModuleKind::Session => {
                 metrics::auth_module::inc_session();
-                if action.is_valid_for_session(SessionFeType::OprfSeed) {
+                if action.has_prefix(FePrefix::SessionOprfSeed) {
                     if let Some(RpSignatureVerification::UniquenessAction {
                         action: signed_action,
                     }) = request.auth.rp_signature_verification
+                        && !signed_action.has_prefix(FePrefix::Uniqueness)
                     {
-                        // TODO: Move this check to a function or trait on FieldElement. Potentially unify with is_valid_for_session.
-                        if signed_action.to_be_bytes()[0] != 0 {
-                            return Err(RpModuleError::InvalidRpSignatureVerification {
-                                context: "uniqueness action MSB must be 0x00",
-                            });
-                        }
+                        return Err(RpModuleError::InvalidRpSignatureVerification {
+                            context: "uniqueness action MSB must be 0x00",
+                        });
                     }
                     NonceScope::SessionOprfSeed
-                } else if action.is_valid_for_session(SessionFeType::Action) {
+                } else if action.has_prefix(FePrefix::SessionAction) {
                     if request.auth.rp_signature_verification.is_some() {
                         return Err(RpModuleError::InvalidRpSignatureVerification {
                             context: "only allowed on session-seed queries",
@@ -419,7 +418,7 @@ impl RpModuleAuth {
                         context: "only allowed on the session module",
                     });
                 }
-                if action.to_be_bytes()[0] != 0 {
+                if !action.has_prefix(FePrefix::Uniqueness) {
                     return Err(RpModuleError::InvalidActionUniqueness { action });
                 }
                 NonceScope::Uniqueness

--- a/services/oprf-node/src/auth/rp_module.rs
+++ b/services/oprf-node/src/auth/rp_module.rs
@@ -2,8 +2,8 @@
 //!
 //! Both the session and uniqueness modules share identical struct fields, init
 //! logic, and query-proof verification. They differ only in:
-//! - which [`FePrefix`] the action field must carry ([`FePrefix::Uniqueness`] for uniqueness vs
-//!   [`FePrefix::SessionOprfSeed`]/[`FePrefix::SessionAction`] for sessions)
+//! - which [`OprfPrefix`] the action field must carry ([`OprfPrefix::Uniqueness`] for uniqueness vs
+//!   [`OprfPrefix::SessionOprfSeed`]/[`OprfPrefix::SessionAction`] for sessions)
 //! - whether the action is included in the RP signature. Some for uniqueness, none for session. For session-seed queries initiated by an RP request for a uniqueness proof,
 //!   the action of the uniqueness proof is part of the data the RP signs over and is included in the `rp_signature_verification` field.
 //! - which [`WorldIdRequestAuthError`] variant is returned for an invalid action
@@ -32,7 +32,7 @@ use taceo_oprf::types::{
 };
 use tracing::instrument;
 use world_id_primitives::{
-    FePrefix, FieldElement, PrefixedFieldElement as _,
+    FieldElement, OprfPrefix, OprfPrefixedFieldElement as _,
     oprf::{NullifierOprfRequestAuthV1, RpSignatureVerification, WorldIdRequestAuthError},
     rp::RpId,
 };
@@ -389,18 +389,18 @@ impl RpModuleAuth {
         let nonce_scope = match self.kind {
             RpModuleKind::Session => {
                 metrics::auth_module::inc_session();
-                if action.has_prefix(FePrefix::SessionOprfSeed) {
+                if action.has_prefix(OprfPrefix::SessionOprfSeed) {
                     if let Some(RpSignatureVerification::UniquenessAction {
                         action: signed_action,
                     }) = request.auth.rp_signature_verification
-                        && !signed_action.has_prefix(FePrefix::Uniqueness)
+                        && !signed_action.has_prefix(OprfPrefix::Uniqueness)
                     {
                         return Err(RpModuleError::InvalidRpSignatureVerification {
                             context: "uniqueness action MSB must be 0x00",
                         });
                     }
                     NonceScope::SessionOprfSeed
-                } else if action.has_prefix(FePrefix::SessionAction) {
+                } else if action.has_prefix(OprfPrefix::SessionAction) {
                     if request.auth.rp_signature_verification.is_some() {
                         return Err(RpModuleError::InvalidRpSignatureVerification {
                             context: "only allowed on session-seed queries",
@@ -418,7 +418,7 @@ impl RpModuleAuth {
                         context: "only allowed on the session module",
                     });
                 }
-                if !action.has_prefix(FePrefix::Uniqueness) {
+                if !action.has_prefix(OprfPrefix::Uniqueness) {
                     return Err(RpModuleError::InvalidActionUniqueness { action });
                 }
                 NonceScope::Uniqueness

--- a/services/oprf-node/src/auth/rp_module/tests.rs
+++ b/services/oprf-node/src/auth/rp_module/tests.rs
@@ -11,7 +11,7 @@ use ark_ff::PrimeField as _;
 use taceo_oprf::types::api::{OprfRequest, OprfRequestAuthenticator as _};
 use uuid::Uuid;
 use world_id_primitives::{
-    FePrefix, FieldElement, PrefixedFieldElement as _,
+    FieldElement, OprfPrefix, OprfPrefixedFieldElement as _,
     oprf::{NullifierOprfRequestAuthV1, RpSignatureVerification, error_codes},
     rp::RpId,
 };
@@ -36,12 +36,12 @@ pub(crate) struct RpModuleTestSetup {
 
 impl RpModuleTestSetup {
     pub(crate) async fn new_session() -> eyre::Result<Self> {
-        Self::new_unbound_session_with_fe_type(FePrefix::SessionOprfSeed).await
+        Self::new_unbound_session_with_fe_type(OprfPrefix::SessionOprfSeed).await
     }
 
     /// Constructs a valid session test setup with the given session type.
     pub(crate) async fn new_unbound_session_with_fe_type(
-        session_type: FePrefix,
+        session_type: OprfPrefix,
     ) -> eyre::Result<Self> {
         let mut rng = rand::thread_rng();
         let infra = AuthModulesTestSetup::new(SetupKind::RpModule).await?;
@@ -96,7 +96,8 @@ impl RpModuleTestSetup {
 
         let request_authenticator = RpModuleAuth::new_session(infra.rp_module_args());
 
-        let session_action = FieldElement::random_with_prefix(&mut rng, FePrefix::SessionOprfSeed);
+        let session_action =
+            FieldElement::random_with_prefix(&mut rng, OprfPrefix::SessionOprfSeed);
         let bundle = infra
             .generate_query_proof(session_action, infra.setup.rp_fixture.world_rp_id.into())?;
 
@@ -653,7 +654,7 @@ async fn test_session_wip101_account_check_timeout() -> eyre::Result<()> {
 #[tokio::test]
 async fn test_session_success_action() -> eyre::Result<()> {
     let setup =
-        RpModuleTestSetup::new_unbound_session_with_fe_type(FePrefix::SessionAction).await?;
+        RpModuleTestSetup::new_unbound_session_with_fe_type(OprfPrefix::SessionAction).await?;
     setup.assert_auth_ok().await
 }
 

--- a/services/oprf-node/src/auth/rp_module/tests.rs
+++ b/services/oprf-node/src/auth/rp_module/tests.rs
@@ -11,7 +11,7 @@ use ark_ff::PrimeField as _;
 use taceo_oprf::types::api::{OprfRequest, OprfRequestAuthenticator as _};
 use uuid::Uuid;
 use world_id_primitives::{
-    FieldElement, SessionFeType, SessionFieldElement as _,
+    FePrefix, FieldElement, PrefixedFieldElement as _,
     oprf::{NullifierOprfRequestAuthV1, RpSignatureVerification, error_codes},
     rp::RpId,
 };
@@ -36,12 +36,12 @@ pub(crate) struct RpModuleTestSetup {
 
 impl RpModuleTestSetup {
     pub(crate) async fn new_session() -> eyre::Result<Self> {
-        Self::new_unbound_session_with_fe_type(SessionFeType::OprfSeed).await
+        Self::new_unbound_session_with_fe_type(FePrefix::SessionOprfSeed).await
     }
 
     /// Constructs a valid session test setup with the given session type.
     pub(crate) async fn new_unbound_session_with_fe_type(
-        session_type: SessionFeType,
+        session_type: FePrefix,
     ) -> eyre::Result<Self> {
         let mut rng = rand::thread_rng();
         let infra = AuthModulesTestSetup::new(SetupKind::RpModule).await?;
@@ -49,7 +49,7 @@ impl RpModuleTestSetup {
         let request_authenticator = RpModuleAuth::new_session(infra.rp_module_args());
 
         // Session action must have the correct prefix byte (0x01 or 0x02)
-        let session_action = FieldElement::random_for_session(&mut rng, session_type);
+        let session_action = FieldElement::random_with_prefix(&mut rng, session_type);
         let bundle = infra
             .generate_query_proof(session_action, infra.setup.rp_fixture.world_rp_id.into())?;
 
@@ -96,7 +96,7 @@ impl RpModuleTestSetup {
 
         let request_authenticator = RpModuleAuth::new_session(infra.rp_module_args());
 
-        let session_action = FieldElement::random_for_session(&mut rng, SessionFeType::OprfSeed);
+        let session_action = FieldElement::random_with_prefix(&mut rng, FePrefix::SessionOprfSeed);
         let bundle = infra
             .generate_query_proof(session_action, infra.setup.rp_fixture.world_rp_id.into())?;
 
@@ -652,7 +652,8 @@ async fn test_session_wip101_account_check_timeout() -> eyre::Result<()> {
 
 #[tokio::test]
 async fn test_session_success_action() -> eyre::Result<()> {
-    let setup = RpModuleTestSetup::new_unbound_session_with_fe_type(SessionFeType::Action).await?;
+    let setup =
+        RpModuleTestSetup::new_unbound_session_with_fe_type(FePrefix::SessionAction).await?;
     setup.assert_auth_ok().await
 }
 


### PR DESCRIPTION
The one-byte prefix in an OPRF input field element's MSB keeps uniqueness nullifiers, session `oprf_seed`s, and session actions from colliding because all three share the same OPRF key and query structure. That namespace was previously spread across `SessionFeType`, which only represented the two session prefixes, and hand-written MSB checks for the `0x00` uniqueness domain.

This consolidates those domains under one OPRF-owned prefix type and one extension trait.

## Changes

- `SessionFeType` → `OprfPrefix`, moved from the session module into the OPRF module and extended with `Uniqueness = 0x00` alongside `SessionOprfSeed = 0x01` and `SessionAction = 0x02`
- `SessionFieldElement` → `OprfPrefixedFieldElement`; `is_valid_for_session` → `has_prefix`, and `random_for_session` → `random_with_prefix`
- hand-written MSB checks in `rp_module` now use `has_prefix`, including uniqueness actions and RP-signed actions on create-and-bind seed queries
- `ProofType` discriminants derive their reserved byte values from the corresponding `OprfPrefix` variants; JSON continues to serialize using snake_case names
- `ProofRequest::validate_proof_type` rejects uniqueness actions carrying a session prefix before sending a request to the OPRF nodes
- tests cover recognition across all three domains and rejection of session-prefixed uniqueness actions
- deliberately untouched: the `uint8(action >> 248)` checks in the V2/V3 verifiers, and `credential_blinding_factor.rs`, which validates the entire action value rather than only its MSB

## Behavior changes

- `validate_proof_type` now rejects a uniqueness request whose `action` carries a session prefix. Previously, such a request parsed successfully and was rejected by the OPRF nodes after a round trip with `invalid_action_for_nullifier`. It now fails at `from_json` time; the request could never have produced a proof.
- `world-id-primitives` renames public exports, so this is an API-breaking change. No known consumer uses them: `worldcoin/idkit` and `worldcoin/developer-portal` were checked, and `world-id-core` does not re-export them.
- Prefix values and existing OPRF-node validation outcomes are unchanged.