### PR TITLE
refactor: share verification logic between the verifiers

### DIFF
--- a/contracts/src/core/UnreleasedWorldIDVerifierV3.sol
+++ b/contracts/src/core/UnreleasedWorldIDVerifierV3.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.13;
 import {WorldIDVerifierV2} from "./WorldIDVerifierV2.sol";
 import {IWorldIDVerifier} from "./interfaces/IWorldIDVerifier.sol";
 import {IWorldIDVerifierV3} from "./interfaces/UnreleasedIWorldIDVerifierV3.sol";
+import {WorldIDVerification} from "./libraries/WorldIDVerification.sol";
 
 /**
  * @title WorldIDVerifierV3
@@ -27,12 +28,8 @@ contract WorldIDVerifierV3 is IWorldIDVerifierV3, WorldIDVerifierV2 {
         uint256 sessionId,
         uint256[5] calldata zeroKnowledgeProof
     ) external view virtual override onlyProxy onlyInitialized {
-        if (uint8(action >> 248) != uint8(0)) {
-            revert InvalidAction();
-        }
-        if (sessionId == 0) {
-            revert InvalidSessionId();
-        }
+        WorldIDVerification.requireUniquenessDomain(action);
+        WorldIDVerification.requireSessionId(sessionId);
 
         verifyProofAndSignals(
             nullifier,
@@ -63,12 +60,8 @@ contract WorldIDVerifierV3 is IWorldIDVerifierV3, WorldIDVerifierV2 {
         uint256[5] calldata zeroKnowledgeProof
     ) external view virtual override(IWorldIDVerifier, WorldIDVerifierV2) onlyProxy onlyInitialized {
         uint256 action = sessionNullifier[1];
-        if (uint8(action >> 248) != uint8(2)) {
-            revert InvalidAction();
-        }
-        if (sessionId == 0) {
-            revert InvalidSessionId();
-        }
+        WorldIDVerification.requireSessionDomain(action);
+        WorldIDVerification.requireSessionId(sessionId);
 
         verifyProofAndSignals(
             sessionNullifier[0],

--- a/contracts/src/core/WorldIDVerifier.sol
+++ b/contracts/src/core/WorldIDVerifier.sol
@@ -9,6 +9,7 @@ import {WorldIDRegistry} from "./WorldIDRegistry.sol";
 import {Verifier} from "./Verifier.sol";
 import {IWorldIDVerifier} from "./interfaces/IWorldIDVerifier.sol";
 import {WorldIDBase} from "./abstract/WorldIDBase.sol";
+import {WorldIDVerification} from "./libraries/WorldIDVerification.sol";
 
 /**
  * @title WorldIDVerifier
@@ -160,53 +161,40 @@ contract WorldIDVerifier is WorldIDBase, IWorldIDVerifier {
         uint256 sessionId,
         uint256[5] calldata zeroKnowledgeProof
     ) public view virtual onlyProxy onlyInitialized {
-        uint256 worldIdRegistryMerkleRoot = zeroKnowledgeProof[4];
-        if (!_worldIDRegistry.isValidRoot(worldIdRegistryMerkleRoot)) {
+        if (!_worldIDRegistry.isValidRoot(zeroKnowledgeProof[4])) {
             revert InvalidMerkleRoot();
         }
 
         ICredentialSchemaIssuerRegistry.Pubkey memory credentialIssuerPubkey =
             _credentialSchemaIssuerRegistry.issuerSchemaIdToPubkey(issuerSchemaId);
-        if (credentialIssuerPubkey.x == 0 || credentialIssuerPubkey.y == 0) {
-            revert UnregisteredIssuerSchemaId();
-        }
 
         // NOTICE: Currently the `oprfKeyId` is the same as the `rpId`. This may change in the future in the `RpRegistry` contract
-        uint160 oprfKeyId = uint160(rpId);
-        BabyJubJub.Affine memory oprfPublicKey = _oprfKeyRegistry.getOprfPublicKey(oprfKeyId);
+        // The registry reverts on an unknown or deleted id, so the pubkey returned here is never empty.
+        BabyJubJub.Affine memory oprfPublicKey = _oprfKeyRegistry.getOprfPublicKey(uint160(rpId));
 
-        // The proof guarantees the credential's private `expires_at` is greater than
-        // the public `expiresAtMin` input. Reject if that lower bound is more than
-        // `_minExpirationThreshold` older than the current block timestamp, preventing
-        // proofs that only show the credential expires after a timestamp too far in the past.
-        if (uint256(expiresAtMin + _minExpirationThreshold) < block.timestamp) {
-            revert ExpirationTooOld();
-        }
-
-        uint256[15] memory pubSignals;
-
-        pubSignals[0] = nullifier;
-        pubSignals[1] = issuerSchemaId;
-        pubSignals[2] = credentialIssuerPubkey.x;
-        pubSignals[3] = credentialIssuerPubkey.y;
-        pubSignals[4] = uint256(expiresAtMin);
-        pubSignals[5] = credentialGenesisIssuedAtMin;
-        pubSignals[6] = worldIdRegistryMerkleRoot;
-        pubSignals[7] = _treeDepth;
-        pubSignals[8] = uint256(rpId);
-        pubSignals[9] = action;
-        pubSignals[10] = oprfPublicKey.x;
-        pubSignals[11] = oprfPublicKey.y;
-        pubSignals[12] = signalHash;
-        pubSignals[13] = nonce;
-        pubSignals[14] = sessionId;
-
-        uint256[4] memory groth16CompressedProof;
-        for (uint256 i = 0; i < 4; i++) {
-            groth16CompressedProof[i] = zeroKnowledgeProof[i];
-        }
-
-        _verifier.verifyCompressedProof(groth16CompressedProof, pubSignals);
+        WorldIDVerification.verify(
+            WorldIDVerification.Context({
+                verifier: _verifier,
+                treeDepth: _treeDepth,
+                minExpirationThreshold: _minExpirationThreshold,
+                issuerPubkeyX: credentialIssuerPubkey.x,
+                issuerPubkeyY: credentialIssuerPubkey.y,
+                oprfPubkeyX: oprfPublicKey.x,
+                oprfPubkeyY: oprfPublicKey.y
+            }),
+            WorldIDVerification.Signals({
+                nullifier: nullifier,
+                action: action,
+                rpId: rpId,
+                nonce: nonce,
+                signalHash: signalHash,
+                expiresAtMin: expiresAtMin,
+                issuerSchemaId: issuerSchemaId,
+                credentialGenesisIssuedAtMin: credentialGenesisIssuedAtMin,
+                sessionId: sessionId
+            }),
+            zeroKnowledgeProof
+        );
     }
 
     /// @inheritdoc IWorldIDVerifier

--- a/contracts/src/core/WorldIDVerifierV2.sol
+++ b/contracts/src/core/WorldIDVerifierV2.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.13;
 import {WorldIDVerifier} from "./WorldIDVerifier.sol";
 import {IWorldIDVerifier} from "./interfaces/IWorldIDVerifier.sol";
 import {IWorldIDVerifierV2} from "./interfaces/IWorldIDVerifierV2.sol";
+import {WorldIDVerification} from "./libraries/WorldIDVerification.sol";
 
 /**
  * @title WorldIDVerifier
@@ -26,9 +27,7 @@ contract WorldIDVerifierV2 is IWorldIDVerifierV2, WorldIDVerifier {
         uint256 credentialGenesisIssuedAtMin,
         uint256[5] calldata zeroKnowledgeProof
     ) external view virtual override(IWorldIDVerifier, WorldIDVerifier) onlyProxy onlyInitialized {
-        if (uint8(action >> 248) != uint8(0)) {
-            revert InvalidAction();
-        }
+        WorldIDVerification.requireUniquenessDomain(action);
 
         verifyProofAndSignals(
             nullifier,
@@ -59,9 +58,7 @@ contract WorldIDVerifierV2 is IWorldIDVerifierV2, WorldIDVerifier {
         uint256[5] calldata zeroKnowledgeProof
     ) external view virtual override(IWorldIDVerifier, WorldIDVerifier) onlyProxy onlyInitialized {
         uint256 action = sessionNullifier[1];
-        if (uint8(action >> 248) != uint8(2)) {
-            revert InvalidAction();
-        }
+        WorldIDVerification.requireSessionDomain(action);
 
         verifyProofAndSignals(
             sessionNullifier[0],

--- a/contracts/src/core/libraries/WorldIDVerification.sol
+++ b/contracts/src/core/libraries/WorldIDVerification.sol
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import {Verifier} from "../Verifier.sol";
+
+/**
+ * @title WorldIDVerification
+ * @author World Contributors
+ * @notice Shared World ID proof verification logic, used by every verifier regardless of where its
+ *  state comes from: `WorldIDVerifier` reads live registries on World Chain, `WorldIDSatellite`
+ *  reads state bridged to a destination chain.
+ * @dev The caller resolves its own state into a `Context` and then hands off, so the public signal
+ *  layout, the action-domain convention and the validity checks exist in exactly one place. Only
+ *  root validity stays with the caller: the two verifiers answer it from genuinely different state
+ *  (a registry call versus a bridged root plus a local validity window).
+ * @dev These are `internal` functions, so they are inlined into the calling contract. The library is
+ *  not deployed and introduces no delegatecall and no linking.
+ */
+library WorldIDVerification {
+    ////////////////////////////////////////////////////////////
+    //                        ERRORS                          //
+    ////////////////////////////////////////////////////////////
+
+    /**
+     * @dev Thrown when the action is not valid for the type of proof. The prefix is enforced
+     *  to ensure any nullifier request for a Uniqueness Proof is signed by the RP (actions
+     *  without this prefix, i.e. for sessions, it doesn't need to be signed).
+     */
+    error InvalidAction();
+
+    /**
+     * @dev Thrown when a session-carrying verification is attempted with `sessionId == 0`. Zero is
+     *  the circuit's "no session" sentinel and is satisfiable by any World ID, so it proves nothing.
+     */
+    error InvalidSessionId();
+
+    /**
+     * @dev Thrown when the credential minimum expiration constraint is too old. A new proof should
+     *  be requested with a fresher expiration.
+     */
+    error ExpirationTooOld();
+
+    /**
+     * @dev Thrown when the credential issuer schema ID is not registered.
+     */
+    error UnregisteredIssuerSchemaId();
+
+    /**
+     * @dev Thrown when the OPRF key ID is not registered.
+     */
+    error UnregisteredOprfKeyId();
+
+    ////////////////////////////////////////////////////////////
+    //                       CONSTANTS                        //
+    ////////////////////////////////////////////////////////////
+
+    /// @dev Bit offset of an action's most significant byte, which carries the OPRF input domain.
+    uint256 internal constant ACTION_DOMAIN_OFFSET = 248;
+
+    /// @dev Action domain for Uniqueness Proofs. Mirrors `OprfPrefix::Uniqueness` in `world-id-primitives`.
+    uint8 internal constant UNIQUENESS_DOMAIN = 0x00;
+
+    /// @dev Action domain for Session Proofs. Mirrors `OprfPrefix::SessionAction` in `world-id-primitives`.
+    uint8 internal constant SESSION_DOMAIN = 0x02;
+
+    ////////////////////////////////////////////////////////////
+    //                        TYPES                           //
+    ////////////////////////////////////////////////////////////
+
+    /**
+     * @notice The verifier state a proof is checked against, resolved by the caller.
+     * @param verifier The Groth16 verifier the proof is submitted to.
+     * @param treeDepth Depth of the World ID Merkle tree, as a circuit public input.
+     * @param minExpirationThreshold How far in the past `expiresAtMin` may be, in seconds.
+     * @param issuerPubkeyX Credential issuer public key, x coordinate. Zero when unregistered.
+     * @param issuerPubkeyY Credential issuer public key, y coordinate. Zero when unregistered.
+     * @param oprfPubkeyX OPRF public key for the `rpId`, x coordinate. Zero when unregistered.
+     * @param oprfPubkeyY OPRF public key for the `rpId`, y coordinate. Zero when unregistered.
+     */
+    struct Context {
+        Verifier verifier;
+        uint256 treeDepth;
+        uint256 minExpirationThreshold;
+        uint256 issuerPubkeyX;
+        uint256 issuerPubkeyY;
+        uint256 oprfPubkeyX;
+        uint256 oprfPubkeyY;
+    }
+
+    /**
+     * @notice The circuit public signals carried by a verification request.
+     * @dev Field order is presentation only; `_publicSignals` fixes the order the circuit expects.
+     */
+    struct Signals {
+        uint256 nullifier;
+        uint256 action;
+        uint64 rpId;
+        uint256 nonce;
+        uint256 signalHash;
+        uint64 expiresAtMin;
+        uint64 issuerSchemaId;
+        uint256 credentialGenesisIssuedAtMin;
+        uint256 sessionId;
+    }
+
+    ////////////////////////////////////////////////////////////
+    //                    DOMAIN CHECKS                       //
+    ////////////////////////////////////////////////////////////
+
+    /// @notice Requires `action` to be in the uniqueness domain (most significant byte `0x00`).
+    function requireUniquenessDomain(uint256 action) internal pure {
+        if (uint8(action >> ACTION_DOMAIN_OFFSET) != UNIQUENESS_DOMAIN) revert InvalidAction();
+    }
+
+    /// @notice Requires `action` to be in the session domain (most significant byte `0x02`).
+    function requireSessionDomain(uint256 action) internal pure {
+        if (uint8(action >> ACTION_DOMAIN_OFFSET) != SESSION_DOMAIN) revert InvalidAction();
+    }
+
+    /// @notice Requires a session-carrying verification to name an actual session.
+    function requireSessionId(uint256 sessionId) internal pure {
+        if (sessionId == 0) revert InvalidSessionId();
+    }
+
+    ////////////////////////////////////////////////////////////
+    //                     VERIFICATION                       //
+    ////////////////////////////////////////////////////////////
+
+    /**
+     * @notice Checks the resolved state and public signals, then verifies the Groth16 proof.
+     * @dev The caller MUST have already rejected an invalid Merkle root; `zeroKnowledgeProof[4]` is
+     *  taken as valid here and packed as the root public input.
+     * @param ctx The verifier state to check against.
+     * @param signals The circuit public signals.
+     * @param zeroKnowledgeProof Compressed Groth16 proof in the first 4 elements, Merkle root in the last.
+     */
+    function verify(Context memory ctx, Signals memory signals, uint256[5] calldata zeroKnowledgeProof) internal view {
+        // A pubkey is "empty" when either coordinate is zero, matching `_isEmptyPubkey` in
+        // `CredentialSchemaIssuerRegistry`, which refuses to register such a key.
+        if (ctx.issuerPubkeyX == 0 || ctx.issuerPubkeyY == 0) revert UnregisteredIssuerSchemaId();
+
+        // The circuit does not constrain `oprf_pk` to be a valid curve point (see the note in
+        // `oprf_nullifier.circom`), so an unregistered key must never reach the public signals.
+        // Unreachable where the OPRF registry itself reverts on an unknown id.
+        if (ctx.oprfPubkeyX == 0 || ctx.oprfPubkeyY == 0) revert UnregisteredOprfKeyId();
+
+        // The proof guarantees the credential's private `expires_at` is greater than
+        // the public `expiresAtMin` input. Reject if that lower bound is more than
+        // `minExpirationThreshold` older than the current block timestamp, preventing
+        // proofs that only show the credential expires after a timestamp too far in the past.
+        if (uint256(signals.expiresAtMin) + ctx.minExpirationThreshold < block.timestamp) {
+            revert ExpirationTooOld();
+        }
+
+        uint256[4] memory groth16CompressedProof;
+        for (uint256 i = 0; i < 4; i++) {
+            groth16CompressedProof[i] = zeroKnowledgeProof[i];
+        }
+
+        ctx.verifier.verifyCompressedProof(groth16CompressedProof, _publicSignals(ctx, signals, zeroKnowledgeProof[4]));
+    }
+
+    /**
+     * @dev Builds the circuit public signals. The order is fixed by the circuit and is the single
+     *  most important invariant in this file: see `component main` in `OPRFNullifierProof.circom`.
+     */
+    function _publicSignals(Context memory ctx, Signals memory signals, uint256 merkleRoot)
+        private
+        pure
+        returns (uint256[15] memory pubSignals)
+    {
+        pubSignals[0] = signals.nullifier;
+        pubSignals[1] = signals.issuerSchemaId;
+        pubSignals[2] = ctx.issuerPubkeyX;
+        pubSignals[3] = ctx.issuerPubkeyY;
+        pubSignals[4] = uint256(signals.expiresAtMin);
+        pubSignals[5] = signals.credentialGenesisIssuedAtMin;
+        pubSignals[6] = merkleRoot;
+        pubSignals[7] = ctx.treeDepth;
+        pubSignals[8] = uint256(signals.rpId);
+        pubSignals[9] = signals.action;
+        pubSignals[10] = ctx.oprfPubkeyX;
+        pubSignals[11] = ctx.oprfPubkeyY;
+        pubSignals[12] = signals.signalHash;
+        pubSignals[13] = signals.nonce;
+        pubSignals[14] = signals.sessionId;
+    }
+}

