### PR TITLE
fix: own the gateway nonce stream and retry batches until they land

### DIFF
--- a/crates/core/tests/authenticator_registration.rs
+++ b/crates/core/tests/authenticator_registration.rs
@@ -14,8 +14,7 @@ fn dummy_zk_source() -> Arc<dyn ZkArtifactSource> {
     Arc::new(DummyZkArtifactSource)
 }
 use world_id_gateway::{
-    TxSubmitterConfig,
-    BatchPolicyConfig, GatewayConfig, RegistryVersion, SignerArgs, defaults,
+    BatchPolicyConfig, GatewayConfig, RegistryVersion, SignerArgs, TxSubmitterConfig, defaults,
     spawn_gateway_for_tests,
 };
 use world_id_primitives::{Config, ServiceEndpoint};

--- a/crates/core/tests/authenticator_registration.rs
+++ b/crates/core/tests/authenticator_registration.rs
@@ -14,6 +14,7 @@ fn dummy_zk_source() -> Arc<dyn ZkArtifactSource> {
     Arc::new(DummyZkArtifactSource)
 }
 use world_id_gateway::{
+    TxSubmitterConfig,
     BatchPolicyConfig, GatewayConfig, RegistryVersion, SignerArgs, defaults,
     spawn_gateway_for_tests,
 };
