### PR TITLE
chore: update reth RPC url

### DIFF
--- a/services/gateway/tests/common.rs
+++ b/services/gateway/tests/common.rs
@@ -17,7 +17,7 @@ use world_id_test_utils::anvil::TestAnvil;
 /// key, not a real secret.
 pub(crate) const GW_PRIVATE_KEY: &str =
     "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
-pub(crate) const RPC_FORK_URL: &str = "https://reth-ethereum.ithaca.xyz/rpc";
+pub(crate) const RPC_FORK_URL: &str = "https://ethereum.reth.rs/rpc";
 
 /// A running gateway + anvil + Redis stack for integration tests.
 ///


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Test-only default URL change with no production or auth impact; CI may fail if the new endpoint is unavailable.
> 
> **Overview**
> Updates the default **Ethereum mainnet fork RPC** used by gateway integration tests when `TESTS_RPC_FORK_URL` is unset, switching from `https://reth-ethereum.ithaca.xyz/rpc` to `https://ethereum.reth.rs/rpc` via `RPC_FORK_URL` in `common.rs`.
> 
> Forked Anvil instances in `spawn_test_anvil()` still honor `TESTS_RPC_FORK_URL` when it is set; only the built-in fallback URL changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ceea2e7374576e4f019f9f51e5b83057e9b39148. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->