--- a/contracts/src/crosschain/WorldIDSatellite.sol
+++ b/contracts/src/crosschain/WorldIDSatellite.sol
@@ -5,6 +5,7 @@ import {IWorldID} from "@world-id-bridge/interfaces/IWorldID.sol";
 import {Lib} from "@world-id-bridge/lib/Lib.sol";
 import {StateBridge} from "@world-id-bridge/lib/StateBridge.sol";
 import {Verifier} from "@world-id-core/Verifier.sol";
+import {WorldIDVerification} from "@world-id-core/libraries/WorldIDVerification.sol";
 import {ERC7786Recipient} from "@openzeppelin/contracts/crosschain/ERC7786Recipient.sol";
 
 import "@world-id-bridge/Error.sol";
@@ -63,7 +64,7 @@ contract WorldIDSatellite is IWorldID, ERC7786Recipient, StateBridge {
         uint256 credentialGenesisIssuedAtMin,
         uint256[5] calldata zeroKnowledgeProof
     ) external view virtual {
-        if (uint8(action >> 248) != uint8(0)) revert InvalidAction();
+        WorldIDVerification.requireUniquenessDomain(action);
 
         verifyProofAndSignals(
             nullifier,
@@ -94,8 +95,8 @@ contract WorldIDSatellite is IWorldID, ERC7786Recipient, StateBridge {
         uint256[5] calldata zeroKnowledgeProof
     ) external view virtual {
         uint256 action = sessionNullifier[1];
-        if (uint8(action >> 248) != uint8(2)) revert InvalidAction();
-        if (sessionId == 0) revert InvalidSessionId();
+        WorldIDVerification.requireSessionDomain(action);
+        WorldIDVerification.requireSessionId(sessionId);
 
         verifyProofAndSignals(
             sessionNullifier[0],
@@ -124,37 +125,34 @@ contract WorldIDSatellite is IWorldID, ERC7786Recipient, StateBridge {
         uint256 sessionId,
         uint256[5] calldata proofExt
     ) public view virtual {
-        uint256 root = proofExt[4];
-
-        if (!isValidRoot(root)) revert InvalidMerkleRoot();
-        if (expiresAtMin < block.timestamp - MIN_EXPIRATION_THRESHOLD) revert ExpirationTooOld();
+        if (!isValidRoot(proofExt[4])) revert InvalidMerkleRoot();
 
         ProvenPubKeyInfo memory issuerPubKeyInfo = issuerSchemaIdToPubkeyAndProofId(issuerSchemaId);
-        if (issuerPubKeyInfo.pubKey.x == 0 && issuerPubKeyInfo.pubKey.y == 0) revert UnregisteredIssuerSchemaId();
-
         ProvenPubKeyInfo memory oprfPubKeyInfo = oprfKeyIdToPubkeyAndProofId(uint160(rpId));
-        if (oprfPubKeyInfo.pubKey.x == 0 && oprfPubKeyInfo.pubKey.y == 0) revert UnregisteredOprfKeyId();
 
-        uint256[4] memory proof = [proofExt[0], proofExt[1], proofExt[2], proofExt[3]];
-        uint256[15] memory input = [
-            nullifier,
-            issuerSchemaId,
-            issuerPubKeyInfo.pubKey.x,
-            issuerPubKeyInfo.pubKey.y,
-            uint256(expiresAtMin),
-            credentialGenesisIssuedAtMin,
-            root,
-            TREE_DEPTH,
-            uint256(rpId),
-            action,
-            oprfPubKeyInfo.pubKey.x,
-            oprfPubKeyInfo.pubKey.y,
-            signalHash,
-            nonce,
-            sessionId
-        ];
-
-        VERIFIER.verifyCompressedProof(proof, input);
+        WorldIDVerification.verify(
+            WorldIDVerification.Context({
+                verifier: VERIFIER,
+                treeDepth: TREE_DEPTH,
+                minExpirationThreshold: MIN_EXPIRATION_THRESHOLD,
+                issuerPubkeyX: issuerPubKeyInfo.pubKey.x,
+                issuerPubkeyY: issuerPubKeyInfo.pubKey.y,
+                oprfPubkeyX: oprfPubKeyInfo.pubKey.x,
+                oprfPubkeyY: oprfPubKeyInfo.pubKey.y
+            }),
+            WorldIDVerification.Signals({
+                nullifier: nullifier,
+                action: action,
+                rpId: rpId,
+                nonce: nonce,
+                signalHash: signalHash,
+                expiresAtMin: expiresAtMin,
+                issuerSchemaId: issuerSchemaId,
+                credentialGenesisIssuedAtMin: credentialGenesisIssuedAtMin,
+                sessionId: sessionId
+            }),
+            proofExt
+        );
     }
 
     /// @inheritdoc IWorldID

--- a/contracts/test/crosschain/SatelliteCoreParity.t.sol
+++ b/contracts/test/crosschain/SatelliteCoreParity.t.sol
@@ -1,0 +1,209 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import {Test} from "forge-std/Test.sol";
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+
+import {WorldIDVerifier} from "../../src/core/WorldIDVerifier.sol";
+import {WorldIDVerifierV3} from "../../src/core/UnreleasedWorldIDVerifierV3.sol";
+import {Verifier} from "../../src/core/Verifier.sol";
+
+import {Lib} from "../../src/crosschain/lib/Lib.sol";
+import {
+    CredentialSchemaIssuerRegistryMock,
+    OprfKeyRegistryMock,
+    WorldIDRegistryMock,
+    WorldIDSatelliteHarness
+} from "./SatelliteVerifierParity.t.sol";
+
+/// @notice Drift guard between the core verifier and the satellite.
+/// @dev The two verifiers reimplement the same checks against different state, which is how they
+///   drifted apart before (the satellite lagged the V2 action-prefix and V3 session-id rules).
+///   `IWorldID` and `IWorldIDVerifier` declare identical signatures, and the shared errors have
+///   identical selectors, so the same calldata can be sent to both and the results compared
+///   byte-for-byte. Any future change that touches one and not the other fails here.
+contract SatelliteCoreParityTest is Test {
+    bytes4 internal constant UPDATE_ROOT_SELECTOR = bytes4(keccak256("updateRoot(uint256,uint256,bytes32)"));
+    bytes4 internal constant SET_ISSUER_PUBKEY_SELECTOR =
+        bytes4(keccak256("setIssuerPubkey(uint64,uint256,uint256,bytes32)"));
+    bytes4 internal constant SET_OPRF_KEY_SELECTOR = bytes4(keccak256("setOprfKey(uint160,uint256,uint256,bytes32)"));
+
+    uint64 internal constant ISSUER_SCHEMA_ID = 1;
+    uint64 internal constant RP_ID = 0x1a6ccf8f70e5de68;
+
+    uint256 internal constant TREE_DEPTH = 30;
+    uint256 internal constant ROOT_VALIDITY_WINDOW = 3600;
+    uint64 internal constant MIN_EXPIRATION_THRESHOLD = 5 hours;
+
+    uint256 internal constant ROOT = 0xaf727d9412a9d5c73b685fd09dc39e727064e65b8269b233009edfc105f9853;
+    uint64 internal constant EXPIRES_AT_MIN = 0x699cfa47;
+
+    uint256 internal constant NULLIFIER = 0x1bae01b23e5f0ee96151331fffb0550351c52e5ee0ced452c762e120723ae702;
+    uint256 internal constant ACTION = 0x15d4b66e5417cb9875f6a2b5be9814dca80651d7c74b3b21685fdd494566e79f;
+    uint256 internal constant SIGNAL_HASH = 0x1578ed0de47522ad0b38e87031739c6a65caecc39ce3410bf3799e756a220f;
+    uint256 internal constant NONCE = 0x18e3ab3d5fedc6eaa5e0d06a3a6f3dd5e0bf2d17b18b797a1cc6ff4706169d1e;
+
+    uint256 internal constant ISSUER_PUBKEY_X = 0x252c8234509649bb469ecb7a7e758f306b41415f2d80d4d67967902d6f589a81;
+    uint256 internal constant ISSUER_PUBKEY_Y = 0x230e4f93a5f1187639314dd25e595db06dc18de219cfaeb8cfdf81d4afe910d5;
+    uint256 internal constant OPRF_PUBKEY_X = 0xac79da013272129ddceae6d20c0f579abd04b0a00160ed2be2151bf4014e8d;
+    uint256 internal constant OPRF_PUBKEY_Y = 0x187ce5ac507fe0760e95d1893cc6ebf3a115eb9adeaa355c14cc52722a2275be;
+
+    uint256 internal constant MSB_MASK = uint256(0xff) << 248;
+
+    uint256[5] internal proof = [
+        uint256(0x4906f4e17b969ef2cfc44bd96520f01a3f5c32972bca2e10b70e05e03e3d9f13),
+        uint256(0xd6d9a3456e9af7d8f6f78eb3380deb8c93505c062f62fa18b8ef8a2ccb55db8),
+        uint256(0xa92a48edeb327b190048648788de9a8eff0abed5dc93bee8881387da40571278),
+        uint256(0x38f52985c393efb732be8f54b5f00f7f25370ac5945de84e0d8d2f2d298866b8),
+        uint256(ROOT)
+    ];
+
+    WorldIDVerifierV3 internal core;
+    WorldIDSatelliteHarness internal satellite;
+
+    function setUp() public {
+        Verifier verifier = new Verifier();
+
+        address worldIdRegistry = address(new WorldIDRegistryMock(TREE_DEPTH, ROOT));
+        address issuerRegistry =
+            address(new CredentialSchemaIssuerRegistryMock(ISSUER_SCHEMA_ID, ISSUER_PUBKEY_X, ISSUER_PUBKEY_Y));
+        address oprfRegistry = address(new OprfKeyRegistryMock(uint160(RP_ID), OPRF_PUBKEY_X, OPRF_PUBKEY_Y));
+
+        bytes memory initData = abi.encodeWithSelector(
+            WorldIDVerifier.initialize.selector,
+            issuerRegistry,
+            worldIdRegistry,
+            oprfRegistry,
+            address(verifier),
+            MIN_EXPIRATION_THRESHOLD
+        );
+        core = WorldIDVerifierV3(address(new ERC1967Proxy(address(new WorldIDVerifierV3()), initData)));
+
+        satellite =
+            new WorldIDSatelliteHarness(address(verifier), ROOT_VALIDITY_WINDOW, TREE_DEPTH, MIN_EXPIRATION_THRESHOLD);
+
+        Lib.Commitment[] memory commits = new Lib.Commitment[](3);
+        bytes32 proofId = bytes32(uint256(1));
+        bytes32 blockHash = bytes32(uint256(0x1234));
+
+        commits[0] = Lib.Commitment({
+            blockHash: blockHash, data: abi.encodeWithSelector(UPDATE_ROOT_SELECTOR, ROOT, block.timestamp, proofId)
+        });
+        commits[1] = Lib.Commitment({
+            blockHash: blockHash,
+            data: abi.encodeWithSelector(
+                SET_ISSUER_PUBKEY_SELECTOR, ISSUER_SCHEMA_ID, ISSUER_PUBKEY_X, ISSUER_PUBKEY_Y, proofId
+            )
+        });
+        commits[2] = Lib.Commitment({
+            blockHash: blockHash,
+            data: abi.encodeWithSelector(SET_OPRF_KEY_SELECTOR, uint160(RP_ID), OPRF_PUBKEY_X, OPRF_PUBKEY_Y, proofId)
+        });
+
+        satellite.applyCommitments(commits);
+
+        vm.warp(EXPIRES_AT_MIN + 1 hours);
+    }
+
+    /// @dev Sends identical calldata to both verifiers and asserts identical outcomes.
+    function _assertParity(bytes memory callData, string memory what) internal view {
+        (bool coreOk, bytes memory coreRet) = address(core).staticcall(callData);
+        (bool satelliteOk, bytes memory satelliteRet) = address(satellite).staticcall(callData);
+
+        assertEq(coreOk, satelliteOk, string.concat("success mismatch: ", what));
+        assertEq(coreRet, satelliteRet, string.concat("return data mismatch: ", what));
+    }
+
+    function _verifyCall(uint256 action) internal view returns (bytes memory) {
+        return abi.encodeWithSignature(
+            "verify(uint256,uint256,uint64,uint256,uint256,uint64,uint64,uint256,uint256[5])",
+            NULLIFIER,
+            action,
+            RP_ID,
+            NONCE,
+            SIGNAL_HASH,
+            EXPIRES_AT_MIN,
+            ISSUER_SCHEMA_ID,
+            uint256(0),
+            proof
+        );
+    }
+
+    function _verifySessionCall(uint256 action, uint256 sessionId) internal view returns (bytes memory) {
+        return abi.encodeWithSignature(
+            "verifySession(uint64,uint256,uint256,uint64,uint64,uint256,uint256,uint256[2],uint256[5])",
+            RP_ID,
+            NONCE,
+            SIGNAL_HASH,
+            EXPIRES_AT_MIN,
+            ISSUER_SCHEMA_ID,
+            uint256(0),
+            sessionId,
+            [NULLIFIER, action],
+            proof
+        );
+    }
+
+    function _verifyProofAndSignalsCall(uint64 issuerSchemaId, uint256 root) internal view returns (bytes memory) {
+        uint256[5] memory p = proof;
+        p[4] = root;
+        return abi.encodeWithSignature(
+            "verifyProofAndSignals(uint256,uint256,uint64,uint256,uint256,uint64,uint64,uint256,uint256,uint256[5])",
+            NULLIFIER,
+            ACTION,
+            RP_ID,
+            NONCE,
+            SIGNAL_HASH,
+            EXPIRES_AT_MIN,
+            issuerSchemaId,
+            uint256(0),
+            uint256(0),
+            p
+        );
+    }
+
+    /// @notice A proof both verifiers accept.
+    function test_parity_acceptedProof() public view {
+        _assertParity(_verifyProofAndSignalsCall(ISSUER_SCHEMA_ID, ROOT), "accepted proof");
+    }
+
+    function test_parity_invalidRoot() public view {
+        _assertParity(_verifyProofAndSignalsCall(ISSUER_SCHEMA_ID, ROOT + 1), "invalid root");
+    }
+
+    function test_parity_unregisteredIssuerSchemaId() public view {
+        _assertParity(_verifyProofAndSignalsCall(ISSUER_SCHEMA_ID + 1, ROOT), "unregistered issuer");
+    }
+
+    function test_parity_expirationTooOld() public {
+        vm.warp(uint256(EXPIRES_AT_MIN) + MIN_EXPIRATION_THRESHOLD + 2);
+        _assertParity(_verifyProofAndSignalsCall(ISSUER_SCHEMA_ID, ROOT), "expiration too old");
+    }
+
+    /// @notice The satellite's old expiration form underflowed here; both must now agree.
+    function test_parity_timestampBelowThreshold() public {
+        vm.warp(1);
+        _assertParity(_verifyProofAndSignalsCall(ISSUER_SCHEMA_ID, ROOT), "timestamp below threshold");
+    }
+
+    function test_parity_verifyRejectsNonUniquenessAction() public view {
+        _assertParity(_verifyCall(ACTION), "verify with session-foreign action");
+    }
+
+    function test_parity_verifySessionRejectsNonSessionAction() public view {
+        _assertParity(_verifySessionCall(ACTION, 1), "verifySession with non-session action");
+    }
+
+    function test_parity_verifySessionRejectsZeroSessionId() public view {
+        uint256 sessionAction = (ACTION & ~MSB_MASK) | (uint256(0x02) << 248);
+        _assertParity(_verifySessionCall(sessionAction, 0), "verifySession with zero sessionId");
+    }
+
+    function testFuzz_parity_verifyActionDomain(uint256 action) public view {
+        _assertParity(_verifyCall(action), "verify across action domains");
+    }
+
+    function testFuzz_parity_verifySessionDomain(uint256 action, uint256 sessionId) public view {
+        _assertParity(_verifySessionCall(action, sessionId), "verifySession across action domains");
+    }
+}


### PR DESCRIPTION
> Stacked on #940 — based on that branch, so review this diff after it. Retarget to `main` once #940 merges.

`WorldIDSatellite` reimplements the core verifier's checks against bridged state rather than sharing them. That is the structural cause of the bug #940 fixes: the satellite lagged the V2 action-prefix rule and the V3 session-id rule, and nobody noticed because there was nothing tying the two together. The action-prefix check alone existed in three copies — `UnreleasedWorldIDVerifierV3.sol:52` even documents why: *"The action prefix check is repeated from V2 because Solidity cannot `super`-call an `external` function."*

This adds `WorldIDVerification`, a stateless library holding the parts that were genuinely duplicated:

- the action-domain convention (`0x00` uniqueness, `0x02` session) and the non-zero session-id rule
- the empty-pubkey checks for the issuer and OPRF keys
- the expiration threshold check
- the 15-element public signal layout — the highest-risk clone, where one transposed index silently changes what is being proven
- the compressed-proof extraction and the Groth16 call

Each verifier resolves its own state into a `Context` and hands off. Root validity deliberately stays with the caller: a registry call on one side, a bridged root plus a local validity window on the other.

## Why a library rather than a base contract

Both contracts sit behind proxies, one of them on mainnet. An abstract base would reorder the inheritance chain and would have to carry `onlyProxy onlyInitialized` for one caller and not the other. The library is `internal`-only, so it inlines into each contract: no deployment, no linking (verified: zero `__$...$__` placeholders in either bytecode), no delegatecall, and no state.

**Storage layout is unchanged.** No state variable or inheritance clause is touched by this diff, and the resulting layouts are identical — `WorldIDVerifier` still has `_verifier` and `_minExpirationThreshold` packed in slot 6 and `_treeDepth` in slot 7.

## Behavior

Converging on the satellite side, per the intent that the live World Chain verifier keeps its semantics:

- **Empty-pubkey test.** The satellite adopts core's `x == 0 || y == 0`. This matches `_isEmptyPubkey` in `CredentialSchemaIssuerRegistry.sol:348`, which is the definition the registry itself uses to refuse registration — so the satellite's `&&` was the odd one out. Not exploitable today, since a half-zero key cannot be registered and therefore cannot be bridged.
- **Expiration form.** The satellite adopts core's `expiresAtMin + threshold < block.timestamp`, which avoids the underflow revert its `block.timestamp - threshold` hits when the chain timestamp is below the threshold.

Three deviations on the core verifier, all worth a reviewer's eye:

1. **The expiration addition widens to `uint256`.** Core previously computed `expiresAtMin + _minExpirationThreshold` in `uint64`, which panics on overflow for an `expiresAtMin` near `type(uint64).max`. It now widens first and no longer panics. Reachable only with an absurd expiry, but it is a change on a deployed contract. Say the word and I will reproduce the `uint64` semantics exactly instead.
2. **Check order.** Core now resolves the OPRF key before the issuer-pubkey emptiness check. When the issuer is unregistered *and* the `rpId` is unknown, the revert is now the registry's `UnknownId` rather than `UnregisteredIssuerSchemaId`. Both revert; only the selector differs.
3. **Core gains an `UnregisteredOprfKeyId` check.** Unreachable in production: `OprfKeyRegistry.getOprfPublicKey` reverts `UnknownId`/`DeletedId` before returning, so the pubkey is never empty. It only becomes reachable if the registry is swapped for one that returns `(0, 0)`, where it is strictly safer than passing a zero key into the public signals — the circuit does not constrain `oprf_pk` to be a valid curve point.

## Test plan

- `forge test` — 357 passing (347 existing, unchanged, plus 10 new).
- New `SatelliteCoreParity.t.sol` is the drift guard this refactor is really for. `IWorldID` and `IWorldIDVerifier` declare identical signatures and the shared errors have identical selectors, so it sends **byte-identical calldata to both verifiers and asserts identical success and identical return data** — across accepted proofs, invalid roots, unregistered issuers, expired credentials, both action domains and the zero session id, including two fuzzed cases. Any future change that touches one verifier and not the other fails here.
- `test_parity_timestampBelowThreshold` pins the underflow fix.