### PR TITLE
chore: Remove experimental graph instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,9 +1,5 @@
 # AGENTS.md
 
-## Knowledge graph (Experimental)
-
-This project MAY have a knowledge graph at `graph/`. If it does, look at the `graph/AGENTS.md` file first for instructions and you can ignore the rest of this file.
-
 ## Repo Overview
 
 - Rust workspace + Solidity contracts + Circom circuits + deployable services.


### PR DESCRIPTION
## Summary

- remove the experimental knowledge graph section from `AGENTS.md`
- make the repository overview the first project-specific guidance

## Impact

Agent instructions no longer redirect readers to an optional `graph/AGENTS.md` file.

## Validation

- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to agent instructions; no runtime or protocol behavior affected.
> 
> **Overview**
> Removes the **experimental knowledge graph** block from `AGENTS.md` that told agents to check `graph/AGENTS.md` first and skip the rest of the file when present.
> 
> **Repo Overview** is now the first project-specific guidance in the agent instructions, with no redirect to optional `graph/` documentation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b09983ffa5392edbd8d8f5cbb0e236d5af3cf1ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->