### PR TITLE
fix!: don't expose fe with modulo reduction

### DIFF
--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -133,9 +133,10 @@ impl FieldElement {
     /// # Warning
     /// Use this function carefully. This function will perform modulo reduction on the input, which may
     /// lead to unexpected results if the input should not be reduced. For example, this is **not** appropriate
-    /// when parsing a canonical field-element encoding.
+    /// when parsing a canonical field-element encoding. Because of the potential footgun, it is not exposed beyond
+    /// this crate.
     #[must_use]
-    pub fn from_be_bytes_mod_order(bytes: &[u8]) -> Self {
+    pub(crate) fn from_be_bytes_mod_order(bytes: &[u8]) -> Self {
         let field_element = Fq::from_be_bytes_mod_order(bytes);
         Self(field_element)
     }


### PR DESCRIPTION
Lowering arbitrary bytes to the field with modulo reduction can be a common pitfall. Depending on the use case, collisions could be undesirable or even disastrous. Almost all use cases are best suited for lowering through a uniform hash function to prevent collisions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking public API change in cryptographic field-element construction; reduces footgun risk but may require downstream migrations to `from_be_bytes` or `from_arbitrary_raw_bytes`.
> 
> **Overview**
> **Breaking change:** `FieldElement::from_be_bytes_mod_order` is no longer part of the public API—it is now `pub(crate)` so only code inside `world-id-primitives` can call it.
> 
> The docs are tightened to spell out that modulo-reducing arbitrary bytes into the field is easy to misuse (e.g. not for canonical encodings, collision risk) and that callers should prefer mechanisms like **`from_arbitrary_raw_bytes`** (Keccak-based) or strict **`from_be_bytes`**. In-crate callers such as Poseidon domain-separator lowering keep using the helper unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4c179808c6273a4a5465defeb717679aa275adb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->