### PR TITLE
feat(gateway): cycle submissions across wallet pool

### DIFF
--- a/services/common/src/alloy/provider.rs
+++ b/services/common/src/alloy/provider.rs
@@ -63,8 +63,12 @@ pub enum ProviderError {
         "exactly one of wallet_private_key, aws_kms_key_id, or aws_kms_key_ids must be provided"
     )]
     SignerConfigMissing,
-    #[error("pod ordinal {ordinal} is out of range: AWS_KMS_KEY_IDS contains {key_count} key(s)")]
+    #[error(
+        "pod ordinal {ordinal} is out of range: AWS_KMS_KEY_IDS contains {key_count} gateway slot(s)"
+    )]
     OrdinalOutOfRange { ordinal: usize, key_count: usize },
+    #[error("AWS_KMS_KEY_IDS gateway slot {ordinal} contains an empty KMS key ID")]
+    EmptyKmsKeyId { ordinal: usize },
     #[error(
         "AWS_KMS_KEY_IDS is set but pod ordinal could not be resolved from HOSTNAME \
          (got: {hostname:?}); ensure the pod hostname follows the StatefulSet convention \
@@ -116,9 +120,12 @@ pub struct SignerArgs {
     #[arg(long, env = "AWS_KMS_KEY_ID")]
     aws_kms_key_id: Option<String>,
 
-    /// Comma-separated list of AWS KMS key ARNs for per-replica signing (StatefulSet).
-    /// Pod ordinal is derived from the trailing numeric suffix of `HOSTNAME`
-    /// (e.g. `world-id-gateway-2` → ordinal 2 → third key in the list).
+    /// AWS KMS keys grouped by StatefulSet replica.
+    ///
+    /// Commas separate pod ordinals and semicolons separate wallets assigned to
+    /// one pod. For example, `key-a1;key-a2,key-b1;key-b2` assigns two wallets
+    /// to pod 0 and two to pod 1. The legacy `key-a,key-b` form still assigns
+    /// exactly one wallet to each pod.
     /// Mutually exclusive with `AWS_KMS_KEY_ID`.
     #[arg(long, env = "AWS_KMS_KEY_IDS")]
     aws_kms_key_ids: Option<String>,
@@ -135,6 +142,21 @@ fn pod_ordinal() -> Option<usize> {
     parse_ordinal(&std::env::var("HOSTNAME").ok()?)
 }
 
