### PR TITLE
chore: ignore RUSTSEC-2026-0255 (soundness), requires provekit bump

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -54,6 +54,7 @@ ignore = [
     "RUSTSEC-2026-0248", # Unmaintained `im`; transitive via `provekit`, requires bumps on `provekit`, no safe upgrade available (2026-08-10)
     "RUSTSEC-2026-0247", # Unmaintained `bitmaps`; pulled in by `im`, same chain (2026-08-10)
     "RUSTSEC-2026-0251", # Unmaintained `sized-chunks`; pulled in by `im`, same chain (2026-08-10)
+    "RUSTSEC-2026-0255", # Unsound `sized-chunks` panic safety in Chunk/RingBuffer/InlineArray; same `im` chain, archived upstream so no fix will ever ship (2026-08-11)
     "RUSTSEC-2023-0126", # Unsound `im` OrdSet aliasing; same provekit chain, unmaintained so no fix will ever ship (2023-02-04)
     "RUSTSEC-2026-0253"  # Unsound `lru` LruCache::pop panic safety; patched in >= 0.18.2, but alloy-provider pins `lru = "^0.16"` so it needs an alloy bump (2026-05-12)
 ]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Documents acceptance of a known unsound transitive crate with no upstream fix; risk is bounded to panic-safety in that dependency chain until provekit is upgraded.
> 
> **Overview**
> Adds **RUSTSEC-2026-0255** to `deny.toml`’s `[advisories].ignore` list so `cargo deny` / CI can pass despite the advisory.
> 
> The ignored issue is an **unsound panic-safety** finding in transitive **`sized-chunks`** (`Chunk` / `RingBuffer` / `InlineArray`), reached through the same **`im` → `provekit`** dependency chain as the existing `RUSTSEC-2026-0251` / `0247` / `0248` entries. The comment notes upstream is archived, so no fix is expected; a real remediation would require a **`provekit` bump** (or dropping that dependency path).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33d5956267c28a49b6f6d0009bda9c75d8e81fb9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->