### PR TITLE
fix: deployment urls for reference services

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The [World Foundation](https://foundation.world.org/) maintains a set of referen
 
 | Service            | Environment | URL                                                   |
 | ------------------ | ----------- | ----------------------------------------------------- |
-| `world-id-indexer` | Staging  | `https://indexer.us.id-infra.worldcoin.org`<br />`https://indexer.eu.id-infra.worldcoin.dev`<br />`https://indexer.ap.id-infra.worldcoin.dev` |
+| `world-id-indexer` | Staging  | `https://indexer.us.id-infra.worldcoin.dev`<br />`https://indexer.eu.id-infra.worldcoin.dev`<br />`https://indexer.ap.id-infra.worldcoin.dev` |
 | `world-id-gateway` | Staging     | `https://gateway.id-infra.worldcoin.dev` |
 | `world-id-indexer` | Production  | `https://indexer.us.id-infra.world.org`<br />`https://indexer.eu.id-infra.world.org`<br />`https://indexer.ap.id-infra.world.org` |
 | `world-id-gateway` | Production     | `https://gateway.id-infra.world.org` |

--- a/README.md
+++ b/README.md
@@ -38,8 +38,10 @@ The [World Foundation](https://foundation.world.org/) maintains a set of referen
 
 | Service            | Environment | URL                                                   |
 | ------------------ | ----------- | ----------------------------------------------------- |
-| `world-id-indexer` | Production  | `https://indexer.us.id-infra.worldcoin.dev`<br />`https://indexer.eu.id-infra.worldcoin.dev`<br />`https://indexer.ap.id-infra.worldcoin.dev` |
+| `world-id-indexer` | Staging  | `https://indexer.us.id-infra.worldcoin.org`<br />`https://indexer.eu.id-infra.worldcoin.dev`<br />`https://indexer.ap.id-infra.worldcoin.dev` |
 | `world-id-gateway` | Staging     | `https://gateway.id-infra.worldcoin.dev` |
+| `world-id-indexer` | Production  | `https://indexer.us.id-infra.world.org`<br />`https://indexer.eu.id-infra.world.org`<br />`https://indexer.ap.id-infra.world.org` |
+| `world-id-gateway` | Production     | `https://gateway.id-infra.world.org` |
 
 ## 🏗️ Project Structure
 


### PR DESCRIPTION
The URLs of the reference deployments were incomplete.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only URL corrections with no runtime or security impact.
> 
> **Overview**
> Updates the **Services** table in `README.md` so reference deployment endpoints are complete and environment-specific.
> 
> **Staging** `world-id-indexer` keeps the `id-infra.worldcoin.dev` regional indexer URLs; **staging** `world-id-gateway` is documented as `https://gateway.id-infra.worldcoin.dev`. **Production** adds regional indexer hosts on `id-infra.world.org` and **production** gateway at `https://gateway.id-infra.world.org`, replacing the prior incomplete production indexer-only row.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4980aae8b5a16cecf550a09f09592ae46fd97eca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->