+fn kms_keys_for_ordinal(key_ids: &str, ordinal: usize) -> ProviderResult<Vec<String>> {
+    let groups: Vec<&str> = key_ids.split(',').collect();
+    let group = groups
+        .get(ordinal)
+        .ok_or(ProviderError::OrdinalOutOfRange {
+            ordinal,
+            key_count: groups.len(),
+        })?;
+    let keys: Vec<String> = group.split(';').map(|key| key.trim().to_string()).collect();
+    if keys.is_empty() || keys.iter().any(String::is_empty) {
+        return Err(ProviderError::EmptyKmsKeyId { ordinal });
+    }
+    Ok(keys)
+}
+
 /// Strips the url to leave only the host & port
 fn endpoint_label(url: &Url) -> String {
     let host = url.host_str().unwrap_or("unknown");
@@ -146,7 +168,8 @@ fn endpoint_label(url: &Url) -> String {
 }
 
 impl SignerArgs {
-    async fn signer(&self, rpc_url: &Url) -> ProviderResult<EthereumWallet> {
+    /// Build every signer assigned to this process.
+    pub async fn signers(&self, rpc_url: &Url) -> ProviderResult<Vec<EthereumWallet>> {
         match (
             &self.wallet_private_key,
             &self.aws_kms_key_id,
@@ -155,37 +178,28 @@ impl SignerArgs {
             (Some(s), None, None) => {
                 // PrivateKey: No RPC call needed
                 let signer = s.parse::<PrivateKeySigner>()?;
-                Ok(EthereumWallet::from(signer))
+                Ok(vec![EthereumWallet::from(signer)])
             }
             (None, Some(key_id), None) => {
                 tracing::info!("Initializing AWS KMS signer with key_id: {}", key_id);
-                Self::aws_kms_wallet(key_id, rpc_url).await
+                Ok(vec![Self::aws_kms_wallet(key_id, rpc_url).await?])
             }
             (None, None, Some(key_ids)) => {
                 let ordinal = pod_ordinal().ok_or_else(|| ProviderError::OrdinalUnresolvable {
                     hostname: std::env::var("HOSTNAME").ok(),
                 })?;
-                let keys: Vec<&str> = key_ids.split(',').map(str::trim).collect();
-                let key_id = keys.get(ordinal).copied().ok_or_else(|| {
-                    tracing::error!(
-                        ordinal,
-                        key_count = keys.len(),
-                        "Pod ordinal is out of range for AWS_KMS_KEY_IDS; \
-                         check that the key list has an entry for every replica"
-                    );
-                    ProviderError::OrdinalOutOfRange {
-                        ordinal,
-                        key_count: keys.len(),
-                    }
-                })?;
-                tracing::info!(ordinal, key_id, "Initializing per-replica AWS KMS signer");
-                Self::aws_kms_wallet(key_id, rpc_url).await
+                let keys = kms_keys_for_ordinal(key_ids, ordinal)?;
+                let mut wallets = Vec::with_capacity(keys.len());
+                for key_id in keys {
+                    tracing::info!(ordinal, key_id, "Initializing per-replica AWS KMS signer");
+                    wallets.push(Self::aws_kms_wallet(&key_id, rpc_url).await?);
+                }
+                Ok(wallets)
             }
-            // (None, None, None) — no signer configured at all.
+            (None, None, None) => Ok(Vec::new()),
             // Any multi-field combo is prevented at parse time by the clap
-            // `#[group(multiple = false)]` attribute; direct construction that
-            // reaches here is a programming error, but SignerConfigMissing is
-            // still the most actionable error for callers.
+            // `#[group(multiple = false)]` attribute. Direct construction that
+            // reaches here is a programming error.
             _ => Err(ProviderError::SignerConfigMissing),
         }
     }
@@ -237,8 +251,8 @@ impl SignerArgs {
         }
     }
 
-    /// Create a new `SignerArgs` with a comma-separated list of per-replica
-    /// AWS KMS key IDs (`AWS_KMS_KEY_IDS`).
+    /// Create `SignerArgs` with comma-separated replica slots and optional
+    /// semicolon-separated wallets inside each slot (`AWS_KMS_KEY_IDS`).
     pub fn from_aws_per_replica(aws_kms_key_ids: String) -> Self {
         Self {
             wallet_private_key: None,
@@ -351,40 +365,46 @@ impl ProviderArgs {
         self
     }
 
-    /// Build a dynamic provider from the configuration using the default
-    /// [`SimpleNonceManager`].
+    /// Build a provider for each signer assigned to this process using the
+    /// default [`SimpleNonceManager`]. Configurations without a signer return
+    /// one read-only provider.
     ///
     /// The simple manager fetches the pending transaction count for each
     /// transaction instead of incrementing a process-local nonce cache.
-    pub async fn http(self) -> ProviderResult<DynProvider> {
+    pub async fn http(self) -> ProviderResult<Vec<DynProvider>> {
         self.http_with_nonce_manager(SimpleNonceManager::default())
             .await
     }
 
-    /// Builds a signer-backed provider wallet.
-    pub async fn http_wallet(self) -> ProviderResult<ProviderWallet> {
+    /// Builds one provider wallet for each signer assigned to this process.
+    pub async fn http_wallets(self) -> ProviderResult<Vec<ProviderWallet>> {
         self.http_with_nonce_manager_and_address(SimpleNonceManager::default())
             .await?
-            .try_into_wallet()
+            .into_iter()
+            .map(ConfiguredProvider::try_into_wallet)
+            .collect()
     }
 
-    /// Build a dynamic provider using a caller-supplied [`NonceManager`].
-    ///
-    /// This allows injecting a distributed nonce manager (e.g. Redis-backed)
-    /// for safe multi-replica transaction submission with a shared signer.
-    pub async fn http_with_nonce_manager<M: NonceManager + 'static>(
+    /// Build a provider for each signer using a caller-supplied [`NonceManager`].
+    /// Configurations without a signer return one read-only provider.
+    pub async fn http_with_nonce_manager<M: NonceManager + Clone + 'static>(
         self,
         nonce_manager: M,
-    ) -> ProviderResult<DynProvider> {
+    ) -> ProviderResult<Vec<DynProvider>> {
         self.http_with_nonce_manager_and_address(nonce_manager)
             .await
-            .map(ConfiguredProvider::into_provider)
+            .map(|providers| {
+                providers
+                    .into_iter()
+                    .map(ConfiguredProvider::into_provider)
+                    .collect()
+            })
     }
 
-    async fn http_with_nonce_manager_and_address<M: NonceManager + 'static>(
+    async fn http_with_nonce_manager_and_address<M: NonceManager + Clone + 'static>(
         self,
         nonce_manager: M,
-    ) -> ProviderResult<ConfiguredProvider> {
+    ) -> ProviderResult<Vec<ConfiguredProvider>> {
         if self.http.is_empty() {
             return Err(ProviderError::NoHttpUrls);
         }
@@ -456,34 +476,35 @@ impl ProviderArgs {
             RpcClient::builder().transport(transport, false)
         };
 
-        let maybe_signer = if self.signer.signer_config().is_some() {
-            // Pass the first URL to the signer - it will only make RPC calls if needed (AWS KMS)
-            Some(self.signer.signer(&first_url).await?)
-        } else {
-            None
-        };
+        // Pass the first URL to the signers - it will only make RPC calls if needed (AWS KMS)
+        let signers = self.signer.signers(&first_url).await?;
 
-        if let Some(wallet) = maybe_signer {
-            let provider = ProviderBuilder::default()
-                .with_gas_estimation() // It is important to have default run first
-                .filler(GasEstimateWithFallbackFiller) // And then our custom filler
-                .with_blob_gas_estimation()
-                .with_nonce_management(nonce_manager)
-                .fetch_chain_id()
-                .wallet(wallet.clone())
-                .connect_client(client);
-
-            Ok(ConfiguredProvider {
-                provider: provider.erased(),
-                wallet: Some(wallet),
-            })
-        } else {
+        if signers.is_empty() {
             let provider = ProviderBuilder::default().connect_client(client);
-            Ok(ConfiguredProvider {
+            return Ok(vec![ConfiguredProvider {
                 provider: provider.erased(),
                 wallet: None,
-            })
+            }]);
         }
+
+        Ok(signers
+            .into_iter()
+            .map(|wallet| {
+                let provider = ProviderBuilder::default()
+                    .with_gas_estimation()
+                    .filler(GasEstimateWithFallbackFiller)
+                    .with_blob_gas_estimation()
+                    .with_nonce_management(nonce_manager.clone())
+                    .fetch_chain_id()
+                    .wallet(wallet.clone())
+                    .connect_client(client.clone());
+
+                ConfiguredProvider {
+                    provider: provider.erased(),
+                    wallet: Some(wallet),
+                }
+            })
+            .collect())
     }
 }
 
@@ -599,6 +620,33 @@ mod tests {
         assert_eq!(parse_ordinal("gateway"), None);
     }
 
+    #[test]
+    fn kms_keys_for_ordinal_supports_multiple_wallets_per_slot() {
+        assert_eq!(
+            kms_keys_for_ordinal("key-a1; key-a2,key-b1;key-b2", 0).unwrap(),
+            ["key-a1", "key-a2"]
+        );
+        assert_eq!(
+            kms_keys_for_ordinal("key-a1; key-a2,key-b1;key-b2", 1).unwrap(),
+            ["key-b1", "key-b2"]
+        );
+    }
+
+    #[test]
+    fn kms_keys_for_ordinal_rejects_invalid_slots() {
+        assert!(matches!(
+            kms_keys_for_ordinal("key-a1;;key-a2,key-b", 0),
+            Err(ProviderError::EmptyKmsKeyId { ordinal: 0 })
+        ));
+        assert!(matches!(
+            kms_keys_for_ordinal("key-a,key-b", 2),
+            Err(ProviderError::OrdinalOutOfRange {
+                ordinal: 2,
+                key_count: 2
+            })
+        ));
+    }
+
     // ── SignerArgs::is_per_replica_signer() ──────────────────────────────────
 
     #[test]
@@ -646,21 +694,21 @@ mod tests {
     async fn http_wallet_exposes_signer_address() {
         let private_key = "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d";
         let signer: PrivateKeySigner = private_key.parse().unwrap();
-        let wallet = ProviderArgs::new()
+        let wallets = ProviderArgs::new()
             .with_http_urls(["http://127.0.0.1:8545"])
             .with_signer(SignerArgs::from_wallet(private_key.to_string()))
-            .http_wallet()
+            .http_wallets()
             .await
             .unwrap();
 
-        assert_eq!(wallet.address, signer.address());
+        assert_eq!(wallets[0].address, signer.address());
     }
 
     #[tokio::test]
     async fn http_wallet_requires_signer() {
         let result = ProviderArgs::new()
             .with_http_urls(["http://127.0.0.1:8545"])
-            .http_wallet()
+            .http_wallets()
             .await;
 
         assert!(matches!(result, Err(ProviderError::SignerConfigMissing)));

--- a/services/common/tests/provider.rs
+++ b/services/common/tests/provider.rs
@@ -102,7 +102,7 @@ async fn retry_succeeds_on_transient_http_error() {
         .await
         .unwrap();
 
-    let chain_id = provider.get_chain_id().await.unwrap();
+    let chain_id = provider[0].get_chain_id().await.unwrap();
     assert_eq!(chain_id, 1);
     assert_eq!(counter.load(Ordering::SeqCst), 3);
 }
@@ -148,7 +148,7 @@ async fn fallback_succeeds_when_endpoint_times_out() {
         .await
         .unwrap();
 
-    let chain_id = provider.get_chain_id().await.unwrap();
+    let chain_id = provider[0].get_chain_id().await.unwrap();
     assert_eq!(chain_id, 1);
     assert!(slow_counter.load(Ordering::SeqCst) >= 1);
     assert!(fast_counter.load(Ordering::SeqCst) >= 1);
@@ -167,7 +167,7 @@ async fn max_retries_exhausted_returns_error() {
         .await
         .unwrap();
 
-    let result = provider.get_chain_id().await;
+    let result = provider[0].get_chain_id().await;
     assert!(result.is_err());
     assert_eq!(counter.load(Ordering::SeqCst), 3); // 1 initial + 2 retries
 }
@@ -195,7 +195,7 @@ async fn contract_revert_not_retried() {
         .await
         .unwrap();
 
-    let result = provider.get_chain_id().await;
+    let result = provider[0].get_chain_id().await;
     assert!(result.is_err());
     assert_eq!(counter.load(Ordering::SeqCst), 1);
 }
@@ -221,7 +221,7 @@ async fn fallback_succeeds_when_endpoint_is_dead() {
         .await
         .unwrap();
 
-    let chain_id = provider.get_chain_id().await.unwrap();
+    let chain_id = provider[0].get_chain_id().await.unwrap();
     assert_eq!(chain_id, 1);
     assert!(live_counter.load(Ordering::SeqCst) >= 1);
 }
@@ -272,7 +272,7 @@ async fn retry_after_tcp_reset_on_same_endpoint() {
         .await
         .unwrap();
 
-    let chain_id = provider.get_chain_id().await.unwrap();
+    let chain_id = provider[0].get_chain_id().await.unwrap();
     assert_eq!(chain_id, 1);
     assert!(counter.load(Ordering::SeqCst) >= 2);
 }
@@ -290,7 +290,7 @@ async fn retries_disabled_when_max_retries_zero() {
         .await
         .unwrap();
 
-    let result = provider.get_chain_id().await;
+    let result = provider[0].get_chain_id().await;
     assert!(result.is_err());
     assert_eq!(counter.load(Ordering::SeqCst), 1);
 }
@@ -316,7 +316,7 @@ async fn endpoint_metrics_record_transport_outcomes() {
         .http()
         .await
         .unwrap();
-    assert!(dead_provider.get_chain_id().await.is_err());
+    assert!(dead_provider[0].get_chain_id().await.is_err());
 
     // Provide for successful transport call.
     let (live_url, _live_counter) = spawn_mock_rpc(|_| success_response()).await;
@@ -326,7 +326,7 @@ async fn endpoint_metrics_record_transport_outcomes() {
         .http()
         .await
         .unwrap();
-    assert_eq!(live_provider.get_chain_id().await.unwrap(), 1);
+    assert_eq!(live_provider[0].get_chain_id().await.unwrap(), 1);
 
     let snapshot = snapshotter.snapshot().into_vec();
     // Sum the `rpc.endpoint_requests` counter value for the given endpoint and

--- a/services/gateway/src/lib.rs
+++ b/services/gateway/src/lib.rs
@@ -52,15 +52,15 @@ pub async fn spawn_gateway_for_tests(cfg: GatewayConfig) -> GatewayResult<Gatewa
     let rate_limit = cfg.rate_limit();
     let sweeper_config = cfg.sweeper();
 
-    let wallet = cfg.provider.clone().http_wallet().await?;
-    let provider = Arc::new(wallet.provider.clone());
+    let wallets = cfg.provider.clone().http_wallets().await?;
+    let provider = Arc::new(wallets[0].provider.clone());
     let registry = Arc::new(WorldIdRegistryInstance::new(
         cfg.registry_addr,
         provider.clone(),
     ));
     let app = build_app(
         registry,
-        wallet,
+        wallets,
         cfg.registry_version,
         batcher_config,
         cfg.redis_url,
@@ -109,8 +109,8 @@ pub async fn run() -> GatewayResult<()> {
     let rate_limit = cfg.rate_limit();
     let sweeper_config = cfg.sweeper();
 
-    let wallet = cfg.provider.clone().http_wallet().await?;
-    let provider = Arc::new(wallet.provider.clone());
+    let wallets = cfg.provider.clone().http_wallets().await?;
+    let provider = Arc::new(wallets[0].provider.clone());
     let registry = Arc::new(WorldIdRegistryInstance::new(
         cfg.registry_addr,
         provider.clone(),
@@ -121,7 +121,7 @@ pub async fn run() -> GatewayResult<()> {
     );
     let app = build_app(
         registry,
-        wallet,
+        wallets,
         cfg.registry_version,
         batcher_config,
         cfg.redis_url,

--- a/services/gateway/src/routes.rs
+++ b/services/gateway/src/routes.rs
@@ -85,7 +85,7 @@ const OPS_BATCHER_CHANNEL_CAPACITY: usize = 2048;
 #[expect(clippy::too_many_arguments)]
 pub(crate) async fn build_app(
     registry: Arc<WorldIdRegistryInstance<Arc<DynProvider>>>,
-    wallet: ProviderWallet,
+    wallets: Vec<ProviderWallet>,
     registry_version: RegistryVersion,
     batcher_config: BatcherConfig,
     redis_url: String,
@@ -97,7 +97,7 @@ pub(crate) async fn build_app(
     let tracker = RequestTracker::new(redis_url.clone(), rate_limit).await;
     let submitter = TransactionSubmitter::connect(
         *registry.address(),
-        wallet,
+        wallets,
         &redis_url,
         tracker.clone(),
         Duration::from_secs(orphan_sweeper_config.interval_secs),

--- a/services/gateway/src/transaction_submitter.rs
+++ b/services/gateway/src/transaction_submitter.rs
@@ -1,13 +1,21 @@
-use std::{sync::Arc, time::Duration};
+use std::{
+    collections::HashSet,
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+    time::Duration,
+};
 
 use alloy::{primitives::Address, providers::Provider, rpc::types::TransactionRequest};
+use tokio::sync::Notify;
 use uuid::Uuid;
 use world_id_primitives::api_types::{GatewayErrorCode, GatewayRequestState};
 use world_id_registries::world_id::WorldIdRegistry::WorldIdRegistryInstance;
 use world_id_services_common::ProviderWallet;
 
 use crate::{
-    error::GatewayResult,
+    error::{GatewayError, GatewayResult},
     metrics,
     request_tracker::{RequestTracker, now_unix_secs},
     storage::wallet_store::{WalletStore, WalletTransaction},
@@ -22,14 +30,16 @@ struct WalletEntry {
 }
 
 struct TransactionSubmitterInner {
-    wallet: WalletEntry,
+    wallets: Vec<WalletEntry>,
     store: WalletStore,
     tracker: RequestTracker,
+    next: AtomicUsize,
+    released: Notify,
     receipt_timeout: Duration,
     tracker_interval: Duration,
 }
 
-/// Signs, persists, broadcasts, and tracks transactions for the configured wallet.
+/// Signs, persists, broadcasts, and tracks transactions for configured wallets.
 #[derive(Clone)]
 pub(crate) struct TransactionSubmitter {
     inner: Arc<TransactionSubmitterInner>,
@@ -39,24 +49,40 @@ impl TransactionSubmitter {
     /// Creates a submitter and starts its persistent receipt tracker.
     pub(crate) async fn connect(
         registry_address: Address,
-        wallet: ProviderWallet,
+        wallets: Vec<ProviderWallet>,
         redis_url: &str,
         tracker: RequestTracker,
         tracker_interval: Duration,
         receipt_timeout: Duration,
     ) -> GatewayResult<Self> {
-        let wallet = WalletEntry {
-            registry: Arc::new(WorldIdRegistryInstance::new(
-                registry_address,
-                Arc::new(wallet.provider.clone()),
-            )),
-            wallet,
-        };
+        if wallets.is_empty() {
+            return Err(GatewayError::Config(
+                "at least one transaction wallet must be configured".to_string(),
+            ));
+        }
+        let addresses: HashSet<Address> = wallets.iter().map(|wallet| wallet.address).collect();
+        if addresses.len() != wallets.len() {
+            return Err(GatewayError::Config(
+                "transaction wallet addresses must be unique".to_string(),
+            ));
+        }
+        let wallets = wallets
+            .into_iter()
+            .map(|wallet| WalletEntry {
+                registry: Arc::new(WorldIdRegistryInstance::new(
+                    registry_address,
+                    Arc::new(wallet.provider.clone()),
+                )),
+                wallet,
+            })
+            .collect();
         let submitter = Self {
             inner: Arc::new(TransactionSubmitterInner {
-                wallet,
+                wallets,
                 store: WalletStore::connect(redis_url).await?,
                 tracker,
+                next: AtomicUsize::new(0),
+                released: Notify::new(),
                 receipt_timeout,
                 tracker_interval,
             }),
@@ -180,22 +206,26 @@ impl TransactionSubmitter {
 
     async fn acquire(&self) -> GatewayResult<TransactionLease> {
         loop {
-            let entry = self.inner.wallet.clone();
-            let reservation_id = Uuid::new_v4();
-            if self
-                .inner
-                .store
-                .reserve(entry.wallet.address, reservation_id)
-                .await?
-            {
-                return Ok(TransactionLease {
-                    submitter: self.clone(),
-                    entry,
-                    reservation_id,
-                });
+            let start = self.inner.next.fetch_add(1, Ordering::Relaxed);
+            for offset in 0..self.inner.wallets.len() {
+                let entry = self.inner.wallets[(start + offset) % self.inner.wallets.len()].clone();
+                let reservation_id = Uuid::new_v4();
+                if self
+                    .inner
+                    .store
+                    .reserve(entry.wallet.address, reservation_id)
+                    .await?
+                {
+                    return Ok(TransactionLease {
+                        submitter: self.clone(),
+                        entry,
+                        reservation_id,
+                    });
+                }
             }
 
-            tokio::time::sleep(WALLET_RECHECK_INTERVAL).await;
+            let notified = self.inner.released.notified();
+            let _ = tokio::time::timeout(WALLET_RECHECK_INTERVAL, notified).await;
         }
     }
 
@@ -209,15 +239,18 @@ impl TransactionSubmitter {
     }
 
     async fn track_transactions(&self) -> GatewayResult<()> {
-        let entry = &self.inner.wallet;
-        let transactions = self
+        let addresses: Vec<Address> = self
             .inner
-            .store
-            .transactions(&[entry.wallet.address])
-            .await?;
-        if let Some(Some(transaction @ WalletTransaction::Submitted { .. })) =
-            transactions.into_iter().next()
-        {
+            .wallets
+            .iter()
+            .map(|entry| entry.wallet.address)
+            .collect();
+        let transactions = self.inner.store.transactions(&addresses).await?;
+
+        for (entry, transaction) in self.inner.wallets.iter().zip(transactions) {
+            let Some(transaction @ WalletTransaction::Submitted { .. }) = transaction else {
+                continue;
+            };
             self.track_transaction(entry, transaction).await;
         }
         Ok(())
@@ -337,6 +370,8 @@ impl TransactionSubmitter {
             .await
         {
             tracing::error!(%error, %wallet, "failed to release tracked wallet transaction");
+        } else {
+            self.inner.released.notify_one();
         }
     }
 }
@@ -361,6 +396,8 @@ impl TransactionLease {
                 wallet = %self.entry.wallet.address,
                 "failed to release wallet reservation"
             );
+        } else {
+            self.submitter.inner.released.notify_one();
         }
     }
 }
@@ -407,6 +444,35 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn submitter_cycles_through_available_wallets() {
+        let (url, _redis) = redis_url().await;
+        let tracker = RequestTracker::new(url.clone(), None).await;
+        let first = address!("1111111111111111111111111111111111111111");
+        let second = address!("2222222222222222222222222222222222222222");
+        let submitter = TransactionSubmitter::connect(
+            Address::ZERO,
+            vec![provider_wallet(first), provider_wallet(second)],
+            &url,
+            tracker,
+            Duration::from_secs(60),
+            Duration::from_secs(60),
+        )
+        .await
+        .unwrap();
+
+        let first_lease = submitter.acquire().await.unwrap();
+        let second_lease = submitter.acquire().await.unwrap();
+        assert_eq!(first_lease.entry.wallet.address, first);
+        assert_eq!(second_lease.entry.wallet.address, second);
+
+        first_lease.release_reservation().await;
+        let next_lease = submitter.acquire().await.unwrap();
+        assert_eq!(next_lease.entry.wallet.address, first);
+        next_lease.release_reservation().await;
+        second_lease.release_reservation().await;
+    }
+
+    #[tokio::test]
     async fn tracker_fails_timed_out_transaction_and_releases_wallet() {
         let (url, _redis) = redis_url().await;
         let tracker = RequestTracker::new(url.clone(), None).await;
@@ -421,7 +487,7 @@ mod tests {
         let wallet = address!("1111111111111111111111111111111111111111");
         let submitter = TransactionSubmitter::connect(
             Address::ZERO,
-            provider_wallet(wallet),
+            vec![provider_wallet(wallet)],
             &url,
             tracker.clone(),
             Duration::from_secs(60),

--- a/services/indexer/src/blockchain/mod.rs
+++ b/services/indexer/src/blockchain/mod.rs
@@ -49,8 +49,7 @@ impl Blockchain {
     ///
     /// # Arguments
     ///
-    /// * `http_provider` - A pre-built HTTP provider (e.g. from
-    ///   [`ProviderArgs::http()`](world_id_services_common::ProviderArgs::http)).
+    /// * `http_provider` - A pre-built HTTP provider (e.g. one entry from [`ProviderArgs::http()`]).
     /// * `world_id_registry` - The address of the World ID registry.
     pub fn new(http_provider: DynProvider, world_id_registry: Address) -> Self {
         Self {

--- a/services/indexer/src/lib.rs
+++ b/services/indexer/src/lib.rs
@@ -124,7 +124,8 @@ pub async unsafe fn run_indexer(cfg: GlobalConfig) -> eyre::Result<()> {
     db.run_migrations().await?;
     tracing::info!("🟢 DB successfully created .");
 
-    let http_provider = cfg.provider.http().await?;
+    let http_providers = cfg.provider.http().await?;
+    let http_provider = http_providers[0].clone();
 
     match cfg.run_mode {
         RunMode::IndexerOnly { indexer_config } => {

--- a/services/indexer/tests/test_blockchain_streams.rs
+++ b/services/indexer/tests/test_blockchain_streams.rs
@@ -72,13 +72,13 @@ async fn test_pull_events_emits_after_poll() {
         .await
         .expect("failed to deploy registry");
 
-    let provider = ProviderArgs::new()
+    let providers = ProviderArgs::new()
         .with_http_urls([anvil.endpoint()])
         .http()
         .await
-        .expect("failed to build provider");
+        .expect("failed to build providers");
 
-    let blockchain = Blockchain::new(provider.clone(), registry_address);
+    let blockchain = Blockchain::new(providers[0].clone(), registry_address);
 
     let http_provider =
         ProviderBuilder::new().connect_http(anvil.endpoint().parse::<url::Url>().unwrap());
@@ -149,14 +149,14 @@ async fn test_pull_stream_stops_on_error() {
         .await
         .expect("failed to deploy registry");
 
-    let provider = ProviderArgs::new()
-        .with_http_urls([anvil.endpoint()])
-        .with_max_rpc_retries(0)
+    let mut provider_args = ProviderArgs::new().with_http_urls([anvil.endpoint()]);
+    provider_args.retry.max_retries = 0;
+    let providers = provider_args
         .http()
         .await
-        .expect("failed to build provider");
+        .expect("failed to build providers");
 
-    let blockchain = Blockchain::new(provider.clone(), registry_address);
+    let blockchain = Blockchain::new(providers[0].clone(), registry_address);
 
     let http_provider =
         ProviderBuilder::new().connect_http(anvil.endpoint().parse::<url::Url>().unwrap());


### PR DESCRIPTION
## Summary

- allow each gateway ordinal to configure multiple KMS wallets with semicolon-separated key IDs
- construct one provider stack per configured wallet
- reject duplicate wallet addresses
- reserve wallets in Redis and cycle submissions across available wallets
- resume tracking persisted wallet transactions after restart

The previous PR in this stack introduces durable single-wallet submission. This PR enables multiple wallets and adds pool scheduling.

## Stack

Previous: #937

## Validation

- common provider tests
- gateway unit tests, including wallet cycling and timeout release
- Redis and Anvil integration test
- indexer tests
- `cargo +nightly fmt --all -- --check`
- focused Clippy with warnings denied

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes on-chain submission paths (multi-wallet nonces, Redis reservations, and config parsing); mistakes could affect throughput or double-use wallets, but behavior is guarded by uniqueness checks and existing durable submission flow.
> 
> **Overview**
> Enables **multiple signing wallets per gateway replica** and **round-robin submission** across them instead of a single wallet per process.
> 
> **Provider / KMS config:** `AWS_KMS_KEY_IDS` now uses **comma-separated pod slots** and **semicolon-separated keys within a slot** (legacy one-key-per-pod still works). `SignerArgs::signers()` and `ProviderArgs::http()` / `http_wallets()` return **vectors**—one stack per signer, with `EmptyKmsKeyId` validation for bad slots.
> 
> **Gateway:** `TransactionSubmitter` takes a wallet pool, rejects empty or duplicate addresses, **reserves wallets in Redis** with rotating start index, and **notifies waiters** when a wallet is released. Receipt tracking runs for **all** configured wallets. Call sites use `http_wallets()` and pass the full pool into `build_app`.
> 
> **Tests / callers:** Provider and indexer tests updated for `Vec<DynProvider>`; new unit tests cover KMS slot parsing and wallet cycling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c209b50b22bf5ad3e924f0d2151dc287c0bc3df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->