### PR TITLE
refactor(node): remove is_blocked and billing contract

### DIFF
--- a/crates/core/tests/generate_proof.rs
+++ b/crates/core/tests/generate_proof.rs
@@ -65,7 +65,6 @@ async fn e2e_authenticator_generate_proof() -> Result<()> {
         anvil,
         world_id_registry,
         rp_registry,
-        billing_contract,
         oprf_key_registry,
         world_id_verifier,
         credential_registry,
@@ -197,7 +196,6 @@ async fn e2e_authenticator_generate_proof() -> Result<()> {
         node_secret_managers,
         world_id_registry,
         rp_registry,
-        billing_contract,
         credential_registry,
     )
     .await;

--- a/crates/primitives/src/oprf.rs
+++ b/crates/primitives/src/oprf.rs
@@ -174,9 +174,6 @@ pub enum WorldIdRequestAuthError {
     /// request proofs. If you are the RP, call `updateRp` to re-activate.
     #[error("inactive_rp")]
     InactiveRp,
-    /// Blocked RP. The RP is marked as blocked in the billing contract. Blocked RPs cannot request proofs. If you are the RP, call `pay` at the billing contract to re-activate.
-    #[error("blocked_rp")]
-    BlockedRp,
     /// **Only valid for Credential Blinding Factor generation**.
     ///
     /// The `issuerSchemaId` provided to generate a blinding factor is not valid. The
@@ -303,7 +300,6 @@ impl WorldIdRequestAuthError {
         match self {
             Self::UnknownRp
             | Self::InactiveRp
-            | Self::BlockedRp
             | Self::CreatedAtTooOld
             | Self::CreatedAtTooFarInFuture
             | Self::ExpiresAtTooFarInFuture
@@ -335,7 +331,6 @@ impl From<u16> for WorldIdRequestAuthError {
     fn from(value: u16) -> Self {
         match value {
             error_codes::UNKNOWN_RP => Self::UnknownRp,
-            error_codes::BLOCKED_RP => Self::BlockedRp,
             error_codes::INACTIVE_RP => Self::InactiveRp,
             error_codes::CREATED_AT_TOO_OLD => Self::CreatedAtTooOld,
             error_codes::INVALID_RP_SIGNATURE => Self::InvalidRpSignature,
@@ -368,7 +363,6 @@ impl From<WorldIdRequestAuthError> for u16 {
     fn from(value: WorldIdRequestAuthError) -> Self {
         match value {
             WorldIdRequestAuthError::UnknownRp => error_codes::UNKNOWN_RP,
-            WorldIdRequestAuthError::BlockedRp => error_codes::BLOCKED_RP,
             WorldIdRequestAuthError::InactiveRp => error_codes::INACTIVE_RP,
             WorldIdRequestAuthError::CreatedAtTooOld => error_codes::CREATED_AT_TOO_OLD,
             WorldIdRequestAuthError::ExpiresAtTooFarInFuture => {
@@ -464,8 +458,6 @@ pub mod error_codes {
     pub const WIP101_VERIFICATION_TIMEOUT: u16 = 4520;
     /// Error code for [`super::WorldIdRequestAuthError::Wip101AccountCheckTimeout`]
     pub const WIP101_ACCOUNT_CHECK_TIMEOUT: u16 = 4521;
-    /// Error code for [`super::WorldIdRequestAuthError::BlockedRp`].
-    pub const BLOCKED_RP: u16 = 4522;
     /// Error code for [`super::WorldIdRequestAuthError::ExpiresAtTooFarInFuture`].
     pub const EXPIRES_AT_TOO_FAR_IN_FUTURE: u16 = 4523;
     /// Error code for [`super::WorldIdRequestAuthError::InvalidRpSignatureVerification`].
@@ -480,9 +472,6 @@ impl From<WorldIdRequestAuthError> for OprfRequestAuthenticatorError {
         let msg = match value {
             WorldIdRequestAuthError::UnknownRp => {
                 taceo_oprf::types::close_frame_message!("unknown RP")
-            }
-            WorldIdRequestAuthError::BlockedRp => {
-                taceo_oprf::types::close_frame_message!("RP blocked by billing contract")
             }
             WorldIdRequestAuthError::CreatedAtTooOld => {
                 taceo_oprf::types::close_frame_message!("created_at too old")
@@ -667,7 +656,6 @@ mod tests {
     fn error_code_roundtrip() {
         let codes: &[u16] = &[
             error_codes::UNKNOWN_RP,
-            error_codes::BLOCKED_RP,
             error_codes::CREATED_AT_TOO_OLD,
             error_codes::CREATED_AT_TOO_FAR_IN_FUTURE,
             error_codes::INVALID_RP_SIGNATURE,

--- a/crates/test-utils/src/anvil.rs
+++ b/crates/test-utils/src/anvil.rs
@@ -169,16 +169,6 @@ sol!(
     )
 );
 
-// FIXME replace me with the actual billing contract as soon as it is done.
-alloy::sol!(
-    #[sol(rpc, bytecode = "60808060405234601357608b908160188239f35b5f80fdfe60808060405260043610156011575f80fd5b5f3560e01c6375298c75146023575f80fd5b3460515760203660031901126051576004359067ffffffffffffffff8216809203605157602a602092148152f35b5f80fdfea2646970667358221220bfb7611c967593ea8addfd14d3e723982bc72dfd2448df1cdcf1563b09adbc4164736f6c634300081e0033")]
-    contract BillingContractMock {
-        function isBlocked(uint64 rpId) external pure returns (bool) {
-            return rpId == 42;
-        }
-    }
-);
-
 // ── State bridge contract bindings ────────────────────────────────────────
 // Each lives in its own module to avoid name collisions on shared internal
 // types (BabyJubJub, IStateBridge, Lib, …).
@@ -661,17 +651,6 @@ impl TestAnvil {
             .context("failed to deploy RpRegistry proxy")?;
 
         Ok(*proxy.address())
-    }
-
-    // FIXME replace me with real billing contract once merged
-    pub async fn deploy_billing_contract(&self, signer: PrivateKeySigner) -> eyre::Result<Address> {
-        let provider = ProviderBuilder::new()
-            .wallet(EthereumWallet::from(signer.clone()))
-            .connect_http(self.rpc_url.parse().context("invalid anvil endpoint URL")?);
-        let billing_contract_mock = BillingContractMock::deploy(provider.clone())
-            .await
-            .context("failed to deploy billing contract")?;
-        Ok(*billing_contract_mock.address())
     }
 
     /// Deploys the `OprfKeyRegistry` contract using the supplied signer.

--- a/crates/test-utils/src/fixtures.rs
+++ b/crates/test-utils/src/fixtures.rs
@@ -26,7 +26,6 @@ pub struct RegistryTestContext {
     pub oprf_key_registry: Address,
     pub credential_registry: Address,
     pub rp_registry: Address,
-    pub billing_contract: Address,
     pub world_id_verifier: Address,
 }
 
@@ -56,10 +55,6 @@ impl RegistryTestContext {
             .deploy_rp_registry(deployer.clone(), oprf_key_registry)
             .await
             .wrap_err("failed to deploy RpRegistry")?;
-        let billing_contract = anvil
-            .deploy_billing_contract(deployer.clone())
-            .await
-            .wrap_err("failed to deploy billing contract")?;
         let world_id_verifier = anvil
             .deploy_world_id_verifier(
                 deployer.clone(),
@@ -95,7 +90,6 @@ impl RegistryTestContext {
             oprf_key_registry,
             credential_registry,
             rp_registry,
-            billing_contract,
             world_id_verifier,
         })
     }

--- a/crates/test-utils/src/stubs.rs
+++ b/crates/test-utils/src/stubs.rs
@@ -199,14 +199,12 @@ async fn spawn_orpf_node(
     secret_manager: taceo_oprf::service::secret_manager::SecretManagerService,
     world_id_registry_contract: Address,
     rp_registry_contract: Address,
-    billing_contract: Address,
     credential_schema_issuer_registry_contract: Address,
 ) -> String {
     let url = format!("http://localhost:1{id:04}"); // set port based on id, e.g. 10001 for id 1
     let bind_addr = format!("0.0.0.0:1{id:04}");
     let contracts = WorldIdNodeContracts {
         world_id_registry_contract,
-        billing_contract,
         rp_registry_contract,
         credential_schema_issuer_registry_contract,
     };
@@ -260,7 +258,6 @@ pub async fn spawn_oprf_nodes(
     ]: [taceo_oprf::service::secret_manager::SecretManagerService; 5],
     world_id_registry_contract: Address,
     rp_registry_contract: Address,
-    billing_contract: Address,
     credential_schema_issuer_registry_contract: Address,
 ) -> [String; 5] {
     tokio::join!(
@@ -270,7 +267,6 @@ pub async fn spawn_oprf_nodes(
             secret_manager0,
             world_id_registry_contract,
             rp_registry_contract,
-            billing_contract,
             credential_schema_issuer_registry_contract,
         ),
         spawn_orpf_node(
@@ -279,7 +275,6 @@ pub async fn spawn_oprf_nodes(
             secret_manager1,
             world_id_registry_contract,
             rp_registry_contract,
-            billing_contract,
             credential_schema_issuer_registry_contract,
         ),
         spawn_orpf_node(
@@ -288,7 +283,6 @@ pub async fn spawn_oprf_nodes(
             secret_manager2,
             world_id_registry_contract,
             rp_registry_contract,
-            billing_contract,
             credential_schema_issuer_registry_contract,
         ),
         spawn_orpf_node(
@@ -297,7 +291,6 @@ pub async fn spawn_oprf_nodes(
             secret_manager3,
             world_id_registry_contract,
             rp_registry_contract,
-            billing_contract,
             credential_schema_issuer_registry_contract,
         ),
         spawn_orpf_node(
@@ -306,7 +299,6 @@ pub async fn spawn_oprf_nodes(
             secret_manager4,
             world_id_registry_contract,
             rp_registry_contract,
-            billing_contract,
             credential_schema_issuer_registry_contract,
         ),
     )

--- a/services/oprf-node/src/auth.rs
+++ b/services/oprf-node/src/auth.rs
@@ -84,7 +84,6 @@ mod tests {
     use taceo_oprf::core::oprf::BlindingFactor;
     use world_id_primitives::{
         AuthenticatorPublicKeySet, FieldElement, Signer, TREE_DEPTH, merkle::MerkleInclusionProof,
-        rp::RpId,
     };
     use world_id_proof::{circuit_inputs::QueryProofCircuitInput, errors};
     use world_id_test_utils::{
@@ -116,10 +115,8 @@ mod tests {
         pub(crate) anvil: TestAnvil,
         pub(crate) world_id_registry: Address,
         pub(crate) rp_registry: Address,
-        pub(crate) billing_contract: Address,
         pub(crate) credential_schema_issuer_registry: Address,
         pub(crate) issuer_schema_id: u64,
-        pub(crate) blocked_rp: RpId,
         pub(crate) rp_fixture: RpFixture,
         pub(crate) merkle_inclusion_proof: MerkleInclusionProof<TREE_DEPTH>,
         pub(crate) key_index: u64,
@@ -138,7 +135,6 @@ mod tests {
     }
 
     impl OprfRequestAuthTestSetup {
-        #[expect(clippy::too_many_lines, reason = "doesn't matter in test")]
         pub(crate) async fn new(kind: SetupKind) -> eyre::Result<Self> {
             let mut rng = rand::thread_rng();
             let anvil = TestAnvil::spawn_auto_mine_with_multicall3().await?;
@@ -150,17 +146,14 @@ mod tests {
 
             let rp_fixture = fixtures::generate_rp_fixture();
             let issuer_schema_id = rng.r#gen::<u64>();
-            let blocked_rp = RpId::new(42);
 
             let mut rp_registry = Address::ZERO;
             let mut credential_schema_issuer_registry = Address::ZERO;
-            let mut billing_contract = Address::ZERO;
             match kind {
                 SetupKind::RpModule => {
                     rp_registry = anvil
                         .deploy_rp_registry(deployer.clone(), oprf_key_registry)
                         .await?;
-                    billing_contract = anvil.deploy_billing_contract(deployer.clone()).await?;
                     // Register the RP which also triggers a OPRF key-gen.
                     let rp_signer = LocalSigner::from_signing_key(rp_fixture.signing_key.clone());
                     anvil
@@ -171,17 +164,6 @@ mod tests {
                             rp_signer.address(),
                             rp_signer.address(),
                             "taceo.oprf".to_string(),
-                        )
-                        .await?;
-
-                    anvil
-                        .register_rp(
-                            rp_registry,
-                            deployer.clone(),
-                            blocked_rp,
-                            rp_signer.address(),
-                            rp_signer.address(),
-                            "taceo.blocked".to_string(),
                         )
                         .await?;
                 }
@@ -244,8 +226,6 @@ mod tests {
                 anvil,
                 world_id_registry,
                 rp_registry,
-                billing_contract,
-                blocked_rp,
                 credential_schema_issuer_registry,
                 issuer_schema_id,
                 rp_fixture,
@@ -296,7 +276,6 @@ mod tests {
 
             let rp_registry_watcher = RpRegistryWatcher::init(
                 setup.rp_registry,
-                setup.billing_contract,
                 http_rpc_provider.clone(),
                 timeout_external_eth_call,
                 WatcherCacheConfig::default(),

--- a/services/oprf-node/src/auth/rp_module.rs
+++ b/services/oprf-node/src/auth/rp_module.rs
@@ -19,7 +19,7 @@ use crate::{
     },
     metrics,
 };
-use alloy::primitives::{Address, U256};
+use alloy::primitives::Address;
 use ark_bn254::Bn254;
 use ark_groth16::PreparedVerifyingKey;
 use async_trait::async_trait;
@@ -34,7 +34,6 @@ use tracing::instrument;
 use world_id_primitives::{
     FieldElement, OprfPrefix, OprfPrefixedFieldElement as _,
     oprf::{NullifierOprfRequestAuthV1, RpSignatureVerification, WorldIdRequestAuthError},
-    rp::RpId,
 };
 
 pub(crate) mod wip101;
@@ -75,13 +74,6 @@ pub(crate) enum RpModuleError {
     MerkleWatcher(#[from] Arc<MerkleWatcherError>),
     #[error(transparent)]
     RpRegistry(#[from] Arc<RpRegistryWatcherError>),
-    /// Rp is blocked
-    #[error("rp is blocked: {rp} at block #{block} with timestamp: {timestamp}")]
-    BlockedRp {
-        rp: RpId,
-        block: U256,
-        timestamp: U256,
-    },
     #[error("created_at in request too old, created_at={created_at:?}, current={current:?}")]
     TimestampTooOld {
         created_at: chrono::DateTime<Utc>,
@@ -139,7 +131,6 @@ impl From<&RpModuleError> for WorldIdRequestAuthError {
             RpModuleError::RpSignatureExpired { .. } => Self::RpSignatureExpired,
             RpModuleError::InvalidTimestamp(_) => Self::InvalidTimestamp,
             RpModuleError::RpSignatureMissing => Self::RpSignatureMissing,
-            RpModuleError::BlockedRp { .. } => Self::BlockedRp,
             RpModuleError::CorruptSignature(_) | RpModuleError::InvalidSignature => {
                 Self::InvalidRpSignature
             }
@@ -172,9 +163,6 @@ pub(crate) struct RelyingParty {
     pub(crate) signer: Address,
     pub(crate) oprf_key_id: OprfKeyId,
     pub(crate) account_type: RpAccountType,
-    pub(crate) is_blocked: bool,
-    pub(crate) fetched_at_block: U256,
-    pub(crate) fetched_at_timestamp: U256,
 }
 
 pub(crate) struct RpModuleAuth {
@@ -362,14 +350,6 @@ impl RpModuleAuth {
         tracing::trace!("fetching RP info...");
         // fetch the RP info
         let rp = self.rp_registry_watcher.get_rp(request.auth.rp_id).await?;
-
-        if rp.is_blocked {
-            return Err(RpModuleError::BlockedRp {
-                rp: request.auth.rp_id,
-                block: rp.fetched_at_block,
-                timestamp: rp.fetched_at_timestamp,
-            });
-        }
 
         self.ensure_signature_valid(&rp, action, request).await?;
 

--- a/services/oprf-node/src/auth/rp_module/tests.rs
+++ b/services/oprf-node/src/auth/rp_module/tests.rs
@@ -329,16 +329,6 @@ async fn test_session_invalid_rp_id() -> eyre::Result<()> {
 }
 
 #[tokio::test]
-async fn test_session_blocked_rp_id() -> eyre::Result<()> {
-    let mut setup = RpModuleTestSetup::new_session().await?;
-    // 42 is the blocked RP in the mock
-    setup.request.auth.rp_id = setup.setup.blocked_rp;
-    setup
-        .assert_auth_err(error_codes::BLOCKED_RP, "RP blocked by billing contract")
-        .await
-}
-
-#[tokio::test]
 async fn test_session_invalid_signer() -> eyre::Result<()> {
     let mut setup = RpModuleTestSetup::new_session().await?;
     setup.request.auth.nonce = rand::random();
@@ -588,7 +578,6 @@ fn mock_session_auth(rpc_provider: taceo_nodes_common::web3::HttpRpcProvider) ->
             WatcherCacheConfig::default(),
         ),
         rp_registry_watcher: RpRegistryWatcher::init(
-            Address::ZERO,
             Address::ZERO,
             rpc_provider.clone(),
             DISPATCH_TIMEOUT,

--- a/services/oprf-node/src/auth/rp_module/wip101/tests.rs
+++ b/services/oprf-node/src/auth/rp_module/wip101/tests.rs
@@ -36,9 +36,6 @@ pub(crate) fn relying_party(account_type: RpAccountType) -> RelyingParty {
         signer: Address::ZERO,
         oprf_key_id: OprfKeyId::new(U160::ZERO),
         account_type,
-        is_blocked: false,
-        fetched_at_block: U256::ZERO,
-        fetched_at_timestamp: U256::ZERO,
     }
 }
 

--- a/services/oprf-node/src/auth/rp_registry_watcher.rs
+++ b/services/oprf-node/src/auth/rp_registry_watcher.rs
@@ -3,9 +3,7 @@ use std::{sync::Arc, time::Duration};
 use crate::{
     auth::{
         rp_module::{RelyingParty, wip101},
-        rp_registry_watcher::{
-            BillingContract::BillingContractInstance, RpRegistry::RpRegistryInstance,
-        },
+        rp_registry_watcher::RpRegistry::RpRegistryInstance,
     },
     config::WatcherCacheConfig,
     metrics,
@@ -22,7 +20,7 @@ use taceo_oprf::types::OprfKeyId;
 use tracing::instrument;
 use world_id_primitives::{oprf::WorldIdRequestAuthError, rp::RpId};
 
-// Copied from IRpRegistry.sol/IBillingContract.sol.
+// Copied from IRpRegistry.sol.
 //
 // For brevity we only copy the methods that are relevant for the watcher
 alloy::sol! {
@@ -41,11 +39,6 @@ alloy::sol! {
         error RpIdInactive();
 
         function getRp(uint64 rpId) external view returns (RelyingParty memory);
-    }
-
-    #[sol(rpc)]
-    interface BillingContract {
-        function isBlocked(uint64 rpId) external view returns (bool);
     }
 }
 
@@ -96,7 +89,6 @@ impl From<&RpRegistryWatcherError> for WorldIdRequestAuthError {
 pub(crate) struct RpRegistryWatcher {
     rp_store: Cache<RpId, RelyingParty>,
     rp_registry_contract: RpRegistryInstance<DynProvider>,
-    billing_contract: BillingContractInstance<DynProvider>,
     timeout_external_eth_call: Duration,
     http_rpc_provider: web3::HttpRpcProvider,
 }
@@ -105,7 +97,6 @@ impl RpRegistryWatcher {
     #[instrument(level = "info", skip_all)]
     pub(crate) fn init(
         rp_registry_address: Address,
-        billing_contract_address: Address,
         http_rpc_provider: web3::HttpRpcProvider,
         timeout_external_eth_call: Duration,
         cache_config: WatcherCacheConfig,
@@ -113,10 +104,6 @@ impl RpRegistryWatcher {
         Self {
             rp_store: cache_config.build_cache(),
             rp_registry_contract: RpRegistry::new(rp_registry_address, http_rpc_provider.inner()),
-            billing_contract: BillingContract::new(
-                billing_contract_address,
-                http_rpc_provider.inner(),
-            ),
             timeout_external_eth_call,
             http_rpc_provider,
         }
@@ -156,20 +143,17 @@ impl RpRegistryWatcher {
         let rp_id_u64 = rp_id.into_inner();
         let get_rp_call =
             CallItemBuilder::new(self.rp_registry_contract.getRp(rp_id_u64)).allow_failure(true);
-        let (get_rp_result, is_blocked, current_block, timestamp) = self
+        let (get_rp_result, current_block, timestamp) = self
             .rp_registry_contract
             .provider()
             .multicall()
             .add_call(get_rp_call)
-            // we expect that isBlocked cannot revert
-            .add(self.billing_contract.isBlocked(rp_id_u64))
             .get_block_number()
             .get_current_block_timestamp()
             .aggregate3()
             .await
             .context("while doing fetch-rp multi-call")?;
 
-        let is_blocked = is_blocked.context("is_blocked failed but allow-failure=false")?;
         let current_block = current_block.context("block_number failed but allow-failure=false")?;
         let timestamp = timestamp.context("timestamp_block failed but allow-failure=false")?;
 
@@ -210,9 +194,6 @@ impl RpRegistryWatcher {
             signer: rp.signer,
             oprf_key_id: OprfKeyId::new(rp.oprfKeyId),
             account_type,
-            is_blocked,
-            fetched_at_block: current_block,
-            fetched_at_timestamp: timestamp,
         };
 
         Ok(relying_party)
@@ -229,7 +210,7 @@ mod tests {
 
     use crate::{auth::tests::build_http_provider, config::WatcherCacheConfig};
 
-    /// Deploys only what the watcher needs (RP registry + billing mock) and registers one RP.
+    /// Deploys only what the watcher needs (RP registry) and registers one RP.
     async fn setup(
         ttl: Duration,
     ) -> eyre::Result<(RpRegistryWatcher, TestAnvil, fixtures::RpFixture, Address)> {
@@ -241,7 +222,6 @@ mod tests {
         let rp_registry = anvil
             .deploy_rp_registry(deployer.clone(), oprf_key_registry)
             .await?;
-        let billing_contract = anvil.deploy_billing_contract(deployer.clone()).await?;
 
         let rp_fixture = fixtures::generate_rp_fixture();
         let rp_signer = LocalSigner::from_signing_key(rp_fixture.signing_key.clone());
@@ -249,19 +229,8 @@ mod tests {
         anvil
             .register_rp(
                 rp_registry,
-                deployer.clone(),
-                rp_fixture.world_rp_id,
-                rp_signer.address(),
-                rp_signer.address(),
-                "test.domain".to_string(),
-            )
-            .await?;
-
-        anvil
-            .register_rp(
-                rp_registry,
                 deployer,
-                RpId::new(42),
+                rp_fixture.world_rp_id,
                 rp_signer.address(),
                 rp_signer.address(),
                 "test.domain".to_string(),
@@ -271,7 +240,6 @@ mod tests {
 
         let watcher = RpRegistryWatcher::init(
             rp_registry,
-            billing_contract,
             http_rpc_provider,
             Duration::from_secs(10),
             WatcherCacheConfig {
@@ -296,29 +264,8 @@ mod tests {
             LocalSigner::from_signing_key(rp_fixture.signing_key.clone()).address();
         assert_eq!(rp.signer, expected_signer);
 
-        assert!(!rp.is_blocked, "RP should not be blocked");
         assert!(
             watcher.rp_store.contains_key(&rp_fixture.world_rp_id),
-            "Cache should have stored RP"
-        );
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_blocked_rp_cached() -> eyre::Result<()> {
-        let (watcher, _anvil, _, _) = setup(Duration::from_secs(10)).await?;
-        let blocked_rp = RpId::new(42);
-
-        // 42 is blocked on the mock contract
-        let rp = watcher
-            .get_rp(blocked_rp)
-            .await
-            .expect("getRp should succeed and cache the RP");
-
-        assert!(rp.is_blocked, "RP should be blocked");
-
-        assert!(
-            watcher.rp_store.contains_key(&blocked_rp),
             "Cache should have stored RP"
         );
         Ok(())

--- a/services/oprf-node/src/config.rs
+++ b/services/oprf-node/src/config.rs
@@ -17,9 +17,6 @@ pub struct WorldOprfNodeConfig {
     /// The address of the `RpRegistry` smart contract
     pub rp_registry_contract: Address,
 
-    /// The address of the `Billing` smart contract
-    pub billing_contract: Address,
-
     /// The address of the `CredentialSchemaIssuerRegistry` smart contract
     pub credential_schema_issuer_registry_contract: Address,
 
@@ -51,8 +48,6 @@ pub struct WorldOprfNodeConfig {
     pub created_at_max_difference: Duration,
 
     /// Maximum allowed delta between `expires_at` and `created_at` on RP signatures.
-    ///
-    /// According to WIP107 §3.1 nodes must check that the difference of the `expires_at` and the `created_at` on RP signatures must not be larger than `expires_at_max_difference`.
     #[serde(
         default = "WorldOprfNodeConfig::default_expires_at_max_difference",
         with = "humantime_serde"
@@ -168,13 +163,11 @@ impl WorldOprfNodeConfig {
         let WorldIdNodeContracts {
             world_id_registry_contract,
             rp_registry_contract,
-            billing_contract,
             credential_schema_issuer_registry_contract,
         } = contracts;
         Self {
             world_id_registry_contract,
             rp_registry_contract,
-            billing_contract,
             credential_schema_issuer_registry_contract,
             rpc_provider_config,
             created_at_max_difference: Self::default_created_at_max_difference(),
@@ -200,8 +193,6 @@ pub struct WorldIdNodeContracts {
     pub world_id_registry_contract: Address,
     /// Address of the `RpRegistry` contract.
     pub rp_registry_contract: Address,
-    /// Address of the `Billing` contract.
-    pub billing_contract: Address,
     /// Address of the `CredentialSchemaIssuerRegistry` contract.
     pub credential_schema_issuer_registry_contract: Address,
 }

--- a/services/oprf-node/src/lib.rs
+++ b/services/oprf-node/src/lib.rs
@@ -112,7 +112,6 @@ pub fn start(
     tracing::info!("init RpRegistry watcher..");
     let rp_registry_watcher = RpRegistryWatcher::init(
         config.rp_registry_contract,
-        config.billing_contract,
         http_rpc_provider.clone(),
         config.timeout_external_eth_call,
         config.rp_cache_config,

--- a/tools/generate-solidity-fixtures/src/main.rs
+++ b/tools/generate-solidity-fixtures/src/main.rs
@@ -71,7 +71,6 @@ async fn main() -> Result<()> {
         oprf_key_registry,
         world_id_verifier,
         credential_registry,
-        billing_contract,
     } = RegistryTestContext::new().await?;
 
     let deployer = anvil
@@ -168,7 +167,6 @@ async fn main() -> Result<()> {
         node_secret_managers,
         world_id_registry,
         rp_registry,
-        billing_contract,
         credential_registry,
     )
     .await;


### PR DESCRIPTION
NOTE: this is part of the larger WIP-107 removal

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes RP gating on the OPRF path (previously blocked RPs could not get proofs); inactive/unknown RP checks via `RpRegistry` remain. Aligns with WIP-107 removal but operators must not rely on billing-based blocking until replaced elsewhere.
> 
> **Overview**
> Removes **WIP-107 billing integration** from OPRF RP authentication: nodes no longer consult a billing contract or reject “blocked” RPs during proof requests.
> 
> **OPRF node** — `RpRegistryWatcher` only multicalls `RpRegistry.getRp` (plus block/timestamp); `BillingContract.isBlocked` and `RelyingParty.is_blocked` / fetch metadata are gone. `RpModuleAuth` no longer returns `BlockedRp` after loading an RP. Node config drops `billing_contract` from `WorldOprfNodeConfig` and `WorldIdNodeContracts`.
> 
> **Primitives** — Deletes `WorldIdRequestAuthError::BlockedRp`, wire code `BLOCKED_RP` (4522), and the associated close-frame message and error roundtrip mappings.
> 
> **Tests & tooling** — Removes the Anvil `BillingContractMock`, fixture deployment, blocked-RP registration (e.g. rpId 42), and tests such as `test_session_blocked_rp_id` / `test_blocked_rp_cached`. E2E and stub OPRF startup no longer pass a billing address.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b70e58009ce5e1ea6b0c638a1e7fb4633469cc64. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->