### PR TITLE
feat(gateway): implement request storage repository

### DIFF
--- a/services/gateway/src/storage/assignment_repository.rs
+++ b/services/gateway/src/storage/assignment_repository.rs
@@ -30,7 +30,7 @@ impl AssignmentRepository {
     ///
     /// This does not read or modify any Redis key.
     pub(crate) fn new(manager: ConnectionManager) -> Self {
-        unimplemented!()
+        Self { manager }
     }
 
     /// Assigns one ready batch to one unassigned local wallet address.

--- a/services/gateway/src/storage/batch_repository.rs
+++ b/services/gateway/src/storage/batch_repository.rs
@@ -37,7 +37,7 @@ impl BatchRepository {
     ///
     /// This does not read or modify any Redis key.
     pub(crate) fn new(manager: ConnectionManager) -> Self {
-        unimplemented!()
+        Self { manager }
     }
 
     /// Seals queued requests into an immutable batch and publishes it as ready.

--- a/services/gateway/src/storage/mod.rs
+++ b/services/gateway/src/storage/mod.rs
@@ -56,3 +56,24 @@ impl Storage {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{BatchKind, Storage, test_support::start_redis};
+
+    #[tokio::test]
+    async fn connects_all_repositories() {
+        let (redis_url, _redis) = start_redis().await;
+
+        let storage = Storage::connect(&redis_url).await.unwrap();
+
+        assert_eq!(
+            storage
+                .requests
+                .queue_len(BatchKind::CreateAccounts)
+                .await
+                .unwrap(),
+            0
+        );
+    }
+}

--- a/services/gateway/src/storage/request_repository.rs
+++ b/services/gateway/src/storage/request_repository.rs
@@ -235,7 +235,56 @@ impl RequestRepository {
         reason: String,
         failed_at: Timestamp,
     ) -> GatewayResult<()> {
-        unimplemented!()
+        let Some(request) = self.load(request_id).await? else {
+            return Err(redis::RedisError::from((
+                redis::ErrorKind::Client,
+                "request does not exist",
+            ))
+            .into());
+        };
+        let failed_state = serde_json::to_string(&RequestState::Failed(reason))?;
+        let mut manager = self.manager.clone();
+        let script = Script::new(
+            r#"
+            local record = redis.call('GET', KEYS[1])
+            if not record then
+                return redis.error_reply('request does not exist')
+            end
+
+            local decoded = cjson.decode(record)
+            if decoded.state ~= 'Queued' then
+                return redis.error_reply('request is not queued')
+            end
+
+            decoded.state = cjson.decode(ARGV[2])
+            decoded.updated_at = tonumber(ARGV[3])
+            redis.call('SET', KEYS[1], cjson.encode(decoded))
+            redis.call('ZREM', KEYS[2], ARGV[1])
+
+            for i = 3, #KEYS do
+                if redis.call('GET', KEYS[i]) == ARGV[1] then
+                    redis.call('DEL', KEYS[i])
+                end
+            end
+
+            return redis.status_reply('OK')
+            "#,
+        );
+        let mut invocation = script.prepare_invoke();
+        invocation
+            .key(request_id.redis_key())
+            .key(request.payload.batch_kind().queue_key());
+        for resource in &request.resource_locks {
+            invocation.key(resource.redis_key());
+        }
+
+        let _: () = invocation
+            .arg(request_id.0.to_string())
+            .arg(failed_state)
+            .arg(failed_at)
+            .invoke_async(&mut manager)
+            .await?;
+        Ok(())
     }
 }
 
@@ -249,7 +298,9 @@ mod tests {
     use super::{AcceptRequestOutcome, RequestRepository};
     use crate::storage::{
         test_support::start_redis,
-        types::{BatchKind, NewRequest, RequestId, RequestPayload, RequestState, ResourceLock},
+        types::{
+            BatchId, BatchKind, NewRequest, RequestId, RequestPayload, RequestState, ResourceLock,
+        },
     };
 
     const ACCEPTED_AT: u64 = 100;
@@ -470,5 +521,101 @@ mod tests {
             .unwrap();
         assert_eq!(oldest.len(), 1);
         assert_eq!(oldest[0].id, queued_id);
+    }
+
+    #[tokio::test]
+    async fn failing_queued_request_updates_state_and_releases_owned_locks() {
+        let (redis_url, _redis) = start_redis().await;
+        let repository = connect_repository(&redis_url).await;
+        let request_id = RequestId(Uuid::from_u128(1));
+        let other_id = RequestId(Uuid::from_u128(2));
+        repository
+            .accept(NewRequest {
+                id: request_id,
+                payload: RequestPayload::Operation(Bytes::from_static(&[1, 2, 3])),
+                accepted_at: 100,
+                resource_locks: vec![ResourceLock::Account(10), ResourceLock::Account(20)],
+            })
+            .await
+            .unwrap();
+
+        let mut manager = repository.manager.clone();
+        let _: () = redis::cmd("SET")
+            .arg(ResourceLock::Account(20).redis_key())
+            .arg(other_id.0.to_string())
+            .query_async(&mut manager)
+            .await
+            .unwrap();
+
+        repository
+            .fail_queued(request_id, "validation expired".to_string(), 300)
+            .await
+            .unwrap();
+
+        let failed = repository.load(request_id).await.unwrap().unwrap();
+        assert_eq!(
+            failed.state,
+            RequestState::Failed("validation expired".to_string())
+        );
+        assert_eq!(failed.updated_at, 300);
+        assert_eq!(
+            repository.queue_len(BatchKind::Operations).await.unwrap(),
+            0
+        );
+        let released: Option<String> = redis::cmd("GET")
+            .arg(ResourceLock::Account(10).redis_key())
+            .query_async(&mut manager)
+            .await
+            .unwrap();
+        assert!(released.is_none());
+        let retained: String = redis::cmd("GET")
+            .arg(ResourceLock::Account(20).redis_key())
+            .query_async(&mut manager)
+            .await
+            .unwrap();
+        assert_eq!(retained, other_id.0.to_string());
+    }
+
+    #[tokio::test]
+    async fn refuses_to_fail_request_that_is_no_longer_queued() {
+        let (redis_url, _redis) = start_redis().await;
+        let repository = connect_repository(&redis_url).await;
+        let request_id = RequestId(Uuid::from_u128(1));
+        repository
+            .accept(operation_request_at(request_id, 10, 100))
+            .await
+            .unwrap();
+
+        let mut stored = repository.load(request_id).await.unwrap().unwrap();
+        let batch_id = BatchId(Uuid::from_u128(2));
+        stored.state = RequestState::Batched(batch_id);
+        let mut manager = repository.manager.clone();
+        let _: () = redis::cmd("SET")
+            .arg(request_id.redis_key())
+            .arg(serde_json::to_string(&stored).unwrap())
+            .query_async(&mut manager)
+            .await
+            .unwrap();
+
+        assert!(
+            repository
+                .fail_queued(request_id, "too late".to_string(), 300)
+                .await
+                .is_err()
+        );
+
+        let unchanged = repository.load(request_id).await.unwrap().unwrap();
+        assert_eq!(unchanged.state, RequestState::Batched(batch_id));
+        assert_eq!(unchanged.updated_at, 100);
+        assert_eq!(
+            repository.queue_len(BatchKind::Operations).await.unwrap(),
+            1
+        );
+        let lock_owner: String = redis::cmd("GET")
+            .arg(ResourceLock::Account(10).redis_key())
+            .query_async(&mut manager)
+            .await
+            .unwrap();
+        assert_eq!(lock_owner, request_id.0.to_string());
     }
 }

--- a/services/gateway/src/storage/request_repository.rs
+++ b/services/gateway/src/storage/request_repository.rs
@@ -146,13 +146,69 @@ impl RequestRepository {
     ///
     /// Reads IDs from `gateway:requests:create` or `gateway:requests:ops`, then
     /// loads their `gateway:request:<request-id>` records. This is an inspection
-    /// operation: it does not reserve or remove requests from the queue.
+    /// operation: it does not reserve or remove requests from the queue. Stale
+    /// index members whose record is missing, no longer queued, or belongs to a
+    /// different queue are skipped.
     pub(crate) async fn oldest_queued(
         &self,
         kind: BatchKind,
         limit: usize,
     ) -> GatewayResult<Vec<StoredRequest>> {
-        unimplemented!()
+        const PAGE_SIZE: usize = 128;
+
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
+
+        let mut manager = self.manager.clone();
+        let mut offset = 0;
+        let mut requests = Vec::with_capacity(limit);
+
+        while requests.len() < limit {
+            let members: Vec<String> = redis::cmd("ZRANGE")
+                .arg(kind.queue_key())
+                .arg(offset)
+                .arg(offset + PAGE_SIZE - 1)
+                .query_async(&mut manager)
+                .await?;
+            if members.is_empty() {
+                break;
+            }
+            offset += members.len();
+
+            let keys: Vec<String> = members
+                .iter()
+                .map(|id| format!("gateway:request:{id}"))
+                .collect();
+            let records: Vec<Option<String>> = redis::cmd("MGET")
+                .arg(keys)
+                .query_async(&mut manager)
+                .await?;
+
+            for (member, serialized) in members.iter().zip(records) {
+                let Some(serialized) = serialized else {
+                    continue;
+                };
+                let request: StoredRequest = serde_json::from_str(&serialized)?;
+                if member != &request.id.0.to_string()
+                    || request.state != RequestState::Queued
+                    || request.payload.batch_kind() != kind
+                {
+                    continue;
+                }
+
+                requests.push(request);
+                if requests.len() == limit {
+                    break;
+                }
+            }
+
+            if members.len() < PAGE_SIZE {
+                break;
+            }
+        }
+
+        Ok(requests)
     }
 
     /// Counts members in the sorted queue for `kind`.
@@ -204,13 +260,17 @@ mod tests {
         RequestRepository::new(manager)
     }
 
-    fn operation_request(id: RequestId, account: u64) -> NewRequest {
+    fn operation_request_at(id: RequestId, account: u64, accepted_at: u64) -> NewRequest {
         NewRequest {
             id,
             payload: RequestPayload::Operation(Bytes::from_static(&[1, 2, 3])),
-            accepted_at: ACCEPTED_AT,
+            accepted_at,
             resource_locks: vec![ResourceLock::Account(account)],
         }
+    }
+
+    fn operation_request(id: RequestId, account: u64) -> NewRequest {
+        operation_request_at(id, account, ACCEPTED_AT)
     }
 
     #[tokio::test]
@@ -318,5 +378,97 @@ mod tests {
         assert!(loaded[1].is_none());
         assert_eq!(loaded[2].as_ref().unwrap().id, first_id);
         assert!(repository.load_many(&[]).await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn returns_oldest_requests_for_each_queue() {
+        let (redis_url, _redis) = start_redis().await;
+        let repository = connect_repository(&redis_url).await;
+        let first_id = RequestId(Uuid::from_u128(1));
+        let second_id = RequestId(Uuid::from_u128(2));
+        let later_id = RequestId(Uuid::from_u128(3));
+        let create_id = RequestId(Uuid::from_u128(4));
+
+        repository
+            .accept(operation_request_at(later_id, 3, 200))
+            .await
+            .unwrap();
+        repository
+            .accept(operation_request_at(second_id, 2, 100))
+            .await
+            .unwrap();
+        repository
+            .accept(operation_request_at(first_id, 1, 100))
+            .await
+            .unwrap();
+        repository
+            .accept(NewRequest {
+                id: create_id,
+                payload: RequestPayload::CreateAccount(CreateAccountRequest {
+                    recovery_address: None,
+                    authenticator_addresses: vec![],
+                    authenticator_pubkeys: vec![],
+                    offchain_signer_commitment: U256::ZERO,
+                }),
+                accepted_at: 50,
+                resource_locks: vec![],
+            })
+            .await
+            .unwrap();
+
+        let oldest_ops = repository
+            .oldest_queued(BatchKind::Operations, 2)
+            .await
+            .unwrap();
+        assert_eq!(
+            oldest_ops
+                .iter()
+                .map(|request| request.id)
+                .collect::<Vec<_>>(),
+            vec![first_id, second_id]
+        );
+        assert!(
+            repository
+                .oldest_queued(BatchKind::Operations, 0)
+                .await
+                .unwrap()
+                .is_empty()
+        );
+
+        let oldest_create = repository
+            .oldest_queued(BatchKind::CreateAccounts, 1)
+            .await
+            .unwrap();
+        assert_eq!(oldest_create[0].id, create_id);
+    }
+
+    #[tokio::test]
+    async fn skips_stale_queue_members() {
+        let (redis_url, _redis) = start_redis().await;
+        let repository = connect_repository(&redis_url).await;
+        let stale_id = RequestId(Uuid::from_u128(1));
+        let queued_id = RequestId(Uuid::from_u128(2));
+        repository
+            .accept(operation_request_at(stale_id, 1, 100))
+            .await
+            .unwrap();
+        repository
+            .accept(operation_request_at(queued_id, 2, 200))
+            .await
+            .unwrap();
+
+        let mut manager = repository.manager.clone();
+        let _: usize = redis::cmd("DEL")
+            .arg(stale_id.redis_key())
+            .query_async(&mut manager)
+            .await
+            .unwrap();
+
+        let oldest = repository
+            .oldest_queued(BatchKind::Operations, 1)
+            .await
+            .unwrap();
+        assert_eq!(oldest.len(), 1);
+        assert_eq!(oldest[0].id, queued_id);
     }
 }


### PR DESCRIPTION
Implements the request-storage portion of the batching design: constructs the repository set, persists and reads queued requests in deterministic order, and atomically fails queued requests while releasing only locks they still own.

Validation: gateway check and clippy pass; seven Redis-backed request-repository tests pass.