### PR TITLE
docs: state the trust anchor obligation on the WIP-106 verifiers

### DIFF
--- a/crates/proof/noir/authenticator-assertion/src/aat.nr
+++ b/crates/proof/noir/authenticator-assertion/src/aat.nr
@@ -46,13 +46,24 @@ pub struct AuthenticatorAssertionToken {
 /// freshness on both the AAT and its nested TAKT (`now < exp`). It MUST be a
 /// public input of any outer proof that calls this function.
 ///
-/// The chain is only as trustworthy as its root: the TAKT's `trust_anchor_key`
-/// is witness-selected, so an outer proof MUST bind it to an approved
-/// Authenticator Provider. See `verify_takt` for what that binding requires.
-/// Without it, this function accepts a self-attested chain.
-///
 /// This is the primary entrypoint; the TAKT digest is computed exactly once
 /// along this path (inside `verify_takt`).
+///
+/// # Trust anchor
+///
+/// The chain is only as trustworthy as its root, and this function does not
+/// establish that root. The nested TAKT's `trust_anchor_key` comes from the
+/// witness, so a verified chain proves only that *some* key attested the
+/// assertion key, not that the key belongs to an approved Authenticator
+/// Provider: a prover can mint a keypair and self-attest any assertion key
+/// with any `sec_flags`, and this function will accept the result. Any outer
+/// proof MUST establish that binding itself, by either:
+/// - proving the anchor's membership in an approved provider registry
+///   in-circuit, or
+/// - exposing the anchor as a public input the verifier checks against that
+///   registry. Note this reveals which provider attested the authenticator,
+///   narrowing the anonymity set; prefer in-circuit membership where the
+///   provider set is not already public per proof.
 pub fn verify_aat(aat: AuthenticatorAssertionToken, now: Field) {
     // CBOR uint32 encoding of `exp` is checked later in `aat_sig_structure`.
     assert_not_expired(aat.exp, now);

--- a/crates/proof/noir/authenticator-assertion/src/aat.nr
+++ b/crates/proof/noir/authenticator-assertion/src/aat.nr
@@ -46,6 +46,11 @@ pub struct AuthenticatorAssertionToken {
 /// freshness on both the AAT and its nested TAKT (`now < exp`). It MUST be a
 /// public input of any outer proof that calls this function.
 ///
+/// The chain is only as trustworthy as its root: the TAKT's `trust_anchor_key`
+/// is witness-selected, so an outer proof MUST bind it to an approved
+/// Authenticator Provider. See `verify_takt` for what that binding requires.
+/// Without it, this function accepts a self-attested chain.
+///
 /// This is the primary entrypoint; the TAKT digest is computed exactly once
 /// along this path (inside `verify_takt`).
 pub fn verify_aat(aat: AuthenticatorAssertionToken, now: Field) {

--- a/crates/proof/noir/authenticator-assertion/src/takt.nr
+++ b/crates/proof/noir/authenticator-assertion/src/takt.nr
@@ -28,6 +28,20 @@ pub struct TrustAnchorKeyToken {
 /// `now` is the verifier-supplied Unix time (seconds) against which CWT `exp`
 /// freshness is checked (`now < exp`). It MUST be a public input of any outer
 /// proof that calls this function.
+///
+/// # Trust anchor
+///
+/// `trust_anchor_key_x` / `trust_anchor_key_y` come from the witness, so this
+/// function proves only that *some* key signed the token, not that the key
+/// belongs to an approved Authenticator Provider. A prover can mint a keypair
+/// and self-attest any assertion key and any `sec_flags`. Establishing that
+/// binding is the outer proof's responsibility, and it MUST do so by either:
+/// - proving the anchor's membership in an approved provider registry
+///   in-circuit, or
+/// - exposing the anchor as a public input the verifier checks against that
+///   registry. Note this reveals which provider attested the authenticator,
+///   narrowing the anonymity set; prefer in-circuit membership where the
+///   provider set is not already public per proof.
 pub fn verify_takt(input: TrustAnchorKeyToken, now: Field) {
     // CBOR uint32 encoding of `exp` is checked later in `serialize_takt`.
     assert_not_expired(input.exp, now);

--- a/crates/proof/noir/authenticator-assertion/src/takt.nr
+++ b/crates/proof/noir/authenticator-assertion/src/takt.nr
@@ -29,19 +29,10 @@ pub struct TrustAnchorKeyToken {
 /// freshness is checked (`now < exp`). It MUST be a public input of any outer
 /// proof that calls this function.
 ///
-/// # Trust anchor
-///
-/// `trust_anchor_key_x` / `trust_anchor_key_y` come from the witness, so this
-/// function proves only that *some* key signed the token, not that the key
-/// belongs to an approved Authenticator Provider. A prover can mint a keypair
-/// and self-attest any assertion key and any `sec_flags`. Establishing that
-/// binding is the outer proof's responsibility, and it MUST do so by either:
-/// - proving the anchor's membership in an approved provider registry
-///   in-circuit, or
-/// - exposing the anchor as a public input the verifier checks against that
-///   registry. Note this reveals which provider attested the authenticator,
-///   narrowing the anonymity set; prefer in-circuit membership where the
-///   provider set is not already public per proof.
+/// `trust_anchor_key_x` / `trust_anchor_key_y` come from the witness: this
+/// verifies the token's signature, not that the signer is an approved
+/// Authenticator Provider. Callers MUST establish that binding themselves; see
+/// `verify_aat` for what it requires.
 pub fn verify_takt(input: TrustAnchorKeyToken, now: Field) {
     // CBOR uint32 encoding of `exp` is checked later in `serialize_takt`.
     assert_not_expired(input.exp, now);


### PR DESCRIPTION
Adds comments for consistency reasons. Addresses Finding 5 in https://hackmd.io/@m1guelpf/protocol-daybreak.