### PR TITLE
test(gateway): cover rate limiter with Redis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3181,7 +3181,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4077,7 +4077,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5427,7 +5427,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7276,7 +7276,7 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -7991,7 +7991,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8932,7 +8932,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9012,7 +9012,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 1.0.6",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10633,7 +10633,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10715,6 +10715,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "test-case"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2550dd13afcd286853192af8601920d959b14c401fcece38071d53bf0768a8"
+dependencies = [
+ "test-case-macros",
+]
+
+[[package]]
+name = "test-case-core"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adcb7fd841cd518e279be3d5a3eb0636409487998a4aff22f3de87b81e88384f"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "test-case-macros"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "test-case-core",
 ]
 
 [[package]]
@@ -12079,7 +12112,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12712,6 +12745,7 @@ dependencies = [
  "strum 0.27.2",
  "taceo-eddsa-babyjubjub",
  "telemetry-batteries",
+ "test-case",
  "testcontainers",
  "testcontainers-modules",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,6 +139,7 @@ semaphore-rs-hasher = "0.5.0"
 semaphore-rs-trees = "0.5.0"
 semaphore-rs-storage = "0.5.0"
 serial_test = "3"
+test-case = "3"
 testcontainers = { version = "0.27", features = ["http_wait_plain", "host-port-exposure"] }
 testcontainers-modules = { version = "0.15", features = ["redis"] }
 sqlx = "0.8"

--- a/services/gateway/Cargo.toml
+++ b/services/gateway/Cargo.toml
@@ -54,6 +54,7 @@ reqwest = { workspace = true }
 rustls = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+test-case = { workspace = true }
 testcontainers = { workspace = true }
 testcontainers-modules = { workspace = true }
 

--- a/services/gateway/Cargo.toml
+++ b/services/gateway/Cargo.toml
@@ -43,7 +43,7 @@ tracing-subscriber = { workspace = true, features = ["json"] }
 telemetry-batteries = { workspace = true }
 metrics = { workspace = true }
 utoipa = { workspace = true }
-uuid = { workspace = true, features = ["v4"] }
+uuid = { workspace = true, features = ["serde", "v4"] }
 
 [dev-dependencies]
 world-id-test-utils = { workspace = true }

--- a/services/gateway/src/lib.rs
+++ b/services/gateway/src/lib.rs
@@ -23,6 +23,7 @@ mod request;
 mod request_store;
 pub mod request_tracker;
 mod routes;
+mod storage;
 mod types;
 
 // Re-export common types

--- a/services/gateway/src/storage/assignment_repository.rs
+++ b/services/gateway/src/storage/assignment_repository.rs
@@ -1,0 +1,76 @@
+use alloy::primitives::Address;
+use redis::aio::ConnectionManager;
+
+use crate::{
+    error::GatewayResult,
+    storage::types::{Assignment, BatchId, Timestamp},
+};
+
+/// Durable mapping between locally configured wallet addresses and batches.
+///
+/// # Redis schema
+///
+/// - `gateway:wallet-assignment:<address>` stores the [`BatchId`] currently
+///   assigned to that address.
+/// - `gateway:batch:<batch-id>` stores the reciprocal wallet address in its
+///   assigned, pending, or included state.
+///
+/// Redis does not store wallet configuration, enabled/disabled status, idle
+/// state, KMS key IDs, or quarantine state. The gateway derives its candidate
+/// addresses from local configuration and resolves nonce inconsistencies using
+/// chain RPC. The assignment key exists to prevent one address from owning two
+/// batches and is changed atomically with the batch record.
+#[derive(Clone)]
+pub(crate) struct AssignmentRepository {
+    manager: ConnectionManager,
+}
+
+impl AssignmentRepository {
+    /// Creates a repository backed by the supplied Redis connection manager.
+    ///
+    /// This does not read or modify any Redis key.
+    pub(crate) fn new(manager: ConnectionManager) -> Self {
+        unimplemented!()
+    }
+
+    /// Assigns one ready batch to one unassigned local wallet address.
+    ///
+    /// Atomically selects an address from `candidate_wallets` without a
+    /// `gateway:wallet-assignment:<address>` key, removes one batch from
+    /// `gateway:batches:ready`, creates the assignment key, and moves the batch
+    /// from ready to assigned. Candidate order defines wallet preference.
+    ///
+    /// `candidate_wallets` must contain only locally configured, enabled wallets
+    /// whose KMS keys are available to this gateway. Disabled wallets are omitted
+    /// here but must still be passed to [`Self::assigned_many`] until drained.
+    pub(crate) async fn assign_ready(
+        &self,
+        candidate_wallets: &[Address],
+        assigned_at: Timestamp,
+    ) -> GatewayResult<Option<Assignment>> {
+        unimplemented!()
+    }
+
+    /// Loads the active assignment for one locally configured wallet.
+    ///
+    /// Reads `gateway:wallet-assignment:<address>` and the referenced
+    /// `gateway:batch:<batch-id>`. Returns `None` when the assignment key does
+    /// not exist. A missing or mismatched batch record is a storage
+    /// inconsistency, not an idle wallet.
+    pub(crate) async fn assigned(&self, wallet: Address) -> GatewayResult<Option<Assignment>> {
+        unimplemented!()
+    }
+
+    /// Loads active assignments for locally configured wallet addresses.
+    ///
+    /// Reads only the supplied addresses, including disabled wallets retained
+    /// for draining. Redis never enumerates or introduces wallets to the gateway.
+    /// Results contain assignments whose reciprocal
+    /// batch records agree with their assignment keys.
+    pub(crate) async fn assigned_many(
+        &self,
+        wallets: &[Address],
+    ) -> GatewayResult<Vec<Assignment>> {
+        unimplemented!()
+    }
+}

--- a/services/gateway/src/storage/batch_repository.rs
+++ b/services/gateway/src/storage/batch_repository.rs
@@ -1,0 +1,149 @@
+use alloy::primitives::{B256, TxHash};
+use redis::aio::ConnectionManager;
+
+use crate::{
+    error::GatewayResult,
+    storage::types::{Batch, BatchId, BatchKind, NewBatch, PreparedSubmission, Timestamp},
+};
+
+/// Result of attempting to atomically seal requests into an immutable batch.
+#[derive(Debug, Eq, PartialEq)]
+pub(crate) enum SealBatchOutcome {
+    /// The batch was persisted and published to the ready queue.
+    Sealed(BatchId),
+    /// At least one request was no longer queued; storage was not changed.
+    RequestsNoLongerQueued,
+}
+
+/// Durable batch records, ready-queue indexing, and submission write-ahead log.
+///
+/// # Redis schema
+///
+/// - `gateway:batch:<batch-id>` stores one serialized [`Batch`], including its
+///   immutable request IDs and intent, mutable state, and signed submission.
+/// - `gateway:batches:ready` is a sorted set of ready batch IDs ordered by
+///   `created_at` with a stable tie-breaker.
+///
+/// Atomic transitions also operate on request, wallet-assignment, and resource keys
+/// owned by the other storage modules. The batch record is the source of truth;
+/// the ready sorted set is an availability index.
+#[derive(Clone)]
+pub(crate) struct BatchRepository {
+    manager: ConnectionManager,
+}
+
+impl BatchRepository {
+    /// Creates a repository backed by the supplied Redis connection manager.
+    ///
+    /// This does not read or modify any Redis key.
+    pub(crate) fn new(manager: ConnectionManager) -> Self {
+        unimplemented!()
+    }
+
+    /// Seals queued requests into an immutable batch and publishes it as ready.
+    ///
+    /// Atomically verifies the corresponding `gateway:request:<request-id>`
+    /// records are queued, writes `gateway:batch:<batch-id>`, changes each
+    /// request to `Batched(batch-id)`, removes the request IDs from their sorted
+    /// queue, and adds the batch ID to `gateway:batches:ready`.
+    pub(crate) async fn seal(&self, batch: NewBatch) -> GatewayResult<SealBatchOutcome> {
+        unimplemented!()
+    }
+
+    /// Loads one batch from `gateway:batch:<batch-id>`.
+    ///
+    /// Returns `None` when the record does not exist. The ready queue and wallet
+    /// assignment indexes are not consulted.
+    pub(crate) async fn load(&self, batch_id: BatchId) -> GatewayResult<Option<Batch>> {
+        unimplemented!()
+    }
+
+    /// Counts batches in `gateway:batches:ready`.
+    ///
+    /// When `kind` is set, batch records are inspected to count only that kind;
+    /// otherwise this returns the sorted-set cardinality.
+    pub(crate) async fn ready_len(&self, kind: Option<BatchKind>) -> GatewayResult<usize> {
+        unimplemented!()
+    }
+
+    /// Persists the batch's signed transaction before broadcast.
+    ///
+    /// Atomically stores `submission` in `gateway:batch:<batch-id>` and moves the
+    /// batch from assigned to pending. A batch accepts exactly one submission.
+    /// The caller must confirm this write before sending the signed bytes to an
+    /// RPC provider.
+    pub(crate) async fn record_prepared_submission(
+        &self,
+        batch_id: BatchId,
+        submission: PreparedSubmission,
+    ) -> GatewayResult<()> {
+        unimplemented!()
+    }
+
+    /// Marks the prepared submission as broadcast after the RPC call returns.
+    ///
+    /// Verifies `tx_hash` matches the submission in
+    /// `gateway:batch:<batch-id>` and records `broadcast_at`. The signed bytes
+    /// remain stored for reconciliation and idempotent rebroadcast.
+    pub(crate) async fn mark_submission_broadcast(
+        &self,
+        batch_id: BatchId,
+        tx_hash: TxHash,
+        broadcast_at: Timestamp,
+    ) -> GatewayResult<()> {
+        unimplemented!()
+    }
+
+    /// Records receipt inclusion for the batch transaction.
+    ///
+    /// Updates `gateway:batch:<batch-id>` with the transaction hash, block hash,
+    /// and block number. It does not release the wallet or finalize requests;
+    /// those changes wait for canonical safe-block confirmation.
+    pub(crate) async fn mark_included(
+        &self,
+        batch_id: BatchId,
+        tx_hash: TxHash,
+        block_hash: B256,
+        block_number: u64,
+        included_at: Timestamp,
+    ) -> GatewayResult<()> {
+        unimplemented!()
+    }
+
+    /// Atomically finalizes the batch and all of its requests at safe confirmation.
+    ///
+    /// Updates `gateway:batch:<batch-id>` and each
+    /// `gateway:request:<request-id>`, deletes their
+    /// `gateway:resource:<resource-id>` locks, and deletes the matching
+    /// `gateway:wallet-assignment:<address>` key. Wallet eligibility remains in
+    /// local gateway configuration.
+    pub(crate) async fn finalize(
+        &self,
+        batch_id: BatchId,
+        tx_hash: TxHash,
+        finalized_at: Timestamp,
+    ) -> GatewayResult<()> {
+        unimplemented!()
+    }
+
+    /// Atomically fails a batch after safe revert or receipt-timeout expiry.
+    ///
+    /// A timeout is measured from [`PreparedSubmission::submitted_at`]. The
+    /// caller must enforce the configured duration, verify no receipt exists,
+    /// and verify the latest chain nonce has not advanced past the submitted
+    /// nonce before invoking this transition.
+    ///
+    /// Updates `gateway:batch:<batch-id>` and each
+    /// `gateway:request:<request-id>`, deletes their
+    /// `gateway:resource:<resource-id>` locks, and deletes the matching
+    /// `gateway:wallet-assignment:<address>` key. Wallet eligibility remains in
+    /// local gateway configuration.
+    pub(crate) async fn fail(
+        &self,
+        batch_id: BatchId,
+        reason: String,
+        resolved_at: Timestamp,
+    ) -> GatewayResult<()> {
+        unimplemented!()
+    }
+}

--- a/services/gateway/src/storage/mod.rs
+++ b/services/gateway/src/storage/mod.rs
@@ -7,6 +7,8 @@ mod rate_limiter;
 mod request_repository;
 mod types;
 
+use redis::{Client, aio::ConnectionManager};
+
 use crate::error::GatewayResult;
 
 pub(crate) use assignment_repository::AssignmentRepository;
@@ -40,6 +42,14 @@ impl Storage {
     /// caller supplies locally enabled wallet addresses when assigning work and
     /// inspecting assignments.
     pub(crate) async fn connect(redis_url: &str) -> GatewayResult<Self> {
-        unimplemented!()
+        let client = Client::open(redis_url)?;
+        let manager = ConnectionManager::new(client).await?;
+
+        Ok(Self {
+            requests: RequestRepository::new(manager.clone()),
+            batches: BatchRepository::new(manager.clone()),
+            assignments: AssignmentRepository::new(manager.clone()),
+            rate_limiter: RateLimiter::new(manager),
+        })
     }
 }

--- a/services/gateway/src/storage/mod.rs
+++ b/services/gateway/src/storage/mod.rs
@@ -7,6 +7,9 @@ mod rate_limiter;
 mod request_repository;
 mod types;
 
+#[cfg(test)]
+mod test_support;
+
 use redis::{Client, aio::ConnectionManager};
 
 use crate::error::GatewayResult;

--- a/services/gateway/src/storage/mod.rs
+++ b/services/gateway/src/storage/mod.rs
@@ -1,0 +1,45 @@
+// This module defines the planned storage interface before its adapters are wired in.
+#![allow(dead_code, unused_imports, unused_variables)]
+
+mod assignment_repository;
+mod batch_repository;
+mod rate_limiter;
+mod request_repository;
+mod types;
+
+use crate::error::GatewayResult;
+
+pub(crate) use assignment_repository::AssignmentRepository;
+pub(crate) use batch_repository::{BatchRepository, SealBatchOutcome};
+pub(crate) use rate_limiter::{RateLimitOutcome, RateLimiter};
+pub(crate) use request_repository::{AcceptRequestOutcome, RequestRepository};
+pub(crate) use types::*;
+
+/// Entry point for durable gateway storage modules sharing one Redis manager.
+///
+/// The repositories use the `gateway:` Redis namespace. Records are serialized
+/// domain values stored at singular keys; sorted sets and sets are disposable
+/// indexes for queue order and availability. Multi-record state transitions use
+/// atomic Lua scripts because the deployment uses one Redis instance.
+#[derive(Clone)]
+pub(crate) struct Storage {
+    /// Request records, batching queues, and admission resource locks.
+    pub(crate) requests: RequestRepository,
+    /// Batch records, ready queue, and the single signed submission per batch.
+    pub(crate) batches: BatchRepository,
+    /// Durable wallet-to-batch assignments; wallet state remains local.
+    pub(crate) assignments: AssignmentRepository,
+    /// Per-account sliding-window admission limits.
+    pub(crate) rate_limiter: RateLimiter,
+}
+
+impl Storage {
+    /// Connects to `redis_url` and constructs all repositories over one manager.
+    ///
+    /// This does not create schema keys or persist wallet configuration. The
+    /// caller supplies locally enabled wallet addresses when assigning work and
+    /// inspecting assignments.
+    pub(crate) async fn connect(redis_url: &str) -> GatewayResult<Self> {
+        unimplemented!()
+    }
+}

--- a/services/gateway/src/storage/rate_limiter.rs
+++ b/services/gateway/src/storage/rate_limiter.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use redis::aio::ConnectionManager;
+use redis::{Script, aio::ConnectionManager};
 
 use crate::{
     error::GatewayResult,
@@ -37,7 +37,7 @@ impl RateLimiter {
     ///
     /// This does not read or modify any Redis key.
     pub(crate) fn new(manager: ConnectionManager) -> Self {
-        unimplemented!()
+        Self { manager }
     }
 
     /// Atomically checks and conditionally records a request for one account.
@@ -59,6 +59,44 @@ impl RateLimiter {
         window: Duration,
         max_requests: u64,
     ) -> GatewayResult<RateLimitOutcome> {
-        unimplemented!()
+        let window_secs = window.as_secs();
+        let mut manager = self.manager.clone();
+        let count: i64 = Script::new(
+            r#"
+            local now = tonumber(ARGV[1])
+            local window = tonumber(ARGV[2])
+            local limit = tonumber(ARGV[3])
+            local oldest = now - window
+
+            redis.call('ZREMRANGEBYSCORE', KEYS[1], '-inf', oldest)
+            local current = redis.call('ZCARD', KEYS[1])
+            if current >= limit then
+                return -1
+            end
+
+            redis.call('ZADD', KEYS[1], now, ARGV[4])
+            redis.call('EXPIRE', KEYS[1], window)
+            return current + 1
+            "#,
+        )
+        .key(rate_limit_key(leaf_index))
+        .arg(now)
+        .arg(window_secs)
+        .arg(max_requests)
+        .arg(request_id.0.to_string())
+        .invoke_async(&mut manager)
+        .await?;
+
+        if count < 0 {
+            Ok(RateLimitOutcome::Exceeded)
+        } else {
+            Ok(RateLimitOutcome::Allowed {
+                current_count: count as u64,
+            })
+        }
     }
+}
+
+fn rate_limit_key(leaf_index: u64) -> String {
+    format!("gateway:ratelimit:leaf:{leaf_index}")
 }

--- a/services/gateway/src/storage/rate_limiter.rs
+++ b/services/gateway/src/storage/rate_limiter.rs
@@ -100,3 +100,62 @@ impl RateLimiter {
 fn rate_limit_key(leaf_index: u64) -> String {
     format!("gateway:ratelimit:leaf:{leaf_index}")
 }
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use redis::aio::ConnectionManager;
+    use test_case::test_case;
+    use uuid::Uuid;
+
+    use super::{RateLimitOutcome, RateLimiter};
+    use crate::storage::{test_support::start_redis, types::RequestId};
+
+    async fn connect_limiter(redis_url: &str) -> RateLimiter {
+        let client = redis::Client::open(redis_url).unwrap();
+        let manager = ConnectionManager::new(client).await.unwrap();
+        RateLimiter::new(manager)
+    }
+
+    #[test_case(&[], 100 => RateLimitOutcome::Allowed { current_count: 1 }; "allows first request")]
+    #[test_case(&[100], 101 => RateLimitOutcome::Allowed { current_count: 2 }; "counts request in window")]
+    #[test_case(&[100, 101], 109 => RateLimitOutcome::Exceeded; "rejects full window")]
+    #[test_case(&[100, 101], 110 => RateLimitOutcome::Allowed { current_count: 2 }; "expires inclusive boundary")]
+    #[tokio::test]
+    async fn enforces_sliding_window_against_redis(
+        existing_timestamps: &[u64],
+        now: u64,
+    ) -> RateLimitOutcome {
+        const LEAF_INDEX: u64 = 7;
+        const WINDOW: Duration = Duration::from_secs(10);
+        const MAX_REQUESTS: u64 = 2;
+
+        let (redis_url, _redis) = start_redis().await;
+        let limiter = connect_limiter(&redis_url).await;
+
+        for timestamp in existing_timestamps {
+            limiter
+                .check_and_record(
+                    LEAF_INDEX,
+                    RequestId(Uuid::new_v4()),
+                    *timestamp,
+                    WINDOW,
+                    MAX_REQUESTS,
+                )
+                .await
+                .unwrap();
+        }
+
+        limiter
+            .check_and_record(
+                LEAF_INDEX,
+                RequestId(Uuid::new_v4()),
+                now,
+                WINDOW,
+                MAX_REQUESTS,
+            )
+            .await
+            .unwrap()
+    }
+}

--- a/services/gateway/src/storage/rate_limiter.rs
+++ b/services/gateway/src/storage/rate_limiter.rs
@@ -1,0 +1,64 @@
+use std::time::Duration;
+
+use redis::aio::ConnectionManager;
+
+use crate::{
+    error::GatewayResult,
+    storage::types::{RequestId, Timestamp},
+};
+
+/// Result of checking and conditionally recording one admission attempt.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum RateLimitOutcome {
+    /// The request was recorded; `current_count` includes this request.
+    Allowed { current_count: u64 },
+    /// The window was already full, so the request was not recorded.
+    Exceeded,
+}
+
+/// Per-account sliding-window admission limiter.
+///
+/// # Redis schema
+///
+/// - `gateway:ratelimit:leaf:<leaf-index>` is a sorted set whose members are
+///   [`RequestId`] values and whose scores are admission timestamps.
+///
+/// Each key expires after one full window without an allowed request. The
+/// limiter is independent from [`crate::storage::RequestRepository`]: admission
+/// may consume rate-limit capacity even when later validation or durable request
+/// acceptance fails.
+#[derive(Clone)]
+pub(crate) struct RateLimiter {
+    manager: ConnectionManager,
+}
+
+impl RateLimiter {
+    /// Creates a limiter backed by the supplied Redis connection manager.
+    ///
+    /// This does not read or modify any Redis key.
+    pub(crate) fn new(manager: ConnectionManager) -> Self {
+        unimplemented!()
+    }
+
+    /// Atomically checks and conditionally records a request for one account.
+    ///
+    /// On `gateway:ratelimit:leaf:<leaf-index>`, removes entries with scores
+    /// at or before `now - window`, then counts the remaining members. If the
+    /// count is below `max_requests`, inserts `request_id` at score `now`,
+    /// refreshes the key TTL to `window`, and returns
+    /// [`RateLimitOutcome::Allowed`]. Otherwise returns
+    /// [`RateLimitOutcome::Exceeded`] without recording the rejected request.
+    ///
+    /// Calls for the same account are serialized by one atomic Redis script, so
+    /// concurrent gateway replicas cannot collectively exceed the limit.
+    pub(crate) async fn check_and_record(
+        &self,
+        leaf_index: u64,
+        request_id: RequestId,
+        now: Timestamp,
+        window: Duration,
+        max_requests: u64,
+    ) -> GatewayResult<RateLimitOutcome> {
+        unimplemented!()
+    }
+}

--- a/services/gateway/src/storage/request_repository.rs
+++ b/services/gateway/src/storage/request_repository.rs
@@ -1,0 +1,106 @@
+use redis::aio::ConnectionManager;
+
+use crate::{
+    error::GatewayResult,
+    storage::types::{BatchKind, NewRequest, RequestId, ResourceLock, StoredRequest, Timestamp},
+};
+
+/// Result of atomically persisting a request and acquiring its resource locks.
+#[derive(Debug, Eq, PartialEq)]
+pub(crate) enum AcceptRequestOutcome {
+    /// The request record, queue entry, and every resource lock were created.
+    Accepted,
+    /// The named resource was already locked; storage was not changed.
+    ResourceLocked(ResourceLock),
+}
+
+/// Durable request records, admission locks, and ordered batching queues.
+///
+/// # Redis schema
+///
+/// - `gateway:request:<request-id>` stores one serialized [`StoredRequest`].
+/// - `gateway:requests:create` is a sorted set of queued create request IDs.
+/// - `gateway:requests:ops` is a sorted set of queued operation request IDs.
+/// - `gateway:resource:<resource-id>` maps a locked resource to its request ID.
+///
+/// Queue scores use `accepted_at`; request IDs provide deterministic ordering
+/// when scores match. Request records remain the source of
+/// truth; sorted sets are indexes. Acceptance and terminal transitions update
+/// records, queue indexes, and resource locks atomically.
+#[derive(Clone)]
+pub(crate) struct RequestRepository {
+    manager: ConnectionManager,
+}
+
+impl RequestRepository {
+    /// Creates a repository backed by the supplied Redis connection manager.
+    ///
+    /// This does not read or modify any Redis key.
+    pub(crate) fn new(manager: ConnectionManager) -> Self {
+        unimplemented!()
+    }
+
+    /// Persists a queued request and acquires all of its resource locks.
+    ///
+    /// Atomically creates `gateway:request:<request-id>`, adds the ID to
+    /// `gateway:requests:create` or `gateway:requests:ops`, and creates each
+    /// `gateway:resource:<resource-id>` lock. If any lock exists, returns
+    /// [`AcceptRequestOutcome::ResourceLocked`] without changing storage.
+    pub(crate) async fn accept(&self, request: NewRequest) -> GatewayResult<AcceptRequestOutcome> {
+        unimplemented!()
+    }
+
+    /// Loads one request from `gateway:request:<request-id>`.
+    ///
+    /// Returns `None` when the record does not exist. Queue indexes and resource
+    /// locks are not consulted.
+    pub(crate) async fn load(&self, request_id: RequestId) -> GatewayResult<Option<StoredRequest>> {
+        unimplemented!()
+    }
+
+    /// Loads request records from `gateway:request:<request-id>` in one round trip.
+    ///
+    /// Results preserve input order, including `None` for every missing record.
+    pub(crate) async fn load_many(
+        &self,
+        request_ids: &[RequestId],
+    ) -> GatewayResult<Vec<Option<StoredRequest>>> {
+        unimplemented!()
+    }
+
+    /// Returns up to `limit` oldest queued requests of `kind`.
+    ///
+    /// Reads IDs from `gateway:requests:create` or `gateway:requests:ops`, then
+    /// loads their `gateway:request:<request-id>` records. This is an inspection
+    /// operation: it does not reserve or remove requests from the queue.
+    pub(crate) async fn oldest_queued(
+        &self,
+        kind: BatchKind,
+        limit: usize,
+    ) -> GatewayResult<Vec<StoredRequest>> {
+        unimplemented!()
+    }
+
+    /// Counts members in the sorted queue for `kind`.
+    ///
+    /// Operates on `gateway:requests:create` or `gateway:requests:ops` without
+    /// loading request records.
+    pub(crate) async fn queue_len(&self, kind: BatchKind) -> GatewayResult<usize> {
+        unimplemented!()
+    }
+
+    /// Fails a request that has not been sealed into a batch.
+    ///
+    /// Atomically updates `gateway:request:<request-id>`, removes the ID from its
+    /// request queue, and deletes all `gateway:resource:<resource-id>` locks
+    /// owned by the request. The transition is rejected unless its state is
+    /// [`crate::storage::types::RequestState::Queued`].
+    pub(crate) async fn fail_queued(
+        &self,
+        request_id: RequestId,
+        reason: String,
+        failed_at: Timestamp,
+    ) -> GatewayResult<()> {
+        unimplemented!()
+    }
+}

--- a/services/gateway/src/storage/test_support.rs
+++ b/services/gateway/src/storage/test_support.rs
@@ -1,0 +1,22 @@
+use testcontainers_modules::{
+    redis::{REDIS_PORT, Redis},
+    testcontainers::{ContainerAsync, ImageExt as _, runners::AsyncRunner as _},
+};
+
+pub(super) async fn start_redis() -> (String, ContainerAsync<Redis>) {
+    let container = Redis::default()
+        .with_tag("latest")
+        .start()
+        .await
+        .expect("failed to start Redis container");
+    let host = container
+        .get_host()
+        .await
+        .expect("failed to get Redis host");
+    let port = container
+        .get_host_port_ipv4(REDIS_PORT)
+        .await
+        .expect("failed to get Redis port");
+
+    (format!("redis://{host}:{port}"), container)
+}

--- a/services/gateway/src/storage/types.rs
+++ b/services/gateway/src/storage/types.rs
@@ -1,4 +1,5 @@
 use alloy::primitives::{Address, B256, Bytes, TxHash, U256};
+use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 use world_id_primitives::api_types::CreateAccountRequest;
 
@@ -9,18 +10,18 @@ pub(crate) type Timestamp = u64;
 ///
 /// The `gw_` prefix used by HTTP responses is presentation only and is not
 /// stored as part of this UUID.
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub(crate) struct RequestId(pub(crate) Uuid);
 
 /// Identity of one immutable sealed batch.
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub(crate) struct BatchId(pub(crate) Uuid);
 
 /// Resource whose conflicting requests must not execute concurrently.
 ///
 /// A lock is acquired when a request is accepted and released only when that
 /// request reaches a terminal state.
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub(crate) enum ResourceLock {
     /// Authenticator address reserved by an account-creation request.
     Authenticator(Address),
@@ -29,7 +30,7 @@ pub(crate) enum ResourceLock {
 }
 
 /// Complete validated request data needed to rebuild a batch after restart.
-#[derive(Debug)]
+#[derive(Debug, Deserialize, Serialize)]
 pub(crate) enum RequestPayload {
     /// Original account-creation request used to build `createManyAccounts`.
     CreateAccount(CreateAccountRequest),
@@ -38,7 +39,7 @@ pub(crate) enum RequestPayload {
 }
 
 /// Durable lifecycle of an accepted gateway request.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub(crate) enum RequestState {
     /// Persisted and available in its ordered batching queue.
     Queued,
@@ -67,7 +68,7 @@ pub(crate) struct NewRequest {
 }
 
 /// Source-of-truth record stored at `gateway:request:<request-id>`.
-#[derive(Debug)]
+#[derive(Debug, Deserialize, Serialize)]
 pub(crate) struct StoredRequest {
     /// Stable internal request identity.
     pub(crate) id: RequestId,
@@ -84,7 +85,7 @@ pub(crate) struct StoredRequest {
 }
 
 /// Transaction construction strategy for a batch.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub(crate) enum BatchKind {
     /// Direct `WorldIDRegistry.createManyAccounts` transaction.
     CreateAccounts,
@@ -96,7 +97,7 @@ pub(crate) enum BatchKind {
 ///
 /// The submitter adds the assigned wallet, nonce, chain ID, and EIP-1559 fee
 /// fields before signing the single transaction for this batch.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub(crate) struct TransactionIntent {
     /// Registry or Multicall3 destination.
     pub(crate) to: Address,
@@ -124,7 +125,7 @@ pub(crate) struct NewBatch {
 }
 
 /// Durable submission lifecycle of a sealed batch.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub(crate) enum BatchState {
     /// Published to the ready queue with no assigned wallet.
     Ready,
@@ -142,6 +143,8 @@ pub(crate) enum BatchState {
     },
     /// The transaction has a receipt but has not reached safe confirmation.
     Included {
+        /// Wallet reserved until the receipt reaches safe confirmation.
+        wallet: Address,
         /// Hash of the included batch transaction.
         tx_hash: TxHash,
         /// Block hash used to detect a reorganization.
@@ -160,7 +163,7 @@ pub(crate) enum BatchState {
 /// `request_ids` and `transaction` become immutable when the record is created.
 /// State, the optional prepared submission, and `updated_at` change as
 /// submission progresses.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub(crate) struct Batch {
     /// Stable batch identity.
     pub(crate) id: BatchId,
@@ -185,7 +188,7 @@ pub(crate) struct Batch {
 /// Signed bytes form the submission write-ahead log. They allow another worker
 /// to query the locally computed hash and rebroadcast the exact transaction
 /// after an ambiguous RPC response or process crash.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub(crate) struct PreparedSubmission {
     /// Wallet nonce encoded in `signed_transaction`.
     pub(crate) nonce: u64,
@@ -211,7 +214,7 @@ pub(crate) struct PreparedSubmission {
 ///
 /// Wallet credentials and assignment eligibility remain in local gateway
 /// configuration and are deliberately absent from this persisted model.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub(crate) struct Assignment {
     /// Locally configured address assigned to the batch.
     pub(crate) wallet: Address,

--- a/services/gateway/src/storage/types.rs
+++ b/services/gateway/src/storage/types.rs
@@ -1,0 +1,220 @@
+use alloy::primitives::{Address, B256, Bytes, TxHash, U256};
+use uuid::Uuid;
+use world_id_primitives::api_types::CreateAccountRequest;
+
+/// Unix timestamp in seconds.
+pub(crate) type Timestamp = u64;
+
+/// Internal request identity.
+///
+/// The `gw_` prefix used by HTTP responses is presentation only and is not
+/// stored as part of this UUID.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub(crate) struct RequestId(pub(crate) Uuid);
+
+/// Identity of one immutable sealed batch.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub(crate) struct BatchId(pub(crate) Uuid);
+
+/// Resource whose conflicting requests must not execute concurrently.
+///
+/// A lock is acquired when a request is accepted and released only when that
+/// request reaches a terminal state.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub(crate) enum ResourceLock {
+    /// Authenticator address reserved by an account-creation request.
+    Authenticator(Address),
+    /// Account leaf index reserved by an account-operation request.
+    Account(u64),
+}
+
+/// Complete validated request data needed to rebuild a batch after restart.
+#[derive(Debug)]
+pub(crate) enum RequestPayload {
+    /// Original account-creation request used to build `createManyAccounts`.
+    CreateAccount(CreateAccountRequest),
+    /// Encoded registry call used as one item in an operations multicall.
+    Operation(Bytes),
+}
+
+/// Durable lifecycle of an accepted gateway request.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum RequestState {
+    /// Persisted and available in its ordered batching queue.
+    Queued,
+    /// Sealed into the identified immutable batch.
+    Batched(BatchId),
+    /// Successfully executed by a transaction that reached safe confirmation.
+    Finalized(TxHash),
+    /// Permanently rejected or included in a safely resolved failed batch.
+    Failed(String),
+}
+
+/// Input for atomically accepting a request.
+///
+/// [`crate::storage::RequestRepository::accept`] supplies the initial `Queued`
+/// state and sets `updated_at` from `accepted_at`.
+#[derive(Debug)]
+pub(crate) struct NewRequest {
+    /// Caller-generated internal request identity.
+    pub(crate) id: RequestId,
+    /// Complete validated payload to persist.
+    pub(crate) payload: RequestPayload,
+    /// Time at which gateway admission accepted the request.
+    pub(crate) accepted_at: Timestamp,
+    /// Resources to acquire in the same atomic operation as persistence.
+    pub(crate) resource_locks: Vec<ResourceLock>,
+}
+
+/// Source-of-truth record stored at `gateway:request:<request-id>`.
+#[derive(Debug)]
+pub(crate) struct StoredRequest {
+    /// Stable internal request identity.
+    pub(crate) id: RequestId,
+    /// Complete payload retained for restart recovery.
+    pub(crate) payload: RequestPayload,
+    /// Current durable lifecycle state.
+    pub(crate) state: RequestState,
+    /// Original admission time, which never changes.
+    pub(crate) accepted_at: Timestamp,
+    /// Time of the latest durable state transition.
+    pub(crate) updated_at: Timestamp,
+    /// Locks owned by this request until it reaches a terminal state.
+    pub(crate) resource_locks: Vec<ResourceLock>,
+}
+
+/// Transaction construction strategy for a batch.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum BatchKind {
+    /// Direct `WorldIDRegistry.createManyAccounts` transaction.
+    CreateAccounts,
+    /// `Multicall3.aggregate3` transaction containing account operations.
+    Operations,
+}
+
+/// Immutable transaction fields produced when a batch is sealed.
+///
+/// The submitter adds the assigned wallet, nonce, chain ID, and EIP-1559 fee
+/// fields before signing the single transaction for this batch.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct TransactionIntent {
+    /// Registry or Multicall3 destination.
+    pub(crate) to: Address,
+    /// Complete encoded call data.
+    pub(crate) calldata: Bytes,
+    /// Native token value sent with the call.
+    pub(crate) value: U256,
+    /// Fixed execution gas limit used by the signed transaction.
+    pub(crate) gas_limit: u64,
+}
+
+/// Input for atomically sealing queued requests into a batch.
+#[derive(Debug)]
+pub(crate) struct NewBatch {
+    /// Caller-generated batch identity.
+    pub(crate) id: BatchId,
+    /// Construction strategy shared by every member request.
+    pub(crate) kind: BatchKind,
+    /// Ordered request membership, immutable after sealing.
+    pub(crate) request_ids: Vec<RequestId>,
+    /// Transaction fields, immutable after sealing.
+    pub(crate) transaction: TransactionIntent,
+    /// Time used to order the batch in the ready queue.
+    pub(crate) created_at: Timestamp,
+}
+
+/// Durable submission lifecycle of a sealed batch.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum BatchState {
+    /// Published to the ready queue with no assigned wallet.
+    Ready,
+    /// Durably assigned to a wallet, before its nonce is persisted.
+    Assigned {
+        /// Wallet reserved until finalization, safe revert, or receipt timeout.
+        wallet: Address,
+    },
+    /// The batch's single signed transaction has been durably prepared.
+    Pending {
+        /// Wallet that signed the transaction.
+        wallet: Address,
+        /// Nonce encoded in the signed transaction.
+        nonce: u64,
+    },
+    /// The transaction has a receipt but has not reached safe confirmation.
+    Included {
+        /// Hash of the included batch transaction.
+        tx_hash: TxHash,
+        /// Block hash used to detect a reorganization.
+        block_hash: B256,
+        /// Block number compared with the chain's safe head.
+        block_number: u64,
+    },
+    /// Successful batch transaction reached safe confirmation.
+    Finalized(TxHash),
+    /// Transaction safely reverted, exceeded its receipt timeout, or failed before broadcast.
+    Failed(String),
+}
+
+/// Source-of-truth record stored at `gateway:batch:<batch-id>`.
+///
+/// `request_ids` and `transaction` become immutable when the record is created.
+/// State, the optional prepared submission, and `updated_at` change as
+/// submission progresses.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct Batch {
+    /// Stable batch identity.
+    pub(crate) id: BatchId,
+    /// Transaction construction strategy.
+    pub(crate) kind: BatchKind,
+    /// Ordered immutable request membership.
+    pub(crate) request_ids: Vec<RequestId>,
+    /// Immutable fields used to build the signed transaction.
+    pub(crate) transaction: TransactionIntent,
+    /// Current durable submission state.
+    pub(crate) state: BatchState,
+    /// Single signed transaction, present after preparation.
+    pub(crate) submission: Option<PreparedSubmission>,
+    /// Time at which queued requests were sealed into this batch.
+    pub(crate) created_at: Timestamp,
+    /// Time of the latest durable state or submission transition.
+    pub(crate) updated_at: Timestamp,
+}
+
+/// The batch's single signed transaction, persisted before broadcast.
+///
+/// Signed bytes form the submission write-ahead log. They allow another worker
+/// to query the locally computed hash and rebroadcast the exact transaction
+/// after an ambiguous RPC response or process crash.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct PreparedSubmission {
+    /// Wallet nonce encoded in `signed_transaction`.
+    pub(crate) nonce: u64,
+    /// Hash computed locally from `signed_transaction`.
+    pub(crate) tx_hash: TxHash,
+    /// Exact EIP-2718 encoded transaction bytes sent to the provider.
+    pub(crate) signed_transaction: Bytes,
+    /// EIP-1559 maximum total fee per gas.
+    pub(crate) max_fee_per_gas: U256,
+    /// EIP-1559 maximum priority fee per gas.
+    pub(crate) max_priority_fee_per_gas: U256,
+    /// Time at which the write-ahead record committed the transaction for broadcast.
+    ///
+    /// The configured receipt timeout starts here. The submitter must broadcast
+    /// immediately after confirming this durable write; recovery rebroadcasts
+    /// the same bytes when the original RPC result is unknown.
+    pub(crate) submitted_at: Timestamp,
+    /// Time the RPC broadcast completed, or `None` when its result is unknown.
+    pub(crate) broadcast_at: Option<Timestamp>,
+}
+
+/// Consistent snapshot of a durable wallet-to-batch assignment.
+///
+/// Wallet credentials and assignment eligibility remain in local gateway
+/// configuration and are deliberately absent from this persisted model.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct Assignment {
+    /// Locally configured address assigned to the batch.
+    pub(crate) wallet: Address,
+    /// Durably assigned batch and its prepared submission, when present.
+    pub(crate) batch: Batch,
+}


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Admission rate limiting and storage connect are now live behavior; incorrect Lua or window logic could admit too many requests or reject valid ones across replicas.
> 
> **Overview**
> Implements gateway Redis wiring that was previously stubbed: **`Storage::connect`** opens a shared **`ConnectionManager`** and constructs all repositories, and **`RateLimiter::check_and_record`** runs an atomic Lua script on **`gateway:ratelimit:leaf:<leaf-index>`** (trim by score, count, **`ZADD`** or reject, **`EXPIRE`**).
> 
> Adds **Redis-backed integration tests** via **`test_support::start_redis`** (testcontainers) and **`test-case`** scenarios for first request, in-window counting, full window rejection, and inclusive window expiry. **`test-case`** is added as a workspace dev dependency; **`uuid`** gains **`serde`** for serializing **`RequestId`** in Redis.
> 
> Gateway storage types gain **`Serialize`/`Deserialize`** for durable Redis records, and **`BatchState::Included`** now carries the assigned **`wallet`** alongside receipt fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de3694fe504ba3a6e52eab5c8d0f392540860a14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->