@@ -37,6 +38,7 @@ async fn test_authenticator_registration() {
     // Spawn gateway pointing to the same anvil instance
     let signer_args = SignerArgs::from_wallet(hex::encode(deployer.to_bytes()));
     let gateway_config = GatewayConfig {
+        tx_submitter: TxSubmitterConfig::default(),
         registry_addr: registry_address,
         registry_version: RegistryVersion::V2,
         provider: world_id_gateway::ProviderArgs {

--- a/crates/core/tests/e2e_authenticator_insert_update_remove.rs
+++ b/crates/core/tests/e2e_authenticator_insert_update_remove.rs
@@ -15,8 +15,7 @@ use world_id_core::{
     artifacts::{ZkArtifactSource, dummy::DummyZkArtifactSource},
 };
 use world_id_gateway::{
-    TxSubmitterConfig,
-    BatchPolicyConfig, GatewayConfig, RegistryVersion, SignerArgs, defaults,
+    BatchPolicyConfig, GatewayConfig, RegistryVersion, SignerArgs, TxSubmitterConfig, defaults,
     spawn_gateway_for_tests,
 };
 use world_id_primitives::{Config, ServiceEndpoint, TREE_DEPTH, merkle::AccountInclusionProof};

--- a/crates/core/tests/e2e_authenticator_insert_update_remove.rs
+++ b/crates/core/tests/e2e_authenticator_insert_update_remove.rs
@@ -15,6 +15,7 @@ use world_id_core::{
     artifacts::{ZkArtifactSource, dummy::DummyZkArtifactSource},
 };
 use world_id_gateway::{
+    TxSubmitterConfig,
     BatchPolicyConfig, GatewayConfig, RegistryVersion, SignerArgs, defaults,
     spawn_gateway_for_tests,
 };
@@ -117,6 +118,7 @@ async fn e2e_authenticator_insert_update_remove() {
 
     let signer_args = SignerArgs::from_wallet(hex::encode(deployer.to_bytes()));
     let gateway_config = GatewayConfig {
+        tx_submitter: TxSubmitterConfig::default(),
         registry_addr: registry_address,
         registry_version: RegistryVersion::V1,
         provider: world_id_gateway::ProviderArgs {

--- a/crates/core/tests/generate_proof.rs
+++ b/crates/core/tests/generate_proof.rs
@@ -27,6 +27,7 @@ fn zk_artifact_source() -> Arc<dyn ZkArtifactSource> {
     Arc::new(world_id_core::artifacts::embedded::EmbeddedZkArtifacts.cached())
 }
 use world_id_gateway::{
+    TxSubmitterConfig,
     BatchPolicyConfig, GatewayConfig, RegistryVersion, SignerArgs, defaults,
     spawn_gateway_for_tests,
 };
@@ -85,6 +86,7 @@ async fn e2e_authenticator_generate_proof() -> Result<()> {
     // Spawn the gateway wired to this Anvil instance.
     let signer_args = SignerArgs::from_wallet(hex::encode(deployer.to_bytes()));
     let gateway_config = GatewayConfig {
+        tx_submitter: TxSubmitterConfig::default(),
         registry_addr: world_id_registry,
         registry_version: RegistryVersion::V2,
         provider: world_id_gateway::ProviderArgs {

--- a/crates/core/tests/generate_proof.rs
+++ b/crates/core/tests/generate_proof.rs
@@ -27,8 +27,7 @@ fn zk_artifact_source() -> Arc<dyn ZkArtifactSource> {
     Arc::new(world_id_core::artifacts::embedded::EmbeddedZkArtifacts.cached())
 }
 use world_id_gateway::{
-    TxSubmitterConfig,
-    BatchPolicyConfig, GatewayConfig, RegistryVersion, SignerArgs, defaults,
+    BatchPolicyConfig, GatewayConfig, RegistryVersion, SignerArgs, TxSubmitterConfig, defaults,
     spawn_gateway_for_tests,
 };
 use world_id_primitives::{

--- a/services/common/src/alloy/mod.rs
+++ b/services/common/src/alloy/mod.rs
@@ -1,3 +1,3 @@
 pub mod provider;
 pub mod provider_layers;
-pub(crate) mod tx_fillers;
+pub mod tx_fillers;

--- a/services/common/src/alloy/provider.rs
+++ b/services/common/src/alloy/provider.rs
@@ -2,6 +2,7 @@ use std::{num::NonZeroUsize, path::Path, time::Duration};
 
 use ::alloy::{
     network::EthereumWallet,
+    primitives::Address,
     providers::{
         DynProvider, Provider, ProviderBuilder,
         fillers::{NonceManager, SimpleNonceManager},
@@ -299,16 +300,33 @@ impl ProviderArgs {
     pub async fn http(self) -> ProviderResult<DynProvider> {
         self.http_with_nonce_manager(SimpleNonceManager::default())
             .await
+            .map(|(provider, _)| provider)
+    }
+
+    /// Build a dynamic provider and also return the configured signer's
+    /// address, if a signer is configured.
+    ///
+    /// [`DynProvider`] erases the concrete filler stack, so the
+    /// `WalletProvider` impl — and with it `default_signer_address()` — is not
+    /// available on the returned provider. Callers that need to read chain
+    /// state for their own signer (transaction count, balance) must obtain the
+    /// address here instead.
+    pub async fn http_with_signer_address(self) -> ProviderResult<(DynProvider, Option<Address>)> {
+        self.http_with_nonce_manager(SimpleNonceManager::default())
+            .await
     }
 
     /// Build a dynamic provider using a caller-supplied [`NonceManager`].
     ///
     /// This allows injecting a distributed nonce manager (e.g. Redis-backed)
     /// for safe multi-replica transaction submission with a shared signer.
+    ///
+    /// Returns the provider alongside the signer address, if a signer is
+    /// configured.
     pub async fn http_with_nonce_manager<M: NonceManager + 'static>(
         self,
         nonce_manager: M,
-    ) -> ProviderResult<DynProvider> {
+    ) -> ProviderResult<(DynProvider, Option<Address>)> {
         let Some(http) = self.http else {
             return Err(ProviderError::NoHttpUrls);
         };
@@ -386,7 +404,8 @@ impl ProviderArgs {
             None
         };
 
-        let provider = if let Some(signer) = maybe_signer {
+        let (provider, signer_address) = if let Some(signer) = maybe_signer {
+            let signer_address = signer.default_signer().address();
             let provider = ProviderBuilder::default()
                 .with_gas_estimation() // It is important to have default run first
                 .filler(GasEstimateWithFallbackFiller) // And then our custom filler
@@ -396,13 +415,13 @@ impl ProviderArgs {
                 .wallet(signer)
                 .connect_client(client);
 
-            provider.erased()
+            (provider.erased(), Some(signer_address))
         } else {
             let provider = ProviderBuilder::default().connect_client(client);
-            provider.erased()
+            (provider.erased(), None)
         };
 
-        Ok(provider)
+        Ok((provider, signer_address))
     }
 }
 

--- a/services/common/src/alloy/tx_fillers.rs
+++ b/services/common/src/alloy/tx_fillers.rs
@@ -12,10 +12,53 @@ use ::alloy::{
 ///
 /// The fallback only needs to cover the cost of a basic revert while still
 /// allowing the transaction to be submitted to avoid nonce gaps.
-pub(crate) const GAS_ESTIMATION_FALLBACK: u64 = 500_000;
+pub const GAS_ESTIMATION_FALLBACK: u64 = 500_000;
 
 const GAS_ESTIMATION_MARGIN_NUMERATOR: u64 = 120;
 const GAS_ESTIMATION_MARGIN_DENOMINATOR: u64 = 100;
+
+const fn apply_margin(estimate: u64) -> u64 {
+    estimate.saturating_mul(GAS_ESTIMATION_MARGIN_NUMERATOR) / GAS_ESTIMATION_MARGIN_DENOMINATOR
+}
+
+/// Estimates the gas limit for `tx` via `eth_estimateGas`, applying a 20%
+/// margin, and falls back to [`GAS_ESTIMATION_FALLBACK`] when the node reports
+/// that the transaction would revert.
+///
+/// Transport / infrastructure errors are returned to the caller so they can be
+/// retried; only execution errors take the fallback.
+///
+/// Callers that set `gas_limit` themselves (for example to keep an explicit
+/// gas limit stable across re-broadcasts of the same nonce) need this directly,
+/// because setting the limit makes [`GasEstimateWithFallbackFiller`] a no-op.
+///
+/// # Errors
+///
+/// Returns the underlying transport error when `eth_estimateGas` fails for a
+/// reason other than execution revert.
+pub async fn estimate_gas_with_fallback<P, N>(provider: &P, tx: N::TransactionRequest) -> TransportResult<u64>
+where
+    P: Provider<N>,
+    N: Network,
+{
+    match provider.estimate_gas(tx).await {
+        Ok(estimate) => Ok(apply_margin(estimate)),
+        // JSON-RPC error: the node ran the transaction and it reverted.
+        // Use the fallback so we can still submit and record the failure.
+        Err(RpcError::ErrorResp(error)) => {
+            tracing::warn!(
+                %error,
+                gas_limit = GAS_ESTIMATION_FALLBACK,
+                "eth_estimateGas returned an execution error, \
+                 transaction will likely revert — using fallback gas limit"
+            );
+            Ok(GAS_ESTIMATION_FALLBACK)
+        }
+        // Transport / infrastructure error: propagate so the caller can
+        // retry or surface the failure.
+        Err(error) => Err(error),
+    }
+}
 
 /// A transaction filler that populates missing gas limits via
 /// `eth_estimateGas`, with a fallback when estimation fails.
@@ -35,12 +78,6 @@ const GAS_ESTIMATION_MARGIN_DENOMINATOR: u64 = 100;
 /// standard alloy `GasFiller`.
 #[derive(Clone, Copy, Debug, Default)]
 pub(crate) struct GasEstimateWithFallbackFiller;
-
-impl GasEstimateWithFallbackFiller {
-    const fn apply_margin(estimate: u64) -> u64 {
-        estimate.saturating_mul(GAS_ESTIMATION_MARGIN_NUMERATOR) / GAS_ESTIMATION_MARGIN_DENOMINATOR
-    }
-}
 
 impl<N> TxFiller<N> for GasEstimateWithFallbackFiller
 where
@@ -67,25 +104,7 @@ where
     where
         P: Provider<N>,
     {
-        let gas_limit = match provider.estimate_gas(tx.clone()).await {
-            Ok(estimate) => Self::apply_margin(estimate),
-            // JSON-RPC error: the node ran the transaction and it reverted.
-            // Use the fallback so we can still submit and record the failure.
-            Err(RpcError::ErrorResp(error)) => {
-                tracing::warn!(
-                    %error,
-                    gas_limit = GAS_ESTIMATION_FALLBACK,
-                    "eth_estimateGas returned an execution error, \
-                     transaction will likely revert — using fallback gas limit"
-                );
-                GAS_ESTIMATION_FALLBACK
-            }
-            // Transport / infrastructure error: propagate so the caller can
-            // retry or surface the failure.
-            Err(error) => return Err(error),
-        };
-
-        Ok(gas_limit)
+        estimate_gas_with_fallback(provider, tx.clone()).await
     }
 
     async fn fill(

--- a/services/common/src/alloy/tx_fillers.rs
+++ b/services/common/src/alloy/tx_fillers.rs
@@ -36,7 +36,10 @@ const fn apply_margin(estimate: u64) -> u64 {
 ///
 /// Returns the underlying transport error when `eth_estimateGas` fails for a
 /// reason other than execution revert.
-pub async fn estimate_gas_with_fallback<P, N>(provider: &P, tx: N::TransactionRequest) -> TransportResult<u64>
+pub async fn estimate_gas_with_fallback<P, N>(
+    provider: &P,
+    tx: N::TransactionRequest,
+) -> TransportResult<u64>
 where
     P: Provider<N>,
     N: Network,

--- a/services/common/src/lib.rs
+++ b/services/common/src/lib.rs
@@ -10,6 +10,7 @@ pub use self::{
             METRICS_RPC_ENDPOINT_LATENCY_MS, METRICS_RPC_ENDPOINT_REQUESTS, RetryConfig,
             describe_provider_transport_metrics,
         },
+        tx_fillers::{GAS_ESTIMATION_FALLBACK, estimate_gas_with_fallback},
     },
     axum::server_layers::{
         Deprecation, DeprecationLayer, DeprecationService, METRICS_DEPRECATED_ENDPOINT_REQUESTS,

--- a/services/gateway/src/batcher/create.rs
+++ b/services/gateway/src/batcher/create.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use alloy::{
     primitives::{Address, U256},
     providers::DynProvider,
+    rpc::types::TransactionRequest,
 };
 use tokio::sync::mpsc;
 use world_id_primitives::api_types::CreateAccountRequest;
@@ -10,7 +11,7 @@ use world_id_registries::world_id::WorldIdRegistry::WorldIdRegistryInstance;
 
 use crate::request_tracker::BacklogScope;
 
-use super::{BatchSubmitStrategy, BatcherEnvelope, GenericBatcherRunner, PendingBatchTx};
+use super::{BatchSubmitStrategy, BatcherEnvelope, GenericBatcherRunner};
 
 #[derive(Clone)]
 pub struct CreateBatcherHandle {
@@ -41,11 +42,11 @@ impl BatchSubmitStrategy<CreateReqEnvelope> for CreateStrategy {
         BacklogScope::Create
     }
 
-    async fn send_batch(
+    fn build_tx(
         &self,
         registry: &WorldIdRegistryInstance<Arc<DynProvider>>,
         batch: Vec<CreateReqEnvelope>,
-    ) -> Result<PendingBatchTx, alloy::contract::Error> {
+    ) -> TransactionRequest {
         let mut recovery_addresses: Vec<Address> = Vec::new();
         let mut auths: Vec<Vec<Address>> = Vec::new();
         let mut pubkeys: Vec<Vec<U256>> = Vec::new();
@@ -58,12 +59,9 @@ impl BatchSubmitStrategy<CreateReqEnvelope> for CreateStrategy {
             commits.push(env.req.offchain_signer_commitment);
         }
 
-        let builder = registry
+        registry
             .createManyAccounts(recovery_addresses, auths, pubkeys, commits)
-            .send()
-            .await?;
-
-        Ok(PendingBatchTx::new(builder))
+            .into_transaction_request()
     }
 }
 

--- a/services/gateway/src/batcher/mod.rs
+++ b/services/gateway/src/batcher/mod.rs
@@ -9,11 +9,8 @@ pub(crate) use ops::{OpsBatcherHandle, OpsBatcherRunner, OpsEnvelope};
 
 use std::{collections::VecDeque, sync::Arc, time::Duration};
 
-use alloy::{network::Ethereum, primitives::Bytes, providers::DynProvider};
-use tokio::{
-    sync::{Mutex, mpsc},
-    time::Instant,
-};
+use alloy::{primitives::Bytes, providers::DynProvider, rpc::types::TransactionRequest};
+use tokio::{sync::mpsc, time::Instant};
 use uuid::Uuid;
 use world_id_primitives::api_types::{CreateAccountRequest, GatewayRequestState};
 use world_id_registries::world_id::WorldIdRegistry::WorldIdRegistryInstance;
@@ -24,9 +21,9 @@ use crate::{
         BacklogUrgencyStats, BaseFeeCache, BatchPolicyEngine, DecisionReason, record_policy_metrics,
     },
     config::BatchPolicyConfig,
-    error::parse_contract_error,
     metrics,
     request_tracker::BacklogScope,
+    tx_submitter::TxSubmitter,
 };
 
 /// Unified batcher handle that routes to the appropriate batcher.
@@ -84,35 +81,22 @@ pub(crate) trait BatcherEnvelope: Send + 'static {
     fn request_id(&self) -> &str;
 }
 
-/// Return value from a successful [`BatchSubmitStrategy::send_batch`] call.
-pub(crate) struct PendingBatchTx {
-    // Hex formatted transaction hash
-    pub formatted_tx_hash: String,
-    // Handle for pending transaction tracking
-    pub builder: alloy::providers::PendingTransactionBuilder<Ethereum>,
-}
-
-impl PendingBatchTx {
-    pub fn new(builder: alloy::providers::PendingTransactionBuilder<Ethereum>) -> Self {
-        Self {
-            formatted_tx_hash: format!("0x{:x}", builder.tx_hash()),
-            builder,
-        }
-    }
-}
-
 /// Strategy trait that captures the only per-batcher differences:
 ///   - batch label / backlog scope (for metrics / policy)
-///   - the actual on-chain send call
+///   - how a batch is turned into a transaction
+///
+/// Strategies build the transaction but never send it: nonce, gas limit and
+/// fees are owned by [`TxSubmitter`], which needs them to stay fixed across
+/// re-broadcasts of the same nonce.
 pub(crate) trait BatchSubmitStrategy<E: BatcherEnvelope>: Send + Default + 'static {
     fn batch_type(&self) -> &'static str;
     fn backlog_scope(&self) -> BacklogScope;
 
-    fn send_batch(
+    fn build_tx(
         &self,
         registry: &WorldIdRegistryInstance<Arc<DynProvider>>,
         batch: Vec<E>,
-    ) -> impl Future<Output = Result<PendingBatchTx, alloy::contract::Error>> + Send;
+    ) -> TransactionRequest;
 }
 
 struct TimedEnvelope<T> {
@@ -137,7 +121,7 @@ where
     tracker: RequestTracker,
     batch_policy: BatchPolicyConfig,
     base_fee_cache: BaseFeeCache,
-    tx_send_lock: Arc<Mutex<()>>,
+    submitter: Arc<TxSubmitter>,
     strategy: S,
 }
 
@@ -155,7 +139,7 @@ where
         tracker: RequestTracker,
         batch_policy: BatchPolicyConfig,
         base_fee_cache: BaseFeeCache,
-        tx_send_lock: Arc<Mutex<()>>,
+        submitter: Arc<TxSubmitter>,
     ) -> Self {
         Self {
             rx,
@@ -165,7 +149,7 @@ where
             tracker,
             batch_policy,
             base_fee_cache,
-            tx_send_lock,
+            submitter,
             strategy: S::default(),
         }
     }
@@ -188,58 +172,10 @@ where
             .set_status_batch(&ids, GatewayRequestState::Batching)
             .await;
 
-        let _send_guard = self.tx_send_lock.lock().await;
-        let start = Instant::now();
-        match self.strategy.send_batch(&self.registry, batch).await {
-            Ok(sent) => {
-                // Record only the RPC send latency here.  The on-chain outcome
-                // (success / failure / confirmation latency) is recorded later
-                // in `spawn_receipt_tracker` once the receipt is obtained.
-                let send_latency_ms = start.elapsed().as_millis() as f64;
-                metrics::record_batch_send_latency(batch_type, send_latency_ms);
-
-                tracing::info!(
-                    tx_hash = %sent.formatted_tx_hash,
-                    batch_type,
-                    batch_size = ids.len(),
-                    send_latency_ms,
-                    "batch transaction submitted to RPC node"
-                );
-
-                self.tracker
-                    .set_status_batch(
-                        &ids,
-                        GatewayRequestState::Submitted {
-                            tx_hash: sent.formatted_tx_hash.clone(),
-                        },
-                    )
-                    .await;
-
-                self.tracker.spawn_receipt_tracker(
-                    ids,
-                    sent.builder,
-                    sent.formatted_tx_hash,
-                    batch_type,
-                    start,
-                );
-            }
-            Err(err) => {
-                let send_latency_ms = start.elapsed().as_millis() as f64;
-                metrics::record_batch_send_failed(batch_type, send_latency_ms);
-
-                let error_str = err.to_string();
-                tracing::error!(
-                    error = %error_str,
-                    batch_type,
-                    send_latency_ms,
-                    "{batch_type} batch failed to submit to RPC node"
-                );
-                let code = parse_contract_error(&error_str);
-                self.tracker
-                    .set_status_batch(&ids, GatewayRequestState::failed(error_str, Some(code)))
-                    .await;
-            }
-        }
+        let request = self.strategy.build_tx(&self.registry, batch);
+        self.submitter
+            .submit(request, ids, batch_type, Instant::now())
+            .await;
     }
 
     fn handle_no_backlog(&self, queue: &mut VecDeque<TimedEnvelope<E>>) {
@@ -336,6 +272,13 @@ where
                         {
                             self.handle_no_backlog(&mut queue);
                         }
+                        next_eval = Instant::now() + reeval_interval;
+                        continue;
+                    }
+
+                    // Capacity is checked before draining, so a batch refused
+                    // for backpressure stays queued instead of being lost.
+                    if !self.submitter.can_submit().await {
                         next_eval = Instant::now() + reeval_interval;
                         continue;
                     }

--- a/services/gateway/src/batcher/ops.rs
+++ b/services/gateway/src/batcher/ops.rs
@@ -1,21 +1,20 @@
 //! Operations batcher for insert/remove/recover/update operations.
 //!
 //! This batcher collects operations and submits them via Multicall3.
-//! Gas estimation is handled automatically by the `GasEstimateWithFallbackFiller`
-//! in the shared provider stack.
 
 use std::sync::Arc;
 
 use alloy::{
     primitives::{Address, Bytes, address},
     providers::DynProvider,
+    rpc::types::TransactionRequest,
 };
 use tokio::sync::mpsc;
 use world_id_registries::world_id::WorldIdRegistry::WorldIdRegistryInstance;
 
 use crate::request_tracker::BacklogScope;
 
-use super::{BatchSubmitStrategy, BatcherEnvelope, GenericBatcherRunner, PendingBatchTx};
+use super::{BatchSubmitStrategy, BatcherEnvelope, GenericBatcherRunner};
 
 const MULTICALL3_ADDR: Address = address!("0xca11bde05977b3631167028862be2a173976ca11");
 
@@ -60,11 +59,11 @@ impl BatchSubmitStrategy<OpsEnvelope> for OpsStrategy {
         BacklogScope::Ops
     }
 
-    async fn send_batch(
+    fn build_tx(
         &self,
         registry: &WorldIdRegistryInstance<Arc<DynProvider>>,
         batch: Vec<OpsEnvelope>,
-    ) -> Result<PendingBatchTx, alloy::contract::Error> {
+    ) -> TransactionRequest {
         let mc = Multicall3::new(MULTICALL3_ADDR, registry.provider().clone());
 
         let calls: Vec<Multicall3::Call3> = batch
@@ -76,12 +75,7 @@ impl BatchSubmitStrategy<OpsEnvelope> for OpsStrategy {
             })
             .collect();
 
-        // No explicit gas limit — the GasEstimateWithFallbackFiller in the
-        // shared provider stack will call eth_estimateGas on the assembled
-        // Multicall3 batch and apply a 20 % margin automatically.
-        let builder = mc.aggregate3(calls).send().await?;
-
-        Ok(PendingBatchTx::new(builder))
+        mc.aggregate3(calls).into_transaction_request()
     }
 }
 

--- a/services/gateway/src/config.rs
+++ b/services/gateway/src/config.rs
@@ -14,6 +14,62 @@ pub mod defaults {
     pub const SWEEPER_INTERVAL_SECS: u64 = 30;
     pub const STALE_QUEUED_THRESHOLD_SECS: u64 = 60;
     pub const STALE_SUBMITTED_THRESHOLD_SECS: u64 = 600;
+
+    /// How long an unconfirmed batch transaction waits before it is
+    /// re-broadcast with a higher priority fee. Well above the ~2s block time,
+    /// so a normally-confirming transaction is never escalated.
+    pub const ESCALATION_INTERVAL_SECS: u64 = 30;
+    /// Priority fee multiplier per escalation, as a percentage. Must exceed the
+    /// node's replacement price bump (`--txpool.pricebump`, 10% on geth) for the
+    /// replacement to be accepted.
+    pub const ESCALATION_FACTOR_PERCENT: u32 = 125;
+    /// Escalations before the batch is abandoned and its nonce released.
+    /// Bounded because each bump raises `max_fee * gas_limit` and would
+    /// eventually hit the balance or the node's fee cap anyway.
+    pub const MAX_ESCALATIONS: u32 = 6;
+    /// Unconfirmed batch transactions allowed at once. Bounds how much piles up
+    /// behind a nonce that is not making progress. The happy path never reaches
+    /// this at a 2s reevaluation cadence against 2s blocks.
+    pub const MAX_INFLIGHT_TXS: usize = 4;
+    /// Signer balance below which submission stops: 0.05 ETH.
+    pub const MIN_BALANCE_WEI: u128 = 50_000_000_000_000_000;
+}
+
+/// Nonce ownership, escalation and backpressure configuration for the
+/// transaction submitter.
+#[derive(Clone, Debug, clap::Args)]
+pub struct TxSubmitterConfig {
+    /// How long an unconfirmed batch transaction waits before re-broadcast.
+    #[arg(long, env = "ESCALATION_INTERVAL_SECS", default_value_t = defaults::ESCALATION_INTERVAL_SECS)]
+    pub escalation_interval_secs: u64,
+
+    /// Priority fee multiplier per escalation, as a percentage of the previous fee.
+    #[arg(long, env = "ESCALATION_FACTOR_PERCENT", default_value_t = defaults::ESCALATION_FACTOR_PERCENT)]
+    pub escalation_factor_percent: u32,
+
+    /// Escalations before a batch is abandoned and its nonce released.
+    #[arg(long, env = "MAX_ESCALATIONS", default_value_t = defaults::MAX_ESCALATIONS)]
+    pub max_escalations: u32,
+
+    /// Unconfirmed batch transactions allowed at once. 0 disables the cap.
+    #[arg(long, env = "MAX_INFLIGHT_TXS", default_value_t = defaults::MAX_INFLIGHT_TXS)]
+    pub max_inflight_txs: usize,
+
+    /// Signer balance in wei below which transaction submission stops.
+    #[arg(long, env = "MIN_BALANCE_WEI", default_value_t = defaults::MIN_BALANCE_WEI)]
+    pub min_balance_wei: u128,
+}
+
+impl Default for TxSubmitterConfig {
+    fn default() -> Self {
+        Self {
+            escalation_interval_secs: defaults::ESCALATION_INTERVAL_SECS,
+            escalation_factor_percent: defaults::ESCALATION_FACTOR_PERCENT,
+            max_escalations: defaults::MAX_ESCALATIONS,
+            max_inflight_txs: defaults::MAX_INFLIGHT_TXS,
+            min_balance_wei: defaults::MIN_BALANCE_WEI,
+        }
+    }
 }
 
 /// WorldIDRegistry implementation version to use for gateway request routing.
@@ -182,6 +238,9 @@ pub struct GatewayConfig {
     /// Staleness threshold for Submitted requests with no receipt (seconds).
     #[arg(long, env = "STALE_SUBMITTED_THRESHOLD_SECS", default_value_t = defaults::STALE_SUBMITTED_THRESHOLD_SECS)]
     pub stale_submitted_threshold_secs: u64,
+
+    #[command(flatten)]
+    pub tx_submitter: TxSubmitterConfig,
 }
 
 impl GatewayConfig {
@@ -253,6 +312,29 @@ impl GatewayConfig {
         if self.sweeper().stale_queued_threshold_secs <= self.batch_policy.max_wait_secs {
             return Err(GatewayError::Config(
                 "STALE_QUEUED_THRESHOLD_SECS must be greater than BATCH_MAX_WAIT_SECS".to_string(),
+            ));
+        }
+
+        if self.tx_submitter.escalation_interval_secs == 0 {
+            return Err(GatewayError::Config(
+                "ESCALATION_INTERVAL_SECS must be greater than 0".to_string(),
+            ));
+        }
+
+        // A replacement transaction must outbid its predecessor by the node's
+        // price bump (10% on geth), otherwise every escalation is rejected with
+        // `replacement transaction underpriced` and the nonce never clears.
+        if self.tx_submitter.escalation_factor_percent <= 110 {
+            return Err(GatewayError::Config(
+                "ESCALATION_FACTOR_PERCENT must be greater than 110 to clear the \
+                 replacement price bump"
+                    .to_string(),
+            ));
+        }
+
+        if self.tx_submitter.max_escalations == 0 {
+            return Err(GatewayError::Config(
+                "MAX_ESCALATIONS must be greater than 0".to_string(),
             ));
         }
 
@@ -439,6 +521,58 @@ mod tests {
         let err = result.unwrap_err().to_string();
         assert!(err.contains("BATCH_COST_HIGH_RATIO"));
         assert!(err.contains("finite"));
+    }
+
+    #[test]
+    fn escalation_factor_must_clear_the_replacement_price_bump() {
+        let mut config = parse_valid_config();
+        config.tx_submitter.escalation_factor_percent = 105;
+
+        let result = config.validate();
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("ESCALATION_FACTOR_PERCENT"));
+    }
+
+    #[test]
+    fn escalation_interval_must_be_non_zero() {
+        let mut config = parse_valid_config();
+        config.tx_submitter.escalation_interval_secs = 0;
+
+        let result = config.validate();
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("ESCALATION_INTERVAL_SECS")
+        );
+    }
+
+    #[test]
+    fn max_escalations_must_be_non_zero() {
+        let mut config = parse_valid_config();
+        config.tx_submitter.max_escalations = 0;
+
+        let result = config.validate();
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("MAX_ESCALATIONS"));
+    }
+
+    #[test]
+    fn tx_submitter_defaults_are_parsed() {
+        let submitter = parse_valid_config().tx_submitter;
+
+        assert_eq!(
+            submitter.escalation_interval_secs,
+            defaults::ESCALATION_INTERVAL_SECS
+        );
+        assert_eq!(submitter.max_escalations, defaults::MAX_ESCALATIONS);
+        assert_eq!(submitter.max_inflight_txs, defaults::MAX_INFLIGHT_TXS);
+        assert!(
+            submitter.escalation_factor_percent > 110,
+            "default factor must clear the replacement price bump"
+        );
     }
 
     #[test]

--- a/services/gateway/src/error.rs
+++ b/services/gateway/src/error.rs
@@ -20,6 +20,8 @@ pub enum GatewayError {
         source: Box<ProviderError>,
         backtrace: String,
     },
+    #[error("failed to read the signer's transaction count to seed the nonce counter: {0}")]
+    NonceSeed(alloy::transports::TransportError),
     #[error("failed to bind listener: {source}")]
     Bind {
         #[source]

--- a/services/gateway/src/error.rs
+++ b/services/gateway/src/error.rs
@@ -20,8 +20,6 @@ pub enum GatewayError {
         source: Box<ProviderError>,
         backtrace: String,
     },
-    #[error("failed to read the signer's transaction count to seed the nonce counter: {0}")]
-    NonceSeed(alloy::transports::TransportError),
     #[error("failed to bind listener: {source}")]
     Bind {
         #[source]

--- a/services/gateway/src/lib.rs
+++ b/services/gateway/src/lib.rs
@@ -3,10 +3,11 @@
 pub use crate::{
     config::{
         BatchPolicyConfig, BatcherConfig, GatewayConfig, OrphanSweeperConfig, RateLimitConfig,
-        RegistryVersion, defaults,
+        RegistryVersion, TxSubmitterConfig, defaults,
     },
     orphan_sweeper::sweep_once,
     request_tracker::{RequestRecord, RequestTracker, now_unix_secs},
+    tx_submitter::TxSubmitter,
 };
 use crate::{routes::build_app, types::AppState};
 use std::{backtrace::Backtrace, net::SocketAddr, sync::Arc};
@@ -22,6 +23,7 @@ pub mod orphan_sweeper;
 mod request;
 pub mod request_tracker;
 mod routes;
+pub mod tx_submitter;
 mod types;
 
 // Re-export common types
@@ -51,8 +53,11 @@ pub async fn spawn_gateway_for_tests(cfg: GatewayConfig) -> GatewayResult<Gatewa
     let batcher_config = cfg.batcher();
     let rate_limit = cfg.rate_limit();
     let sweeper_config = cfg.sweeper();
+    let tx_submitter_config = cfg.tx_submitter.clone();
 
-    let provider = Arc::new(cfg.provider.http().await?);
+    let (provider, signer) = cfg.provider.http_with_signer_address().await?;
+    let signer = signer.ok_or_else(|| GatewayError::Config("no signer configured".to_string()))?;
+    let provider = Arc::new(provider);
     let registry = Arc::new(WorldIdRegistryInstance::new(
         cfg.registry_addr,
         provider.clone(),
@@ -66,6 +71,8 @@ pub async fn spawn_gateway_for_tests(cfg: GatewayConfig) -> GatewayResult<Gatewa
         cfg.request_timeout_secs,
         sweeper_config,
         cfg.batch_policy.clone(),
+        tx_submitter_config,
+        signer,
     )
     .await?;
 
@@ -106,8 +113,11 @@ pub async fn run() -> GatewayResult<()> {
     let batcher_config = cfg.batcher();
     let rate_limit = cfg.rate_limit();
     let sweeper_config = cfg.sweeper();
+    let tx_submitter_config = cfg.tx_submitter.clone();
 
-    let provider = Arc::new(cfg.provider.http().await?);
+    let (provider, signer) = cfg.provider.http_with_signer_address().await?;
+    let signer = signer.ok_or_else(|| GatewayError::Config("no signer configured".to_string()))?;
+    let provider = Arc::new(provider);
     let registry = Arc::new(WorldIdRegistryInstance::new(
         cfg.registry_addr,
         provider.clone(),
@@ -115,6 +125,7 @@ pub async fn run() -> GatewayResult<()> {
 
     tracing::info!(
         registry_version = ?cfg.registry_version,
+        signer = %signer,
         "Config is ready. Building app..."
     );
     let app = build_app(
@@ -126,6 +137,8 @@ pub async fn run() -> GatewayResult<()> {
         cfg.request_timeout_secs,
         sweeper_config,
         cfg.batch_policy.clone(),
+        tx_submitter_config,
+        signer,
     )
     .await?;
     let listener = tokio::net::TcpListener::bind(cfg.listen_addr)

--- a/services/gateway/src/metrics.rs
+++ b/services/gateway/src/metrics.rs
@@ -45,6 +45,9 @@ pub const METRICS_NONCE_ESCALATION: &str = "nonce.escalation";
 pub const METRICS_NONCE_TERMINAL: &str = "nonce.terminal";
 /// Attempts to release a blocked nonce with a self-transfer, by outcome.
 pub const METRICS_NONCE_RELEASE: &str = "nonce.release";
+/// Nonce-counter resyncs against the chain, by outcome. A non-zero rate means
+/// the signer is being used by something other than this replica.
+pub const METRICS_NONCE_RESYNC: &str = "nonce.resync";
 /// Times the in-flight cap refused a batch.
 pub const METRICS_INFLIGHT_CAP_REACHED: &str = "nonce.inflight_cap_reached";
 /// Times submission was refused because the balance was below the floor.
@@ -169,6 +172,11 @@ pub fn describe_metrics() {
         "Attempts to release a blocked nonce, by outcome."
     );
     ::metrics::describe_counter!(
+        METRICS_NONCE_RESYNC,
+        ::metrics::Unit::Count,
+        "Nonce-counter resyncs against the chain, by outcome."
+    );
+    ::metrics::describe_counter!(
         METRICS_INFLIGHT_CAP_REACHED,
         ::metrics::Unit::Count,
         "Times the in-flight transaction cap refused a batch."
@@ -212,6 +220,11 @@ pub fn record_terminal(batch_type: &'static str, reason: &'static str) {
 
 pub fn record_nonce_release(outcome: &'static str) {
     ::metrics::counter!(METRICS_NONCE_RELEASE, "outcome" => outcome).increment(1);
+}
+
+/// Records a resync of the owned nonce counter against the chain.
+pub fn record_nonce_resync(outcome: &'static str) {
+    ::metrics::counter!(METRICS_NONCE_RESYNC, "outcome" => outcome).increment(1);
 }
 
 pub fn record_inflight_cap_reached() {

--- a/services/gateway/src/metrics.rs
+++ b/services/gateway/src/metrics.rs
@@ -29,6 +29,27 @@ pub const METRICS_BATCH_POLICY_TARGET_SIZE: &str = "batch.policy.target_size";
 // Request rejection metrics
 pub const METRICS_REQUEST_REJECTED: &str = "request.rejected";
 
+// Nonce / transaction submission metrics
+/// Highest nonce the gateway has handed out.
+pub const METRICS_NONCE_OWNED: &str = "nonce.owned";
+/// Confirmed transaction count of the signer. Stops advancing during a stall.
+pub const METRICS_NONCE_LATEST: &str = "nonce.latest";
+/// Batch transactions submitted but not yet confirmed.
+pub const METRICS_NONCE_INFLIGHT: &str = "nonce.inflight";
+/// Signer balance, so escalation cannot silently drain it.
+pub const METRICS_SIGNER_BALANCE_WEI: &str = "signer.balance_wei";
+/// Re-broadcasts of an unconfirmed batch transaction at the same nonce.
+pub const METRICS_NONCE_ESCALATION: &str = "nonce.escalation";
+/// Batches abandoned without landing, by reason. Any increase means requests
+/// were dropped.
+pub const METRICS_NONCE_TERMINAL: &str = "nonce.terminal";
+/// Attempts to release a blocked nonce with a self-transfer, by outcome.
+pub const METRICS_NONCE_RELEASE: &str = "nonce.release";
+/// Times the in-flight cap refused a batch.
+pub const METRICS_INFLIGHT_CAP_REACHED: &str = "nonce.inflight_cap_reached";
+/// Times submission was refused because the balance was below the floor.
+pub const METRICS_BALANCE_FLOOR: &str = "nonce.balance_floor";
+
 pub fn describe_metrics() {
     world_id_services_common::describe_http_request_metrics();
     world_id_services_common::describe_deprecated_endpoint_metrics();
@@ -112,7 +133,93 @@ pub fn describe_metrics() {
         "Number of rejected requests by reason."
     );
 
+    ::metrics::describe_gauge!(
+        METRICS_NONCE_OWNED,
+        ::metrics::Unit::Count,
+        "Highest nonce handed out by the gateway."
+    );
+    ::metrics::describe_gauge!(
+        METRICS_NONCE_LATEST,
+        ::metrics::Unit::Count,
+        "Confirmed transaction count of the signer."
+    );
+    ::metrics::describe_gauge!(
+        METRICS_NONCE_INFLIGHT,
+        ::metrics::Unit::Count,
+        "Batch transactions submitted but not yet confirmed."
+    );
+    ::metrics::describe_gauge!(
+        METRICS_SIGNER_BALANCE_WEI,
+        ::metrics::Unit::Count,
+        "Signer balance in wei."
+    );
+    ::metrics::describe_counter!(
+        METRICS_NONCE_ESCALATION,
+        ::metrics::Unit::Count,
+        "Re-broadcasts of an unconfirmed batch transaction at the same nonce."
+    );
+    ::metrics::describe_counter!(
+        METRICS_NONCE_TERMINAL,
+        ::metrics::Unit::Count,
+        "Batches abandoned without landing, by reason."
+    );
+    ::metrics::describe_counter!(
+        METRICS_NONCE_RELEASE,
+        ::metrics::Unit::Count,
+        "Attempts to release a blocked nonce, by outcome."
+    );
+    ::metrics::describe_counter!(
+        METRICS_INFLIGHT_CAP_REACHED,
+        ::metrics::Unit::Count,
+        "Times the in-flight transaction cap refused a batch."
+    );
+    ::metrics::describe_counter!(
+        METRICS_BALANCE_FLOOR,
+        ::metrics::Unit::Count,
+        "Times submission was refused because the signer balance was below the floor."
+    );
+
     world_id_services_common::describe_provider_transport_metrics();
+}
+
+pub fn set_nonce_owned(nonce: u64) {
+    ::metrics::gauge!(METRICS_NONCE_OWNED).set(nonce as f64);
+}
+
+pub fn set_nonce_latest(nonce: u64) {
+    ::metrics::gauge!(METRICS_NONCE_LATEST).set(nonce as f64);
+}
+
+pub fn set_nonce_inflight(count: usize) {
+    ::metrics::gauge!(METRICS_NONCE_INFLIGHT).set(count as f64);
+}
+
+pub fn set_signer_balance_wei(balance: f64) {
+    ::metrics::gauge!(METRICS_SIGNER_BALANCE_WEI).set(balance);
+}
+
+pub fn record_escalation(batch_type: &'static str, outcome: &'static str) {
+    ::metrics::counter!(METRICS_NONCE_ESCALATION, "type" => batch_type, "outcome" => outcome)
+        .increment(1);
+}
+
+/// Records that a batch was abandoned without landing. Requests were dropped,
+/// so this should be alerted on.
+pub fn record_terminal(batch_type: &'static str, reason: &'static str) {
+    ::metrics::counter!(METRICS_NONCE_TERMINAL, "type" => batch_type, "reason" => reason)
+        .increment(1);
+}
+
+pub fn record_nonce_release(outcome: &'static str) {
+    ::metrics::counter!(METRICS_NONCE_RELEASE, "outcome" => outcome).increment(1);
+}
+
+pub fn record_inflight_cap_reached() {
+    ::metrics::counter!(METRICS_INFLIGHT_CAP_REACHED).increment(1);
+}
+
+pub fn record_balance_floor_hit() {
+    ::metrics::counter!(METRICS_BALANCE_FLOOR).increment(1);
 }
 
 pub fn increment_root_cache_hit() {

--- a/services/gateway/src/routes.rs
+++ b/services/gateway/src/routes.rs
@@ -10,7 +10,7 @@ use crate::{
         BatchPolicyConfig, BatcherConfig, OrphanSweeperConfig, RateLimitConfig, RegistryVersion,
         TxSubmitterConfig,
     },
-    error::{GatewayError, GatewayErrorBody, GatewayErrorResponse, GatewayResult},
+    error::{GatewayErrorBody, GatewayErrorResponse, GatewayResult},
     orphan_sweeper::run_orphan_sweeper,
     request::GatewayContext,
     request_tracker::RequestTracker,
@@ -106,16 +106,12 @@ pub(crate) async fn build_app(
     .await;
     let base_fee_cache = BaseFeeCache::default();
 
-    let submitter = Arc::new(
-        TxSubmitter::new(
-            registry.provider().clone(),
-            signer,
-            tx_submitter_config,
-            tracker.clone(),
-        )
-        .await
-        .map_err(GatewayError::NonceSeed)?,
-    );
+    let submitter = Arc::new(TxSubmitter::new(
+        registry.provider().clone(),
+        signer,
+        tx_submitter_config,
+        tracker.clone(),
+    ));
     tokio::spawn(run_escalation_loop(Arc::clone(&submitter)));
     tracing::info!(signer = %signer, "Tx submitter and escalation loop initialized");
 

--- a/services/gateway/src/routes.rs
+++ b/services/gateway/src/routes.rs
@@ -8,8 +8,9 @@ use crate::{
     },
     config::{
         BatchPolicyConfig, BatcherConfig, OrphanSweeperConfig, RateLimitConfig, RegistryVersion,
+        TxSubmitterConfig,
     },
-    error::{GatewayErrorBody, GatewayErrorResponse, GatewayResult},
+    error::{GatewayError, GatewayErrorBody, GatewayErrorResponse, GatewayResult},
     orphan_sweeper::run_orphan_sweeper,
     request::GatewayContext,
     request_tracker::RequestTracker,
@@ -28,9 +29,10 @@ use crate::{
         update_authenticator::update_authenticator,
         update_recovery_agent::update_recovery_agent,
     },
+    tx_submitter::{TxSubmitter, run_escalation_loop},
     types::RootExpiry,
 };
-use alloy::providers::DynProvider;
+use alloy::{primitives::Address, providers::DynProvider};
 use axum::{
     Json, Router,
     extract::{Path, State},
@@ -39,7 +41,7 @@ use axum::{
     routing::{get, post},
 };
 use moka::future::Cache;
-use tokio::sync::{Mutex, mpsc};
+use tokio::sync::mpsc;
 use utoipa::OpenApi;
 use world_id_primitives::api_types::{
     CancelRecoveryAgentUpdateRequest, CreateAccountRequest, ExecuteRecoveryAgentUpdateRequest,
@@ -92,6 +94,8 @@ pub(crate) async fn build_app(
     request_timeout_secs: u64,
     orphan_sweeper_config: OrphanSweeperConfig,
     batch_policy_config: BatchPolicyConfig,
+    tx_submitter_config: TxSubmitterConfig,
+    signer: Address,
 ) -> GatewayResult<Router> {
     let tracker = RequestTracker::new(
         redis_url,
@@ -101,7 +105,19 @@ pub(crate) async fn build_app(
     )
     .await;
     let base_fee_cache = BaseFeeCache::default();
-    let tx_send_lock = Arc::new(Mutex::new(()));
+
+    let submitter = Arc::new(
+        TxSubmitter::new(
+            registry.provider().clone(),
+            signer,
+            tx_submitter_config,
+            tracker.clone(),
+        )
+        .await
+        .map_err(GatewayError::NonceSeed)?,
+    );
+    tokio::spawn(run_escalation_loop(Arc::clone(&submitter)));
+    tracing::info!(signer = %signer, "Tx submitter and escalation loop initialized");
 
     spawn_base_fee_sampler(
         registry.provider().clone(),
@@ -119,7 +135,7 @@ pub(crate) async fn build_app(
         tracker.clone(),
         batch_policy_config.clone(),
         base_fee_cache.clone(),
-        tx_send_lock.clone(),
+        Arc::clone(&submitter),
     );
     tokio::spawn(runner.run());
 
@@ -134,7 +150,7 @@ pub(crate) async fn build_app(
         tracker.clone(),
         batch_policy_config,
         base_fee_cache,
-        tx_send_lock,
+        submitter,
     );
     tokio::spawn(ops_runner.run());
 

--- a/services/gateway/src/tx_submitter.rs
+++ b/services/gateway/src/tx_submitter.rs
@@ -111,6 +111,8 @@ struct InflightTx {
     batch_type: &'static str,
     /// Priority fee of the most recent broadcast.
     priority_fee: u128,
+    /// Hash of the most recent broadcast, for logs and for inspection.
+    last_tx_hash: String,
     /// Number of escalations performed so far.
     escalations: u32,
     /// When the most recent broadcast happened.
@@ -163,6 +165,17 @@ impl TxSubmitter {
             next_nonce: AtomicU64::new(seed),
             inflight: Arc::new(Mutex::new(BTreeMap::new())),
         })
+    }
+
+    /// Snapshot of unconfirmed transactions as `(nonce, last broadcast hash)`,
+    /// ordered by nonce so the blocking one is first.
+    pub async fn inflight(&self) -> Vec<(u64, String)> {
+        self.inflight
+            .lock()
+            .await
+            .iter()
+            .map(|(nonce, tx)| (*nonce, tx.last_tx_hash.clone()))
+            .collect()
     }
 
     /// Whether another batch may be submitted right now.
@@ -279,11 +292,12 @@ impl TxSubmitter {
         let send_started = Instant::now();
         let result = self.provider.send_transaction(request.clone()).await;
 
-        let entry = InflightTx {
+        let mut entry = InflightTx {
             request,
             ids: ids.clone(),
             batch_type,
             priority_fee: fees.max_priority_fee_per_gas,
+            last_tx_hash: String::new(),
             escalations: 0,
             last_sent_at: Instant::now(),
             submitted_at,
@@ -313,6 +327,7 @@ impl TxSubmitter {
                     )
                     .await;
 
+                entry.last_tx_hash = tx_hash.clone();
                 self.inflight.lock().await.insert(nonce, entry);
                 spawn_receipt_watch(
                     Arc::clone(&self.inflight),
@@ -404,21 +419,38 @@ impl TxSubmitter {
         metrics::set_nonce_latest(latest);
 
         let due: Vec<u64> = {
-            let inflight = self.inflight.lock().await;
+            let mut inflight = self.inflight.lock().await;
+
+            // Nonces below `latest` are consumed on-chain. Normally the receipt
+            // watcher removes them; if it was lost (transport failure, restarted
+            // subscription) the entry would otherwise occupy in-flight capacity
+            // for the process lifetime and eventually wedge the cap. Request
+            // finalization for these is the orphan sweeper's job — it reads the
+            // receipt by hash — so dropping the entry here is safe.
+            let stale: Vec<u64> = inflight.range(..latest).map(|(nonce, _)| *nonce).collect();
+            for nonce in stale {
+                if let Some(tx) = inflight.remove(&nonce) {
+                    tracing::warn!(
+                        nonce,
+                        latest,
+                        batch_type = tx.batch_type,
+                        tx_hash = %tx.last_tx_hash,
+                        "escalation: pruning in-flight entry whose nonce is already consumed"
+                    );
+                }
+            }
+
             metrics::set_nonce_inflight(inflight.len());
             inflight
                 .iter()
-                .filter(|(nonce, tx)| {
-                    **nonce >= latest
-                        && tx.last_sent_at.elapsed()
-                            >= Duration::from_secs(self.config.escalation_interval_secs)
+                .filter(|(_, tx)| {
+                    tx.last_sent_at.elapsed()
+                        >= Duration::from_secs(self.config.escalation_interval_secs)
                 })
                 .map(|(nonce, _)| *nonce)
                 .collect()
         };
 
-        // Entries below `latest` were mined; the receipt watcher finalizes them
-        // and removes them. Nothing to do here.
         for nonce in due {
             self.escalate_one(nonce).await;
         }
@@ -509,6 +541,7 @@ impl TxSubmitter {
                 if let Some(tx) = self.inflight.lock().await.get_mut(&nonce) {
                     tx.request = request;
                     tx.priority_fee = priority_fee;
+                    tx.last_tx_hash = tx_hash.clone();
                     tx.escalations += 1;
                     tx.last_sent_at = Instant::now();
                 }
@@ -576,6 +609,7 @@ impl TxSubmitter {
         tracing::error!(
             nonce,
             batch_type = tx.batch_type,
+            tx_hash = %tx.last_tx_hash,
             reason = reason.as_str(),
             escalations = tx.escalations,
             request_count = tx.ids.len(),

--- a/services/gateway/src/tx_submitter.rs
+++ b/services/gateway/src/tx_submitter.rs
@@ -285,12 +285,29 @@ impl TxSubmitter {
         request.set_max_fee_per_gas(fees.max_fee_per_gas);
         request.set_max_priority_fee_per_gas(fees.max_priority_fee_per_gas);
 
-        let nonce = self.next_nonce.fetch_add(1, Ordering::SeqCst);
+        let mut nonce = self.next_nonce.fetch_add(1, Ordering::SeqCst);
         request.set_nonce(nonce);
         metrics::set_nonce_owned(nonce);
 
         let send_started = Instant::now();
-        let result = self.provider.send_transaction(request.clone()).await;
+        let mut result = self.provider.send_transaction(request.clone()).await;
+
+        // The counter assumes this replica is the only sender for its signer.
+        // If something else used the address — a local setup sharing the key, an
+        // operator transaction — the counter is stale and every send from here
+        // on would fail. Reconcile against the chain and retry once rather than
+        // wedging.
+        let stale_counter = matches!(&result, Err(err) if is_nonce_too_low(&err.to_string()));
+        if let Some(resynced) = if stale_counter {
+            self.resync_nonce(nonce).await
+        } else {
+            None
+        } {
+            nonce = resynced;
+            request.set_nonce(nonce);
+            metrics::set_nonce_owned(nonce);
+            result = self.provider.send_transaction(request.clone()).await;
+        }
 
         let mut entry = InflightTx {
             request,
@@ -389,6 +406,52 @@ impl TxSubmitter {
                 .await;
             }
         }
+    }
+
+    /// Re-reads the pending transaction count and rewinds the counter to it.
+    ///
+    /// Called when the node reports `nonce too low`, which means the counter has
+    /// drifted ahead of reality — the address was used by something other than
+    /// this replica. Returns the nonce to retry with, or `None` if the count
+    /// could not be read or does not actually resolve the conflict.
+    async fn resync_nonce(&self, stale: u64) -> Option<u64> {
+        let fresh = match self
+            .provider
+            .get_transaction_count(self.signer)
+            .pending()
+            .await
+        {
+            Ok(fresh) => fresh,
+            Err(err) => {
+                tracing::error!(error = %err, "nonce resync failed to read transaction count");
+                metrics::record_nonce_resync("rpc_error");
+                return None;
+            }
+        };
+
+        if fresh <= stale {
+            // Not a stale counter after all — retrying would hit the same error.
+            tracing::error!(
+                stale,
+                fresh,
+                "node reported nonce too low but the pending count is not ahead"
+            );
+            metrics::record_nonce_resync("no_progress");
+            return None;
+        }
+
+        tracing::warn!(
+            stale,
+            fresh,
+            signer = %self.signer,
+            "nonce counter drifted behind the chain, resyncing; the signer is being \
+             used by something other than this replica"
+        );
+        metrics::record_nonce_resync("resynced");
+
+        // Hand out the nonce after this one to the next caller.
+        self.next_nonce.store(fresh + 1, Ordering::SeqCst);
+        Some(fresh)
     }
 
     /// Marks a batch's requests as failed.

--- a/services/gateway/src/tx_submitter.rs
+++ b/services/gateway/src/tx_submitter.rs
@@ -1,0 +1,812 @@
+//! Transaction submission with gateway-owned nonces.
+//!
+//! The gateway is the sole submitter for its signer: production provisions one
+//! KMS key per replica ordinal, so each replica owns an independent nonce
+//! stream and can allocate nonces in-process.
+//!
+//! Owning the nonce is what makes "retry until it lands" safe. A retained batch
+//! is re-broadcast at the *same* nonce with an escalating priority fee until it
+//! is mined; re-deriving the nonce from `eth_getTransactionCount(pending)` on a
+//! retry could pick a different nonce and execute the same batch twice.
+//!
+//! Because a reserved nonce blocks every later nonce until it is consumed,
+//! every reservation must end in exactly one of two states:
+//!
+//! - **mined** — a receipt arrived (success or revert; both consume the nonce)
+//! - **released** — the batch is abandoned and a minimal self-transfer is sent
+//!   at that nonce so the transactions queued behind it become executable
+//!
+//! Escalation can create its own permanent rejection: each bump raises
+//! `max_fee_per_gas * gas_limit`, which eventually exceeds the signer balance or
+//! the node's transaction fee cap. Those errors are classified as terminal, so
+//! the nonce is released instead of being retried forever.
+
+use std::{
+    collections::BTreeMap,
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
+    time::Duration,
+};
+
+use alloy::{
+    network::{Ethereum, TransactionBuilder},
+    primitives::{Address, U256},
+    providers::{DynProvider, PendingTransactionBuilder, Provider},
+    rpc::types::TransactionRequest,
+};
+use tokio::{sync::Mutex, time::Instant};
+use world_id_primitives::api_types::{GatewayErrorCode, GatewayRequestState};
+use world_id_services_common::estimate_gas_with_fallback;
+
+use crate::{RequestTracker, config::TxSubmitterConfig, error::parse_contract_error, metrics};
+
+/// Gas limit of the transaction used to release a nonce. A plain value transfer
+/// to self costs nothing beyond the 21k intrinsic gas.
+const RELEASE_TX_GAS_LIMIT: u64 = 21_000;
+
+/// Shared in-flight registry, keyed by nonce so the blocking nonce is first.
+type Inflight = Arc<Mutex<BTreeMap<u64, InflightTx>>>;
+
+/// Why a reserved nonce was given up on.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum TerminalReason {
+    /// The node rejected the transaction for a reason that will not change.
+    PermanentRejection,
+    /// The escalation budget was exhausted without the transaction landing.
+    EscalationExhausted,
+    /// The signer balance is below the configured floor.
+    BalanceFloor,
+}
+
+impl TerminalReason {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::PermanentRejection => "permanent_rejection",
+            Self::EscalationExhausted => "escalation_exhausted",
+            Self::BalanceFloor => "balance_floor",
+        }
+    }
+}
+
+/// Whether a send error means the transaction can never be included.
+///
+/// Only causes that cannot change with time or with a higher fee belong here.
+/// Everything else — `already known`, `replacement transaction underpriced`,
+/// transport failures, timeouts — is transient and left to the escalation loop.
+fn is_permanent_rejection(error: &str) -> bool {
+    const PERMANENT: [&str; 6] = [
+        "insufficient funds",
+        "exceeds block gas limit",
+        "oversized data",
+        "exceeds the configured cap",
+        "intrinsic gas too low",
+        "negative value",
+    ];
+    let lowered = error.to_ascii_lowercase();
+    PERMANENT.iter().any(|needle| lowered.contains(needle))
+}
+
+/// Whether the node already holds this exact transaction.
+///
+/// Not a failure: the transaction is in the pool, so the nonce is occupied and
+/// must not be released.
+fn is_already_known(error: &str) -> bool {
+    let lowered = error.to_ascii_lowercase();
+    lowered.contains("already known") || lowered.contains("already imported")
+}
+
+/// Whether the nonce has already been consumed by some other transaction.
+fn is_nonce_too_low(error: &str) -> bool {
+    error.to_ascii_lowercase().contains("nonce too low")
+}
+
+/// A batch transaction that has been broadcast but not yet mined.
+struct InflightTx {
+    /// Fully populated request; escalation rewrites only the fee fields.
+    request: TransactionRequest,
+    /// Gateway request ids carried by this batch.
+    ids: Vec<String>,
+    batch_type: &'static str,
+    /// Priority fee of the most recent broadcast.
+    priority_fee: u128,
+    /// Number of escalations performed so far.
+    escalations: u32,
+    /// When the most recent broadcast happened.
+    last_sent_at: Instant,
+    /// When the batch was first submitted, for end-to-end latency.
+    submitted_at: Instant,
+}
+
+/// Owns the signer's nonce stream and every unconfirmed batch transaction.
+pub struct TxSubmitter {
+    provider: Arc<DynProvider>,
+    signer: Address,
+    config: TxSubmitterConfig,
+    tracker: RequestTracker,
+    /// Next nonce to hand out. Seeded from the pending count, then owned here.
+    next_nonce: AtomicU64,
+    inflight: Inflight,
+}
+
+impl TxSubmitter {
+    /// Creates a submitter and seeds the nonce counter.
+    ///
+    /// Seeded from the *pending* count rather than `latest`, so a replica that
+    /// restarts while its own earlier transactions are still in the mempool
+    /// does not hand out a nonce that collides with them.
+    ///
+    /// # Errors
+    ///
+    /// Returns the transport error if the initial transaction count cannot be
+    /// read — the gateway cannot submit anything without it.
+    pub async fn new(
+        provider: Arc<DynProvider>,
+        signer: Address,
+        config: TxSubmitterConfig,
+        tracker: RequestTracker,
+    ) -> Result<Self, alloy::transports::TransportError> {
+        let seed = provider.get_transaction_count(signer).pending().await?;
+
+        tracing::info!(
+            signer = %signer,
+            seed_nonce = seed,
+            "tx submitter seeded nonce counter from pending transaction count"
+        );
+
+        Ok(Self {
+            provider,
+            signer,
+            config,
+            tracker,
+            next_nonce: AtomicU64::new(seed),
+            inflight: Arc::new(Mutex::new(BTreeMap::new())),
+        })
+    }
+
+    /// Whether another batch may be submitted right now.
+    ///
+    /// Checked before a batch is drained from the policy queue, so a refused
+    /// batch is never lost. Two conditions gate submission: the in-flight cap,
+    /// which bounds how much piles up behind a nonce that is not progressing,
+    /// and the balance floor, so escalation cannot drain the signer.
+    pub async fn can_submit(&self) -> bool {
+        let inflight = self.inflight.lock().await.len();
+        metrics::set_nonce_inflight(inflight);
+
+        // A cap of 0 disables the check.
+        if self.config.max_inflight_txs > 0 && inflight >= self.config.max_inflight_txs {
+            tracing::warn!(
+                inflight,
+                max_inflight_txs = self.config.max_inflight_txs,
+                "in-flight transaction cap reached, applying backpressure"
+            );
+            metrics::record_inflight_cap_reached();
+            return false;
+        }
+
+        self.has_sufficient_balance().await
+    }
+
+    /// Reads the signer balance and compares it against the configured floor.
+    ///
+    /// An RPC failure counts as sufficient: refusing to submit because a
+    /// balance read failed would turn a telemetry problem into an outage. The
+    /// gauge goes stale instead, and the RPC error metrics fire.
+    async fn has_sufficient_balance(&self) -> bool {
+        match self.provider.get_balance(self.signer).await {
+            Ok(balance) => {
+                metrics::set_signer_balance_wei(f64::from(balance));
+                if balance < U256::from(self.config.min_balance_wei) {
+                    tracing::error!(
+                        signer = %self.signer,
+                        balance = %balance,
+                        min_balance_wei = self.config.min_balance_wei,
+                        "signer balance below floor, refusing to submit transactions"
+                    );
+                    metrics::record_balance_floor_hit();
+                    return false;
+                }
+                true
+            }
+            Err(err) => {
+                tracing::warn!(error = %err, "failed to read signer balance");
+                true
+            }
+        }
+    }
+
+    /// Submits a batch transaction at a gateway-owned nonce.
+    ///
+    /// Sets `nonce`, `gas_limit` and both fee fields explicitly. That is
+    /// required rather than cosmetic: alloy's `GasFiller` overwrites both fee
+    /// fields unless `gas_limit` is also set, which would make the fee used on a
+    /// re-broadcast unpredictable and could fail to clear the replacement price
+    /// bump.
+    ///
+    /// Both estimation calls happen *before* a nonce is reserved, so an
+    /// estimation failure can never consume one — the failure mode behind
+    /// PROTO-4494.
+    pub async fn submit(
+        &self,
+        mut request: TransactionRequest,
+        ids: Vec<String>,
+        batch_type: &'static str,
+        submitted_at: Instant,
+    ) {
+        request.set_from(self.signer);
+
+        let gas_limit =
+            match estimate_gas_with_fallback(self.provider.as_ref(), request.clone()).await {
+                Ok(gas_limit) => gas_limit,
+                Err(err) => {
+                    tracing::error!(
+                        error = %err,
+                        batch_type,
+                        "gas estimation failed with a transport error, dropping batch"
+                    );
+                    metrics::record_batch_send_failed(batch_type, 0.0);
+                    self.fail_requests(&ids, &format!("gas estimation failed: {err}"))
+                        .await;
+                    return;
+                }
+            };
+
+        let fees = match self.provider.estimate_eip1559_fees().await {
+            Ok(fees) => fees,
+            Err(err) => {
+                tracing::error!(
+                    error = %err,
+                    batch_type,
+                    "fee estimation failed, dropping batch"
+                );
+                metrics::record_batch_send_failed(batch_type, 0.0);
+                self.fail_requests(&ids, &format!("fee estimation failed: {err}"))
+                    .await;
+                return;
+            }
+        };
+
+        request.set_gas_limit(gas_limit);
+        request.set_max_fee_per_gas(fees.max_fee_per_gas);
+        request.set_max_priority_fee_per_gas(fees.max_priority_fee_per_gas);
+
+        let nonce = self.next_nonce.fetch_add(1, Ordering::SeqCst);
+        request.set_nonce(nonce);
+        metrics::set_nonce_owned(nonce);
+
+        let send_started = Instant::now();
+        let result = self.provider.send_transaction(request.clone()).await;
+
+        let entry = InflightTx {
+            request,
+            ids: ids.clone(),
+            batch_type,
+            priority_fee: fees.max_priority_fee_per_gas,
+            escalations: 0,
+            last_sent_at: Instant::now(),
+            submitted_at,
+        };
+
+        match result {
+            Ok(pending) => {
+                let send_latency_ms = send_started.elapsed().as_millis() as f64;
+                metrics::record_batch_send_latency(batch_type, send_latency_ms);
+
+                let tx_hash = format!("0x{:x}", pending.tx_hash());
+                tracing::info!(
+                    tx_hash = %tx_hash,
+                    batch_type,
+                    nonce,
+                    batch_size = ids.len(),
+                    send_latency_ms,
+                    "batch transaction submitted to RPC node"
+                );
+
+                self.tracker
+                    .set_status_batch(
+                        &ids,
+                        GatewayRequestState::Submitted {
+                            tx_hash: tx_hash.clone(),
+                        },
+                    )
+                    .await;
+
+                self.inflight.lock().await.insert(nonce, entry);
+                spawn_receipt_watch(
+                    Arc::clone(&self.inflight),
+                    self.tracker.clone(),
+                    nonce,
+                    pending,
+                    tx_hash,
+                    batch_type,
+                    submitted_at,
+                );
+            }
+            Err(err) => {
+                let send_latency_ms = send_started.elapsed().as_millis() as f64;
+                metrics::record_batch_send_failed(batch_type, send_latency_ms);
+                let error_str = err.to_string();
+
+                if is_already_known(&error_str) {
+                    // The node holds this exact transaction. The nonce is
+                    // occupied, so keep it in flight and let the escalation
+                    // loop drive it to a receipt.
+                    tracing::warn!(
+                        batch_type,
+                        nonce,
+                        "node reports transaction already known, retaining nonce"
+                    );
+                    self.inflight.lock().await.insert(nonce, entry);
+                    return;
+                }
+
+                tracing::error!(
+                    error = %error_str,
+                    batch_type,
+                    nonce,
+                    send_latency_ms,
+                    "{batch_type} batch failed to submit to RPC node"
+                );
+
+                let code = parse_contract_error(&error_str);
+                self.tracker
+                    .set_status_batch(
+                        &ids,
+                        GatewayRequestState::failed(error_str.clone(), Some(code)),
+                    )
+                    .await;
+
+                if is_nonce_too_low(&error_str) {
+                    // Something else consumed this nonce; nothing to release.
+                    return;
+                }
+
+                // The node never accepted the transaction, so this nonce is
+                // unoccupied — but later nonces have already been handed out,
+                // so it still has to be filled.
+                self.release_nonce(
+                    nonce,
+                    fees.max_priority_fee_per_gas,
+                    TerminalReason::PermanentRejection,
+                )
+                .await;
+            }
+        }
+    }
+
+    /// Marks a batch's requests as failed.
+    async fn fail_requests(&self, ids: &[String], reason: &str) {
+        self.tracker
+            .set_status_batch(
+                ids,
+                GatewayRequestState::failed(
+                    reason.to_owned(),
+                    Some(GatewayErrorCode::InternalServerError),
+                ),
+            )
+            .await;
+    }
+
+    /// One escalation pass over the in-flight set.
+    ///
+    /// Public so tests can drive it directly without managing task lifetime,
+    /// mirroring [`crate::orphan_sweeper::sweep_once`].
+    pub async fn escalate_once(&self) {
+        let latest = match self.provider.get_transaction_count(self.signer).await {
+            Ok(latest) => latest,
+            Err(err) => {
+                tracing::warn!(error = %err, "escalation: failed to read latest nonce, skipping pass");
+                return;
+            }
+        };
+        metrics::set_nonce_latest(latest);
+
+        let due: Vec<u64> = {
+            let inflight = self.inflight.lock().await;
+            metrics::set_nonce_inflight(inflight.len());
+            inflight
+                .iter()
+                .filter(|(nonce, tx)| {
+                    **nonce >= latest
+                        && tx.last_sent_at.elapsed()
+                            >= Duration::from_secs(self.config.escalation_interval_secs)
+                })
+                .map(|(nonce, _)| *nonce)
+                .collect()
+        };
+
+        // Entries below `latest` were mined; the receipt watcher finalizes them
+        // and removes them. Nothing to do here.
+        for nonce in due {
+            self.escalate_one(nonce).await;
+        }
+    }
+
+    /// Re-broadcasts a single in-flight transaction at its original nonce with a
+    /// higher priority fee, or gives up and releases the nonce.
+    async fn escalate_one(&self, nonce: u64) {
+        let Some((mut request, batch_type, ids, escalations, prev_priority_fee, submitted_at)) = ({
+            let inflight = self.inflight.lock().await;
+            inflight.get(&nonce).map(|tx| {
+                (
+                    tx.request.clone(),
+                    tx.batch_type,
+                    tx.ids.clone(),
+                    tx.escalations,
+                    tx.priority_fee,
+                    tx.submitted_at,
+                )
+            })
+        }) else {
+            return;
+        };
+
+        if escalations >= self.config.max_escalations {
+            self.go_terminal(
+                nonce,
+                prev_priority_fee,
+                TerminalReason::EscalationExhausted,
+            )
+            .await;
+            return;
+        }
+
+        if !self.has_sufficient_balance().await {
+            self.go_terminal(nonce, prev_priority_fee, TerminalReason::BalanceFloor)
+                .await;
+            return;
+        }
+
+        let fees = match self.provider.estimate_eip1559_fees().await {
+            Ok(fees) => fees,
+            Err(err) => {
+                tracing::warn!(error = %err, nonce, "escalation: fee estimation failed, retrying next pass");
+                return;
+            }
+        };
+
+        // Bump the priority fee, and keep the base-fee component of the fresh
+        // estimate rather than compounding it, so `max_fee * gas_limit` does not
+        // inflate faster than necessary and walk into `insufficient funds`.
+        let priority_fee = prev_priority_fee
+            .saturating_mul(u128::from(self.config.escalation_factor_percent))
+            / 100;
+        let priority_fee = priority_fee.max(fees.max_priority_fee_per_gas);
+        let base_component = fees
+            .max_fee_per_gas
+            .saturating_sub(fees.max_priority_fee_per_gas);
+        let max_fee = base_component.saturating_add(priority_fee);
+
+        request.set_max_priority_fee_per_gas(priority_fee);
+        request.set_max_fee_per_gas(max_fee);
+
+        tracing::warn!(
+            nonce,
+            batch_type,
+            escalation = escalations + 1,
+            priority_fee,
+            max_fee,
+            age_secs = submitted_at.elapsed().as_secs(),
+            "escalating unconfirmed batch transaction"
+        );
+
+        match self.provider.send_transaction(request.clone()).await {
+            Ok(pending) => {
+                let tx_hash = format!("0x{:x}", pending.tx_hash());
+                metrics::record_escalation(batch_type, "sent");
+
+                self.tracker
+                    .set_status_batch(
+                        &ids,
+                        GatewayRequestState::Submitted {
+                            tx_hash: tx_hash.clone(),
+                        },
+                    )
+                    .await;
+
+                if let Some(tx) = self.inflight.lock().await.get_mut(&nonce) {
+                    tx.request = request;
+                    tx.priority_fee = priority_fee;
+                    tx.escalations += 1;
+                    tx.last_sent_at = Instant::now();
+                }
+
+                spawn_receipt_watch(
+                    Arc::clone(&self.inflight),
+                    self.tracker.clone(),
+                    nonce,
+                    pending,
+                    tx_hash,
+                    batch_type,
+                    submitted_at,
+                );
+            }
+            Err(err) => {
+                let error_str = err.to_string();
+
+                if is_already_known(&error_str) || is_nonce_too_low(&error_str) {
+                    // Either the replacement is redundant or the nonce is gone.
+                    // Both resolve on their own; do not burn an escalation.
+                    tracing::info!(
+                        nonce,
+                        error = %error_str,
+                        "escalation: no-op response from node"
+                    );
+                    return;
+                }
+
+                metrics::record_escalation(batch_type, "failed");
+
+                if is_permanent_rejection(&error_str) {
+                    tracing::error!(
+                        error = %error_str,
+                        nonce,
+                        batch_type,
+                        "escalation hit a permanent rejection, releasing nonce"
+                    );
+                    self.go_terminal(nonce, prev_priority_fee, TerminalReason::PermanentRejection)
+                        .await;
+                    return;
+                }
+
+                tracing::warn!(
+                    error = %error_str,
+                    nonce,
+                    batch_type,
+                    "escalation send failed, retrying next pass"
+                );
+
+                if let Some(tx) = self.inflight.lock().await.get_mut(&nonce) {
+                    tx.escalations += 1;
+                    tx.last_sent_at = Instant::now();
+                }
+            }
+        }
+    }
+
+    /// Abandons the batch at `nonce`: fails its requests, then releases the
+    /// nonce so later transactions become executable.
+    async fn go_terminal(&self, nonce: u64, priority_fee: u128, reason: TerminalReason) {
+        let Some(tx) = self.inflight.lock().await.remove(&nonce) else {
+            return;
+        };
+
+        tracing::error!(
+            nonce,
+            batch_type = tx.batch_type,
+            reason = reason.as_str(),
+            escalations = tx.escalations,
+            request_count = tx.ids.len(),
+            age_secs = tx.submitted_at.elapsed().as_secs(),
+            "abandoning batch transaction, requests will be failed"
+        );
+        metrics::record_terminal(tx.batch_type, reason.as_str());
+
+        self.tracker
+            .set_status_batch(
+                &tx.ids,
+                GatewayRequestState::failed(
+                    format!(
+                        "transaction abandoned after {} escalation(s) ({})",
+                        tx.escalations,
+                        reason.as_str()
+                    ),
+                    Some(GatewayErrorCode::ConfirmationError),
+                ),
+            )
+            .await;
+
+        self.release_nonce(nonce, priority_fee, reason).await;
+    }
+
+    /// Sends a minimal self-transfer at `nonce` so transactions queued behind it
+    /// become executable.
+    ///
+    /// The replacement price bump is cleared by doubling the priority fee of the
+    /// transaction being displaced. If the nonce was never occupied — a send the
+    /// node rejected outright — there is nothing to replace and the transfer
+    /// simply lands.
+    async fn release_nonce(
+        &self,
+        nonce: u64,
+        displaced_priority_fee: u128,
+        reason: TerminalReason,
+    ) {
+        match self.provider.get_transaction_count(self.signer).await {
+            Ok(latest) if latest > nonce => {
+                tracing::info!(
+                    nonce,
+                    latest,
+                    "nonce already consumed on-chain, no release needed"
+                );
+                metrics::record_nonce_release("already_consumed");
+                return;
+            }
+            Ok(_) => {}
+            Err(err) => {
+                tracing::warn!(error = %err, nonce, "failed to read latest nonce before release");
+                metrics::record_nonce_release("rpc_error");
+                return;
+            }
+        }
+
+        let fees = match self.provider.estimate_eip1559_fees().await {
+            Ok(fees) => fees,
+            Err(err) => {
+                tracing::error!(error = %err, nonce, "failed to estimate fees for nonce release");
+                metrics::record_nonce_release("fee_estimation_failed");
+                return;
+            }
+        };
+
+        let priority_fee = displaced_priority_fee
+            .saturating_mul(2)
+            .max(fees.max_priority_fee_per_gas);
+        let base_component = fees
+            .max_fee_per_gas
+            .saturating_sub(fees.max_priority_fee_per_gas);
+        let max_fee = base_component.saturating_add(priority_fee);
+
+        let request = TransactionRequest::default()
+            .with_from(self.signer)
+            .with_to(self.signer)
+            .with_value(U256::ZERO)
+            .with_nonce(nonce)
+            .with_gas_limit(RELEASE_TX_GAS_LIMIT)
+            .with_max_fee_per_gas(max_fee)
+            .with_max_priority_fee_per_gas(priority_fee);
+
+        tracing::warn!(
+            nonce,
+            reason = reason.as_str(),
+            priority_fee,
+            "releasing blocked nonce with a self-transfer"
+        );
+
+        match self.provider.send_transaction(request).await {
+            Ok(pending) => {
+                tracing::warn!(
+                    nonce,
+                    reason = reason.as_str(),
+                    tx_hash = %format!("0x{:x}", pending.tx_hash()),
+                    "nonce release transaction submitted"
+                );
+                metrics::record_nonce_release("sent");
+            }
+            Err(err) => {
+                tracing::error!(
+                    error = %err,
+                    nonce,
+                    reason = reason.as_str(),
+                    "nonce release transaction failed to submit, submission remains blocked"
+                );
+                metrics::record_nonce_release("failed");
+            }
+        }
+    }
+}
+
+/// Watches for a receipt and drops the in-flight entry once the nonce is
+/// consumed. A revert consumes the nonce just as a success does.
+///
+/// A watcher that ends without a receipt is not terminal: the escalation loop
+/// still owns the nonce and will re-broadcast or release it.
+fn spawn_receipt_watch(
+    inflight: Inflight,
+    tracker: RequestTracker,
+    nonce: u64,
+    pending: PendingTransactionBuilder<Ethereum>,
+    tx_hash: String,
+    batch_type: &'static str,
+    submitted_at: Instant,
+) {
+    tokio::spawn(async move {
+        match pending.get_receipt().await {
+            Ok(receipt) => {
+                let confirmed = receipt.status();
+                let latency_ms = submitted_at.elapsed().as_millis() as f64;
+                metrics::record_batch_confirmed(batch_type, confirmed, latency_ms);
+
+                if confirmed {
+                    tracing::info!(
+                        tx_hash = %tx_hash,
+                        batch_type,
+                        nonce,
+                        latency_ms,
+                        "batch transaction confirmed on-chain"
+                    );
+                } else {
+                    tracing::error!(
+                        tx_hash = %tx_hash,
+                        batch_type,
+                        nonce,
+                        "batch transaction reverted on-chain"
+                    );
+                }
+
+                let ids = inflight.lock().await.remove(&nonce).map(|tx| tx.ids);
+                if let Some(ids) = ids {
+                    tracker
+                        .finalize_from_receipt(&ids, confirmed, &tx_hash)
+                        .await;
+                }
+            }
+            Err(err) => {
+                tracing::warn!(
+                    tx_hash = %tx_hash,
+                    batch_type,
+                    nonce,
+                    error = %err,
+                    "receipt watch ended without a receipt, escalation loop retains the nonce"
+                );
+            }
+        }
+    });
+}
+
+/// Runs the escalation loop indefinitely.
+pub async fn run_escalation_loop(submitter: Arc<TxSubmitter>) {
+    let interval = Duration::from_secs(submitter.config.escalation_interval_secs);
+    loop {
+        tokio::time::sleep(interval).await;
+        submitter.escalate_once().await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn permanent_rejections_are_classified() {
+        assert!(is_permanent_rejection(
+            "insufficient funds for gas * price + value"
+        ));
+        assert!(is_permanent_rejection("exceeds block gas limit"));
+        assert!(is_permanent_rejection("oversized data"));
+        assert!(is_permanent_rejection(
+            "tx fee (2.10 ether) exceeds the configured cap (1.00 ether)"
+        ));
+        assert!(is_permanent_rejection("intrinsic gas too low"));
+    }
+
+    #[test]
+    fn transient_errors_are_not_permanent() {
+        assert!(!is_permanent_rejection(
+            "replacement transaction underpriced"
+        ));
+        assert!(!is_permanent_rejection("already known"));
+        assert!(!is_permanent_rejection(
+            "nonce too low: next nonce 82, tx nonce 81"
+        ));
+        assert!(!is_permanent_rejection("request timed out"));
+        assert!(!is_permanent_rejection("connection reset by peer"));
+    }
+
+    #[test]
+    fn already_known_and_nonce_too_low_are_recognised() {
+        assert!(is_already_known("already known"));
+        assert!(is_already_known("Transaction ALREADY IMPORTED"));
+        assert!(!is_already_known("replacement transaction underpriced"));
+
+        assert!(is_nonce_too_low(
+            "nonce too low: next nonce 82, tx nonce 81"
+        ));
+        assert!(!is_nonce_too_low("already known"));
+    }
+
+    #[test]
+    fn terminal_reason_labels_are_stable() {
+        assert_eq!(
+            TerminalReason::PermanentRejection.as_str(),
+            "permanent_rejection"
+        );
+        assert_eq!(
+            TerminalReason::EscalationExhausted.as_str(),
+            "escalation_exhausted"
+        );
+        assert_eq!(TerminalReason::BalanceFloor.as_str(), "balance_floor");
+    }
+}

--- a/services/gateway/src/tx_submitter.rs
+++ b/services/gateway/src/tx_submitter.rs
@@ -21,14 +21,7 @@
 //! the node's transaction fee cap. Those errors are classified as terminal, so
 //! the nonce is released instead of being retried forever.
 
-use std::{
-    collections::BTreeMap,
-    sync::{
-        Arc,
-        atomic::{AtomicU64, Ordering},
-    },
-    time::Duration,
-};
+use std::{collections::BTreeMap, sync::Arc, time::Duration};
 
 use alloy::{
     network::{Ethereum, TransactionBuilder},
@@ -127,44 +120,76 @@ pub struct TxSubmitter {
     signer: Address,
     config: TxSubmitterConfig,
     tracker: RequestTracker,
-    /// Next nonce to hand out. Seeded from the pending count, then owned here.
-    next_nonce: AtomicU64,
+    /// Next nonce to hand out, or `None` until it has been seeded.
+    ///
+    /// Seeded lazily on first use rather than at startup: a transient RPC
+    /// failure must not stop the service from booting, or a dependency blip
+    /// turns into a crash loop (`/health` backs both the liveness and the
+    /// readiness probe).
+    next_nonce: Mutex<Option<u64>>,
     inflight: Inflight,
 }
 
 impl TxSubmitter {
-    /// Creates a submitter and seeds the nonce counter.
-    ///
-    /// Seeded from the *pending* count rather than `latest`, so a replica that
-    /// restarts while its own earlier transactions are still in the mempool
-    /// does not hand out a nonce that collides with them.
-    ///
-    /// # Errors
-    ///
-    /// Returns the transport error if the initial transaction count cannot be
-    /// read — the gateway cannot submit anything without it.
-    pub async fn new(
+    /// Creates a submitter. The nonce counter is seeded on first use.
+    pub fn new(
         provider: Arc<DynProvider>,
         signer: Address,
         config: TxSubmitterConfig,
         tracker: RequestTracker,
-    ) -> Result<Self, alloy::transports::TransportError> {
-        let seed = provider.get_transaction_count(signer).pending().await?;
-
-        tracing::info!(
-            signer = %signer,
-            seed_nonce = seed,
-            "tx submitter seeded nonce counter from pending transaction count"
-        );
-
-        Ok(Self {
+    ) -> Self {
+        Self {
             provider,
             signer,
             config,
             tracker,
-            next_nonce: AtomicU64::new(seed),
+            next_nonce: Mutex::new(None),
             inflight: Arc::new(Mutex::new(BTreeMap::new())),
-        })
+        }
+    }
+
+    /// Reserves the next nonce, seeding the counter from the chain if needed.
+    ///
+    /// Seeded from the *pending* count rather than `latest`, so a replica that
+    /// restarts while its own earlier transactions are still in the mempool does
+    /// not hand out a nonce that collides with them.
+    ///
+    /// Returns `None` when the seed read fails; no nonce is consumed in that
+    /// case, so the caller can fail the batch without leaving a gap.
+    async fn reserve_nonce(&self) -> Option<u64> {
+        let mut guard = self.next_nonce.lock().await;
+
+        let nonce = match *guard {
+            Some(nonce) => nonce,
+            None => {
+                match self
+                    .provider
+                    .get_transaction_count(self.signer)
+                    .pending()
+                    .await
+                {
+                    Ok(seed) => {
+                        tracing::info!(
+                            signer = %self.signer,
+                            seed_nonce = seed,
+                            "seeded nonce counter from the pending transaction count"
+                        );
+                        seed
+                    }
+                    Err(err) => {
+                        tracing::error!(
+                            error = %err,
+                            signer = %self.signer,
+                            "failed to seed the nonce counter; cannot submit transactions yet"
+                        );
+                        return None;
+                    }
+                }
+            }
+        };
+
+        *guard = Some(nonce + 1);
+        Some(nonce)
     }
 
     /// Snapshot of unconfirmed transactions as `(nonce, last broadcast hash)`,
@@ -285,7 +310,12 @@ impl TxSubmitter {
         request.set_max_fee_per_gas(fees.max_fee_per_gas);
         request.set_max_priority_fee_per_gas(fees.max_priority_fee_per_gas);
 
-        let mut nonce = self.next_nonce.fetch_add(1, Ordering::SeqCst);
+        let Some(mut nonce) = self.reserve_nonce().await else {
+            metrics::record_batch_send_failed(batch_type, 0.0);
+            self.fail_requests(&ids, "nonce counter unavailable, RPC unreachable")
+                .await;
+            return;
+        };
         request.set_nonce(nonce);
         metrics::set_nonce_owned(nonce);
 
@@ -450,7 +480,7 @@ impl TxSubmitter {
         metrics::record_nonce_resync("resynced");
 
         // Hand out the nonce after this one to the next caller.
-        self.next_nonce.store(fresh + 1, Ordering::SeqCst);
+        *self.next_nonce.lock().await = Some(fresh + 1);
         Some(fresh)
     }
 

--- a/services/gateway/tests/common.rs
+++ b/services/gateway/tests/common.rs
@@ -6,8 +6,8 @@ use testcontainers_modules::{
     testcontainers::{ContainerAsync, ImageExt as _, runners::AsyncRunner as _},
 };
 use world_id_gateway::{
-    BatchPolicyConfig, GatewayConfig, GatewayHandle, RegistryVersion, SignerArgs, defaults,
-    spawn_gateway_for_tests,
+    BatchPolicyConfig, GatewayConfig, GatewayHandle, RegistryVersion, SignerArgs,
+    TxSubmitterConfig, defaults, spawn_gateway_for_tests,
 };
 use world_id_primitives::api_types::{GatewayRequestState, GatewayStatusResponse};
 use world_id_services_common::ProviderArgs;
@@ -109,6 +109,7 @@ async fn spawn_test_gateway_for_registry(
             stale_queued_threshold_secs: defaults::STALE_QUEUED_THRESHOLD_SECS,
             stale_submitted_threshold_secs: defaults::STALE_SUBMITTED_THRESHOLD_SECS,
             batch_policy: BatchPolicyConfig::default(),
+            tx_submitter: TxSubmitterConfig::default(),
         },
         Some(ms) => {
             let max_wait_secs = (ms / 1000).max(1);
@@ -136,6 +137,7 @@ async fn spawn_test_gateway_for_registry(
                 sweeper_interval_secs: max_wait_secs + 1,
                 stale_queued_threshold_secs: max_wait_secs + 1,
                 stale_submitted_threshold_secs: 600,
+                tx_submitter: TxSubmitterConfig::default(),
             }
         }
     };

--- a/services/gateway/tests/test_nonce_gap.rs
+++ b/services/gateway/tests/test_nonce_gap.rs
@@ -1,0 +1,286 @@
+//! Nonce-gap recovery tests for [`TxSubmitter`].
+//!
+//! These drive the submitter directly rather than through the HTTP API: the
+//! behaviour under test is nonce mechanics, so the transactions are plain
+//! self-transfers and no registry is involved.
+//!
+//! Anvil runs with auto-mining disabled so that transactions can be held in the
+//! mempool, dropped with `anvil_dropTransaction`, and mined on demand — which is
+//! what makes the production failure reproducible.
+
+#![cfg(feature = "integration-tests")]
+
+use std::{sync::Arc, time::Duration};
+
+use alloy::{
+    primitives::{Address, TxHash, U256},
+    providers::{Provider, ext::AnvilApi},
+    rpc::types::TransactionRequest,
+};
+use world_id_gateway::{RequestTracker, TxSubmitter, TxSubmitterConfig};
+use world_id_primitives::api_types::{GatewayRequestKind, GatewayRequestState};
+use world_id_services_common::{ProviderArgs, SignerArgs};
+use world_id_test_utils::anvil::TestAnvil;
+
+mod common;
+use crate::common::{GW_PRIVATE_KEY, start_redis};
+
+/// Escalation interval used by the tests. Short so a pass becomes due without
+/// making the suite slow; production defaults to 30s.
+const TEST_ESCALATION_INTERVAL_SECS: u64 = 1;
+
+struct Harness {
+    submitter: Arc<TxSubmitter>,
+    provider: Arc<alloy::providers::DynProvider>,
+    tracker: RequestTracker,
+    signer: Address,
+    _anvil: TestAnvil,
+    _redis: testcontainers_modules::testcontainers::ContainerAsync<
+        testcontainers_modules::redis::Redis,
+    >,
+}
+
+impl Harness {
+    /// Spawns anvil with auto-mining off, plus Redis, and builds a submitter.
+    async fn new(config: TxSubmitterConfig) -> Self {
+        let anvil = TestAnvil::spawn_auto_mine().expect("failed to spawn anvil");
+        let (redis_url, redis) = start_redis().await;
+
+        let args = ProviderArgs {
+            http: Some(vec![anvil.endpoint().parse().expect("invalid anvil url")]),
+            signer: Some(SignerArgs::from_wallet(GW_PRIVATE_KEY.to_string())),
+            ..Default::default()
+        };
+        let (provider, signer) = args
+            .http_with_signer_address()
+            .await
+            .expect("failed to build provider");
+        let signer = signer.expect("signer address should be resolved");
+        let provider = Arc::new(provider);
+
+        // Hold transactions in the mempool so a gap can be created on purpose.
+        provider
+            .anvil_set_auto_mine(false)
+            .await
+            .expect("failed to disable automine");
+
+        let tracker = RequestTracker::new(redis_url, None, 600).await;
+        let submitter = Arc::new(
+            TxSubmitter::new(provider.clone(), signer, config, tracker.clone())
+                .await
+                .expect("failed to seed submitter"),
+        );
+
+        Self {
+            submitter,
+            provider,
+            tracker,
+            signer,
+            _anvil: anvil,
+            _redis: redis,
+        }
+    }
+
+    /// Registers a request in the tracker and submits a self-transfer carrying
+    /// it, returning the request id.
+    async fn submit_one(&self) -> String {
+        let id = uuid::Uuid::new_v4().to_string();
+        self.tracker
+            .new_request_with_id(id.clone(), GatewayRequestKind::CreateAccount, vec![])
+            .await
+            .expect("failed to register request");
+
+        let request = TransactionRequest::default()
+            .to(self.signer)
+            .value(U256::ZERO);
+
+        self.submitter
+            .submit(
+                request,
+                vec![id.clone()],
+                "create",
+                tokio::time::Instant::now(),
+            )
+            .await;
+        id
+    }
+
+    async fn latest_nonce(&self) -> u64 {
+        self.provider
+            .get_transaction_count(self.signer)
+            .await
+            .expect("failed to read transaction count")
+    }
+
+    async fn mine(&self) {
+        self.provider
+            .anvil_mine(Some(1), None)
+            .await
+            .expect("failed to mine");
+    }
+
+    async fn drop_tx(&self, hash: &str) {
+        let hash: TxHash = hash.parse().expect("invalid tx hash");
+        self.provider
+            .anvil_drop_transaction(hash)
+            .await
+            .expect("failed to drop transaction");
+    }
+}
+
+fn base_config() -> TxSubmitterConfig {
+    TxSubmitterConfig {
+        escalation_interval_secs: TEST_ESCALATION_INTERVAL_SECS,
+        escalation_factor_percent: 200,
+        max_escalations: 3,
+        // Disabled by default so the gap tests can queue several transactions.
+        max_inflight_txs: 0,
+        // Anvil accounts are funded; a floor of 0 keeps the tests deterministic.
+        min_balance_wei: 0,
+    }
+}
+
+/// The production failure: the transaction holding nonce `N` is dropped from the
+/// mempool while `N+1` is already queued behind it. Nothing can be mined until
+/// `N` is filled again.
+///
+/// Asserts that escalation re-broadcasts the dropped transaction at its original
+/// nonce and both transactions then land.
+#[tokio::test]
+async fn dropped_transaction_is_rebroadcast_at_the_same_nonce() {
+    let harness = Harness::new(base_config()).await;
+    let start_nonce = harness.latest_nonce().await;
+
+    harness.submit_one().await;
+    harness.submit_one().await;
+
+    let inflight = harness.submitter.inflight().await;
+    assert_eq!(inflight.len(), 2, "both transactions should be in flight");
+    assert_eq!(inflight[0].0, start_nonce);
+    assert_eq!(inflight[1].0, start_nonce + 1);
+
+    // Drop the transaction holding the lower nonce, leaving a gap.
+    harness.drop_tx(&inflight[0].1).await;
+    harness.mine().await;
+    assert_eq!(
+        harness.latest_nonce().await,
+        start_nonce,
+        "nothing can be mined while the gap exists"
+    );
+
+    // Let the escalation interval elapse, then run one pass.
+    tokio::time::sleep(Duration::from_millis(
+        TEST_ESCALATION_INTERVAL_SECS * 1000 + 200,
+    ))
+    .await;
+    harness.submitter.escalate_once().await;
+
+    harness.mine().await;
+    assert_eq!(
+        harness.latest_nonce().await,
+        start_nonce + 2,
+        "re-broadcast should fill the gap and unblock the queued transaction"
+    );
+}
+
+/// With the escalation budget exhausted, the batch is abandoned: its requests
+/// are failed and the nonce is released so later transactions can be mined.
+#[tokio::test]
+async fn exhausted_escalations_release_the_nonce() {
+    let config = TxSubmitterConfig {
+        // The first escalation pass goes straight to terminal.
+        max_escalations: 0,
+        ..base_config()
+    };
+    let harness = Harness::new(config).await;
+    let start_nonce = harness.latest_nonce().await;
+
+    let abandoned_id = harness.submit_one().await;
+    harness.submit_one().await;
+
+    let inflight = harness.submitter.inflight().await;
+    harness.drop_tx(&inflight[0].1).await;
+    harness.mine().await;
+    assert_eq!(harness.latest_nonce().await, start_nonce);
+
+    tokio::time::sleep(Duration::from_millis(
+        TEST_ESCALATION_INTERVAL_SECS * 1000 + 200,
+    ))
+    .await;
+    harness.submitter.escalate_once().await;
+
+    harness.mine().await;
+    assert_eq!(
+        harness.latest_nonce().await,
+        start_nonce + 2,
+        "the release transaction should fill the nonce and unblock the queue"
+    );
+
+    let record = harness
+        .tracker
+        .snapshot(&abandoned_id)
+        .await
+        .expect("abandoned request should still have a record");
+    assert!(
+        matches!(record.status, GatewayRequestState::Failed { .. }),
+        "abandoned batch requests must be failed, got {:?}",
+        record.status
+    );
+
+    assert!(
+        harness.submitter.inflight().await.is_empty(),
+        "the abandoned entry must be dropped from the in-flight set"
+    );
+}
+
+/// The in-flight cap refuses further submissions rather than piling batches up
+/// behind a nonce that is not progressing.
+#[tokio::test]
+async fn inflight_cap_refuses_further_submissions() {
+    let config = TxSubmitterConfig {
+        max_inflight_txs: 1,
+        ..base_config()
+    };
+    let harness = Harness::new(config).await;
+
+    assert!(
+        harness.submitter.can_submit().await,
+        "an idle submitter should accept a batch"
+    );
+
+    harness.submit_one().await;
+
+    assert!(
+        !harness.submitter.can_submit().await,
+        "the cap should refuse a second batch while one is unconfirmed"
+    );
+
+    harness.mine().await;
+    // Give the receipt watcher a moment to clear the entry.
+    for _ in 0..50 {
+        if harness.submitter.inflight().await.is_empty() {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    assert!(
+        harness.submitter.can_submit().await,
+        "capacity should return once the transaction is confirmed"
+    );
+}
+
+/// A balance floor above the signer's balance stops submission.
+#[tokio::test]
+async fn balance_floor_stops_submission() {
+    let config = TxSubmitterConfig {
+        min_balance_wei: u128::MAX,
+        ..base_config()
+    };
+    let harness = Harness::new(config).await;
+
+    assert!(
+        !harness.submitter.can_submit().await,
+        "submission must stop when the balance is below the floor"
+    );
+}

--- a/services/gateway/tests/test_nonce_gap.rs
+++ b/services/gateway/tests/test_nonce_gap.rs
@@ -65,11 +65,12 @@ impl Harness {
             .expect("failed to disable automine");
 
         let tracker = RequestTracker::new(redis_url, None, 600).await;
-        let submitter = Arc::new(
-            TxSubmitter::new(provider.clone(), signer, config, tracker.clone())
-                .await
-                .expect("failed to seed submitter"),
-        );
+        let submitter = Arc::new(TxSubmitter::new(
+            provider.clone(),
+            signer,
+            config,
+            tracker.clone(),
+        ));
 
         Self {
             submitter,

--- a/services/gateway/tests/test_orphan_sweeper.rs
+++ b/services/gateway/tests/test_orphan_sweeper.rs
@@ -11,7 +11,7 @@ use redis::{AsyncCommands, aio::ConnectionManager};
 use reqwest::{Client, StatusCode};
 use world_id_gateway::{
     BatchPolicyConfig, GatewayConfig, OrphanSweeperConfig, RegistryVersion, RequestRecord,
-    RequestTracker, defaults, now_unix_secs, request_tracker::BacklogScope,
+    RequestTracker, TxSubmitterConfig, defaults, now_unix_secs, request_tracker::BacklogScope,
     spawn_gateway_for_tests, sweep_once,
 };
 use world_id_primitives::api_types::{
@@ -684,6 +684,7 @@ async fn sweep_submitted_with_real_receipt() {
 
     let signer_args = SignerArgs::from_wallet(GW_PRIVATE_KEY.to_string());
     let cfg = GatewayConfig {
+        tx_submitter: TxSubmitterConfig::default(),
         registry_addr,
         registry_version: RegistryVersion::V2,
         provider: ProviderArgs {

--- a/services/gateway/tests/test_rate_limiting.rs
+++ b/services/gateway/tests/test_rate_limiting.rs
@@ -7,7 +7,8 @@ use alloy::{
 };
 use reqwest::{Client, StatusCode};
 use world_id_gateway::{
-    BatchPolicyConfig, GatewayConfig, RegistryVersion, defaults, spawn_gateway_for_tests,
+    BatchPolicyConfig, GatewayConfig, RegistryVersion, TxSubmitterConfig, defaults,
+    spawn_gateway_for_tests,
 };
 use world_id_primitives::api_types::{InsertAuthenticatorRequest, UpdateAuthenticatorRequest};
 use world_id_registries::world_id::{InsertAuthenticatorTypedData, UpdateAuthenticatorTypedData};
@@ -63,6 +64,7 @@ async fn test_rate_limit_basic() {
 
     let signer_args = SignerArgs::from_wallet(GW_PRIVATE_KEY.to_string());
     let cfg = GatewayConfig {
+        tx_submitter: TxSubmitterConfig::default(),
         registry_addr,
         registry_version: RegistryVersion::V2,
         provider: ProviderArgs {
@@ -271,6 +273,7 @@ async fn test_rate_limit_different_leaf_indexes() {
 
     let signer_args = SignerArgs::from_wallet(GW_PRIVATE_KEY.to_string());
     let cfg = GatewayConfig {
+        tx_submitter: TxSubmitterConfig::default(),
         registry_addr,
         registry_version: RegistryVersion::V2,
         provider: ProviderArgs {
@@ -428,6 +431,7 @@ async fn test_rate_limit_sliding_window() {
 
     let signer_args = SignerArgs::from_wallet(GW_PRIVATE_KEY.to_string());
     let cfg = GatewayConfig {
+        tx_submitter: TxSubmitterConfig::default(),
         registry_addr,
         registry_version: RegistryVersion::V2,
         provider: ProviderArgs {
@@ -582,6 +586,7 @@ async fn test_rate_limit_multiple_endpoints() {
 
     let signer_args = SignerArgs::from_wallet(GW_PRIVATE_KEY.to_string());
     let cfg = GatewayConfig {
+        tx_submitter: TxSubmitterConfig::default(),
         registry_addr,
         registry_version: RegistryVersion::V2,
         provider: ProviderArgs {

--- a/services/gateway/tests/test_with_redis.rs
+++ b/services/gateway/tests/test_with_redis.rs
@@ -7,7 +7,8 @@ use alloy::{
 use redis::{AsyncTypedCommands, IntegerReplyOrNoOp, aio::ConnectionManager};
 use reqwest::{Client, StatusCode};
 use world_id_gateway::{
-    BatchPolicyConfig, GatewayConfig, RegistryVersion, defaults, spawn_gateway_for_tests,
+    BatchPolicyConfig, GatewayConfig, RegistryVersion, TxSubmitterConfig, defaults,
+    spawn_gateway_for_tests,
 };
 use world_id_primitives::api_types::GatewayStatusResponse;
 use world_id_services_common::{ProviderArgs, SignerArgs};
@@ -38,6 +39,7 @@ async fn redis_integration() {
 
     let signer_args = SignerArgs::from_wallet(GW_PRIVATE_KEY.to_string());
     let cfg = GatewayConfig {
+        tx_submitter: TxSubmitterConfig::default(),
         registry_addr,
         registry_version: RegistryVersion::V2,
         provider: ProviderArgs {

--- a/tools/generate-solidity-fixtures/src/main.rs
+++ b/tools/generate-solidity-fixtures/src/main.rs
@@ -34,6 +34,7 @@ use world_id_core::{
     requests::{ProofRequest, ProofType, RequestItem, RequestVersion},
 };
 use world_id_gateway::{
+    TxSubmitterConfig,
     BatchPolicyConfig, GatewayConfig, RegistryVersion, SignerArgs, defaults,
     spawn_gateway_for_tests,
 };
@@ -82,6 +83,7 @@ async fn main() -> Result<()> {
     let gw_port: u16 = 4105;
     let signer_args = SignerArgs::from_wallet(hex::encode(deployer.to_bytes()));
     let gateway_config = GatewayConfig {
+        tx_submitter: TxSubmitterConfig::default(),
         registry_addr: world_id_registry,
         registry_version: RegistryVersion::V2,
         provider: world_id_gateway::ProviderArgs {

--- a/tools/generate-solidity-fixtures/src/main.rs
+++ b/tools/generate-solidity-fixtures/src/main.rs
@@ -34,8 +34,7 @@ use world_id_core::{
     requests::{ProofRequest, ProofType, RequestItem, RequestVersion},
 };
 use world_id_gateway::{
-    TxSubmitterConfig,
-    BatchPolicyConfig, GatewayConfig, RegistryVersion, SignerArgs, defaults,
+    BatchPolicyConfig, GatewayConfig, RegistryVersion, SignerArgs, TxSubmitterConfig, defaults,
     spawn_gateway_for_tests,
 };
 use world_id_primitives::{


### PR DESCRIPTION
Batch submission stalls indefinitely when a batch transaction is dropped from the mempool or gets stuck: everything the gateway submits afterwards queues behind the unfilled nonce and nothing is mined. This makes the gateway own its nonce stream and drive every batch to a terminal state, so a nonce is either consumed or explicitly released — never left blocking.

## The bug

- The gateway never chose its own nonce. Every provider is built with alloy's `SimpleNonceManager` (`services/common/src/alloy/provider.rs`), so each transaction's nonce was whatever `eth_getTransactionCount(signer, pending)` returned — read from a remote node's mempool view rather than owned by the service.
- Submission was fire-and-forget: `submit_common` held the shared `tx_send_lock` only for the duration of the `send()` RPC and handed confirmation to a detached task. Several batch transactions were in flight at once, at nonces `N`, `N+1`, `N+2`, …
- If the transaction at nonce `N` never landed, the transactions at `N+1`… were non-executable and nothing from this signer could be mined until `N` was filled.
- There was no mechanism to fill or replace `N`: the gateway never re-broadcast a submitted transaction, never bumped fees, and its next nonce came from the same `pending` count, which stays ahead of `latest` while the queued transactions sit in the pool.
- The orphan sweeper observed the symptom and failed the affected user requests, but left the nonce stream untouched — so the next batch reproduced the stall immediately. Time-to-detect was floored by `STALE_SUBMITTED_THRESHOLD_SECS` (600s), and no metric exposed the condition.
- Blast radius: the create batcher and the ops batcher share one signer, so a single gap stopped *all* on-chain progress for the replica. #654 fixed one trigger for this class of failure (PROTO-4494, ~4.5h stall on stage); this addresses the mechanism rather than a trigger.

## The fix

Nonce ownership plus "retry until it lands", following the patterns in `worldcoin/tx-sitter-monolith`.

- **Gateway-owned nonces.** New `services/gateway/src/tx_submitter.rs` holds an in-process counter, seeded from the *pending* transaction count at startup so a restarting replica does not collide with its own still-queued transactions. Safe per replica because prod provisions one KMS key per pod ordinal (`AWS_KMS_KEY_IDS`), giving each replica an independent nonce stream.
- **Retry at the same nonce.** Each submitted batch is retained and re-broadcast every `ESCALATION_INTERVAL_SECS` (30s) with the priority fee multiplied by `ESCALATION_FACTOR_PERCENT` (125%) until it is mined. Owning the nonce is what makes this safe — retrying through `SimpleNonceManager` could pick a *different* nonce and execute the same batch twice.
- **Terminal release.** Escalation creates its own permanent rejections: each bump raises `max_fee_per_gas * gas_limit` until it exceeds the signer balance or the node's fee cap. On a permanent rejection, `MAX_ESCALATIONS` (6), or the balance floor, the batch is abandoned and a 21k self-transfer is sent at that nonce so the queue behind it becomes executable. Without this, owning the nonce would be *worse* than the status quo — an unlandable transaction would block the counter permanently.
- **Error classification.** `insufficient funds`, `exceeds block gas limit`, `oversized data`, `exceeds the configured cap`, `intrinsic gas too low` go terminal without burning escalations. `already known` retains the nonce (the node holds the transaction); `nonce too low` means it is already consumed, so nothing is released.
- **In-flight cap.** `MAX_INFLIGHT_TXS` (4, `0` disables) bounds how much piles up behind a nonce that is not progressing. Capacity is checked *before* the batch is drained from the policy queue, so a refused batch stays queued rather than being lost. At `BATCH_REEVAL_MS=2000` against 2s blocks the happy path never reaches the cap.
- **Balance guard.** Submission and escalation stop below `MIN_BALANCE_WEI` (0.05 ETH), with a counter and a balance gauge. `/health` is deliberately unaffected — the replica still serves reads, and alerting is the operator's signal.
- **Explicit gas and fees.** The submitter sets `nonce`, `gas_limit`, `max_fee_per_gas` and `max_priority_fee_per_gas` itself. This is required, not cosmetic: alloy's `GasFiller` overwrites both fee fields unless `gas_limit` is also set, which would make the fee on a re-broadcast unpredictable and could fail to clear the replacement price bump. Both estimation calls happen *before* a nonce is reserved, so an estimation failure can never consume one.
- **Counter reconciliation.** The counter assumes this replica is the sole sender for its signer. If something else uses the address, `nonce too low` comes back; rather than wedging, the counter is re-read from the chain and the send retried once, counted under `nonce.resync{outcome}`. `local-setup.sh:171` is exactly this case — it hands the gateway the same key the deploy scripts use.
- **Lazy seeding.** The counter is seeded on first use, not at startup. Seeding during `build_app` made an unreachable RPC fatal at boot, which would crash-loop the pod on a transient dependency failure — `/health` backs both the liveness and the readiness probe, so there is no degraded state to fall back to. A failed seed now fails that batch, not the process.
- Batch strategies (`batcher/create.rs`, `batcher/ops.rs`) now only build a `TransactionRequest`; `tx_send_lock` is gone, replaced by the submitter.
- `services/common` gains `ProviderArgs::http_with_signer_address()` (the erased `DynProvider` drops the `WalletProvider` impl, so the address has to come from the builder) and a reusable `estimate_gas_with_fallback()` extracted from `GasEstimateWithFallbackFiller` so both paths share one implementation.

## Observability

New gauges `nonce.owned`, `nonce.latest`, `nonce.inflight`, `signer.balance_wei`, and counters `nonce.escalation{type,outcome}`, `nonce.terminal{type,reason}`, `nonce.release{outcome}`, `nonce.resync{outcome}`, `nonce.inflight_cap_reached`, `nonce.balance_floor`.

`nonce.terminal` is the one to alert on — every increment means a batch was abandoned and its requests failed. `nonce.owned` minus `nonce.latest` is the live gap, which is what was invisible before.

A non-zero `nonce.resync` rate means something other than this replica is using the signer — worth alerting on separately, since it silently breaks the sole-sender assumption the counter rests on.

## Rollout

All behaviour is env-configurable. `MAX_INFLIGHT_TXS=0` disables the cap and `MIN_BALANCE_WEI=0` disables the balance guard, so both new gating paths can be neutralised without a rollback. Escalation itself is inherent to the change; reverting the commit is the kill switch for that. Stage first — it runs a single replica, so the nonce-ownership path gets exercised in isolation.

## Test plan

- [x] `cargo nextest run --all-features -p world-id-gateway` — new `tests/test_nonce_gap.rs` runs anvil with auto-mining disabled and uses `anvil_dropTransaction` to reproduce the production failure directly:
  - a dropped transaction is re-broadcast at its original nonce, and the transaction queued behind it then mines
  - an exhausted escalation budget fails the batch's requests, releases the nonce, and unblocks the queue
  - the in-flight cap refuses a second batch while one is unconfirmed, and recovers capacity after confirmation
  - a balance floor above the signer's balance stops submission
- [x] Unit tests cover the error classifier and the config validation (`ESCALATION_FACTOR_PERCENT` must exceed 110 to clear geth's `--txpool.pricebump`).
- [ ] On stage: confirm `nonce.owned - nonce.latest` stays at or near zero under normal load, and that `nonce.terminal` stays flat.

All four `test_nonce_gap` tests and the full 584-test suite pass in CI on stable and nightly. `Cargo deny (advisories)` fails, but it fails identically on `main` at the base commit and the job is `continue-on-error: true`.

## Notes for review

- The escalation pass prunes in-flight entries whose nonce is already below `latest`. Without it, a lost receipt watcher would hold in-flight capacity for the process lifetime and eventually wedge the cap. Request finalization for those is the orphan sweeper's job, which looks the receipt up by hash.
- Abandoned requests are failed rather than requeued. Requeueing would recover them transparently, but if the abandoned transaction is later mined the operations would execute twice; failing is the safe default and matches today's semantics.
- Backpressure from the in-flight cap leaves requests `Queued`, which the sweeper fails after `STALE_QUEUED_THRESHOLD_SECS` (60s). So the cap buys a 60s grace window, not indefinite holding.
- #495 (`nonce too low` with a shared signer) is **not** in scope and appears to be stale: prod terraform provisions one KMS key per replica and publishes `AWS_KMS_KEY_IDS`. The secrets comment in `values-world-id-gateway-prod.yaml` still lists `WALLET_PRIVATE_KEY` and points at the *stage* terraform path — worth correcting separately.
- The root cause is reconstructed from the code and the #654 / #754 / #495 history. Production logs for the most recent occurrence were not consulted, so the reason the node keeps reporting an elevated `pending` count after a drop is not pinned down — a single node that drops nonce `N` normally rolls its own pending nonce back to `N`, which self-heals. A durable gap needs an additional cause (a transaction stuck rather than dropped, or divergent pool views behind a load-balanced endpoint). The fix does not depend on which of those it is: it covers both, and the new `nonce.*` metrics will identify it next time.
