### PR TITLE
chore: remove the "after initial enrollment" clause from wip-103 spec

### DIFF
--- a/docs/WIPs/wip-103.md
+++ b/docs/WIPs/wip-103.md
@@ -107,7 +107,7 @@ The `0` element is NOT a valid context.
 2. If future use cases are added, the `commitment_blinder` IS REQUIRED to always be a high entropy value to prevent finding a user's `leaf_index`. Unless otherwise noted, it should be randomly generated from a CSPRNG uniformly distributed over the entire $F$.
 
 ### WIP-103-001: Issuer Authentication
-- **Use case**: Authenticating to an Issuer after initial enrollment where the Issuer has a `sub` as identifier.
+- **Use case**: Authenticating to an Issuer where the Issuer has a `sub` as identifier.
 - **Domain Separator**: `b"H_CS(id, r)"` named `DS_C_CS`.
 - **`commitment_blinder` value**: The credential's blinding factor as stored (or re-derived) by the Authenticator.
 - **Use conditions**: Can only be used to prove ownership with the specific Issuer for which the `sub` was generated. The Authenticator MUST ensure this proof is only provided to the Issuer it corresponds. The Authenticator knows this from the blinding factor used as the `commitment_blinder` input. Furthermore, providing this proof MUST come from a user initiated action and SHALL NOT be requested by Issuers. Acceptable examples include: when a user requests a Credential re-issuance, when a user requests a Credential renewal, when a user requests a Credential deletion.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single-line spec wording change with no implementation or security mechanism changes.
> 
> **Overview**
> **WIP-103** Issuer Authentication (WIP-103-001) is described more broadly: the use case is now *authenticating to an Issuer where the Issuer has a `sub` as identifier*, without the *after initial enrollment* qualifier.
> 
> This is a documentation-only clarification in `docs/WIPs/wip-103.md`; circuit constraints, domain separators, and verification rules are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bef1de3a1ff4b330c77b16799922d8e28637e82b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->