### PR TITLE
refactor(gateway): centralize application lifecycle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12762,6 +12762,7 @@ dependencies = [
  "axum",
  "clap",
  "dotenvy",
+ "flume",
  "futures",
  "hex",
  "http 1.4.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ circom-types = { package = "taceo-circom-types", version = "0.2", default-featur
 coset = "0.4.2"
 eddsa-babyjubjub = { package = "taceo-eddsa-babyjubjub", version = "0.5.5" }
 eyre = "0.6"
+flume = { version = "0.11", default-features = false, features = ["async"] }
 futures = "0.3"
 groth16-material = { package = "taceo-groth16-material", version = "0.3", default-features = false }
 hex = { version = "0.4" }

--- a/crates/core/tests/authenticator_registration.rs
+++ b/crates/core/tests/authenticator_registration.rs
@@ -14,7 +14,7 @@ fn dummy_zk_source() -> Arc<dyn ZkArtifactSource> {
     Arc::new(DummyZkArtifactSource)
 }
 use world_id_gateway::{
-    BatchPolicyConfig, GatewayConfig, RegistryVersion, SignerArgs, defaults,
+    BatchPolicyConfig, GatewayConfig, RateLimitConfig, RegistryVersion, SignerArgs, defaults,
     spawn_gateway_for_tests,
 };
 use world_id_primitives::{Config, ServiceEndpoint};
@@ -50,9 +50,8 @@ async fn test_authenticator_registration() {
         redis_url: std::env::var("REDIS_URL")
             .unwrap_or_else(|_| "redis://localhost:6379".to_string()),
         request_timeout_secs: 10,
-        rate_limit_max_requests: None,
-        rate_limit_window_secs: None,
-        sweeper_interval_secs: defaults::SWEEPER_INTERVAL_SECS,
+        rate_limit: RateLimitConfig::default(),
+        transaction_tracker_interval_secs: defaults::TRANSACTION_TRACKER_INTERVAL_SECS,
         stale_queued_threshold_secs: defaults::STALE_QUEUED_THRESHOLD_SECS,
         stale_submitted_threshold_secs: defaults::STALE_SUBMITTED_THRESHOLD_SECS,
         batch_policy: BatchPolicyConfig::default(),

--- a/crates/core/tests/e2e_authenticator_insert_update_remove.rs
+++ b/crates/core/tests/e2e_authenticator_insert_update_remove.rs
@@ -15,7 +15,7 @@ use world_id_core::{
     artifacts::{ZkArtifactSource, dummy::DummyZkArtifactSource},
 };
 use world_id_gateway::{
-    BatchPolicyConfig, GatewayConfig, RegistryVersion, SignerArgs, defaults,
+    BatchPolicyConfig, GatewayConfig, RateLimitConfig, RegistryVersion, SignerArgs, defaults,
     spawn_gateway_for_tests,
 };
 use world_id_primitives::{Config, ServiceEndpoint, TREE_DEPTH, merkle::AccountInclusionProof};
@@ -130,9 +130,8 @@ async fn e2e_authenticator_insert_update_remove() {
         redis_url: std::env::var("REDIS_URL")
             .unwrap_or_else(|_| "redis://localhost:6379".to_string()),
         request_timeout_secs: 10,
-        rate_limit_max_requests: None,
-        rate_limit_window_secs: None,
-        sweeper_interval_secs: defaults::SWEEPER_INTERVAL_SECS,
+        rate_limit: RateLimitConfig::default(),
+        transaction_tracker_interval_secs: defaults::TRANSACTION_TRACKER_INTERVAL_SECS,
         stale_queued_threshold_secs: defaults::STALE_QUEUED_THRESHOLD_SECS,
         stale_submitted_threshold_secs: defaults::STALE_SUBMITTED_THRESHOLD_SECS,
         batch_policy: BatchPolicyConfig::default(),

--- a/crates/core/tests/generate_proof.rs
+++ b/crates/core/tests/generate_proof.rs
@@ -27,7 +27,7 @@ fn zk_artifact_source() -> Arc<dyn ZkArtifactSource> {
     Arc::new(world_id_core::artifacts::embedded::EmbeddedZkArtifacts.cached())
 }
 use world_id_gateway::{
-    BatchPolicyConfig, GatewayConfig, RegistryVersion, SignerArgs, defaults,
+    BatchPolicyConfig, GatewayConfig, RateLimitConfig, RegistryVersion, SignerArgs, defaults,
     spawn_gateway_for_tests,
 };
 use world_id_primitives::{
@@ -97,9 +97,8 @@ async fn e2e_authenticator_generate_proof() -> Result<()> {
         redis_url: std::env::var("REDIS_URL")
             .unwrap_or_else(|_| "redis://localhost:6379".to_string()),
         request_timeout_secs: 10,
-        rate_limit_max_requests: None,
-        rate_limit_window_secs: None,
-        sweeper_interval_secs: defaults::SWEEPER_INTERVAL_SECS,
+        rate_limit: RateLimitConfig::default(),
+        transaction_tracker_interval_secs: defaults::TRANSACTION_TRACKER_INTERVAL_SECS,
         stale_queued_threshold_secs: defaults::STALE_QUEUED_THRESHOLD_SECS,
         stale_submitted_threshold_secs: defaults::STALE_SUBMITTED_THRESHOLD_SECS,
         batch_policy: BatchPolicyConfig::default(),

--- a/services/gateway/Cargo.toml
+++ b/services/gateway/Cargo.toml
@@ -28,6 +28,7 @@ clap = { workspace = true, features = ["derive", "env"] }
 world-id-primitives = { workspace = true, features = ["openapi"] }
 world-id-registries = { workspace = true }
 dotenvy = { workspace = true }
+flume = { workspace = true }
 hex = { workspace = true }
 moka = { workspace = true }
 once_cell = { workspace = true }

--- a/services/gateway/src/app.rs
+++ b/services/gateway/src/app.rs
@@ -44,17 +44,14 @@ impl Gateway {
         registry: Arc<Registry>,
         wallets: Vec<ProviderWallet>,
     ) -> GatewayResult<Self> {
-        let batcher_config = config.batcher();
         let batch_policy_config = config.batch_policy.clone();
-        let rate_limit = config.rate_limit();
-        let sweeper_config = config.sweeper();
         let submitter = TransactionSubmitter::connect(
             *registry.address(),
             wallets,
             &config.redis_url,
-            rate_limit,
-            Duration::from_secs(sweeper_config.interval_secs),
-            Duration::from_secs(sweeper_config.stale_submitted_threshold_secs),
+            config.rate_limit.clone(),
+            Duration::from_secs(config.transaction_tracker_interval_secs),
+            Duration::from_secs(config.stale_submitted_threshold_secs),
         )
         .await?;
 
@@ -63,7 +60,7 @@ impl Gateway {
         let create_batcher = Arc::new(CreateBatcher::new(
             registry.clone(),
             submitter.clone(),
-            batcher_config.max_create_batch_size,
+            config.max_create_batch_size,
             CREATE_BATCHER_CHANNEL_CAPACITY,
             batch_policy_config.clone(),
             base_fee_cache.clone(),
@@ -71,7 +68,7 @@ impl Gateway {
         let ops_batcher = Arc::new(OpsBatcher::new(
             registry.clone(),
             submitter.clone(),
-            batcher_config.max_ops_batch_size,
+            config.max_ops_batch_size,
             OPS_BATCHER_CHANNEL_CAPACITY,
             batch_policy_config,
             base_fee_cache.clone(),

--- a/services/gateway/src/app.rs
+++ b/services/gateway/src/app.rs
@@ -1,0 +1,214 @@
+use std::{
+    future::{Future, IntoFuture},
+    sync::Arc,
+    time::Duration,
+};
+
+use alloy::{primitives::U256, providers::DynProvider};
+use moka::future::Cache;
+use tokio::task::JoinSet;
+use world_id_registries::world_id::WorldIdRegistry::WorldIdRegistryInstance;
+use world_id_services_common::ProviderWallet;
+
+use crate::{
+    batch_policy::{BaseFeeCache, run_base_fee_sampler},
+    batcher::{Batcher, CreateBatcher, OpsBatcher},
+    config::GatewayConfig,
+    error::{GatewayError, GatewayResult},
+    routes,
+    transaction_submitter::TransactionSubmitter,
+    types::{AppState, RootExpiry},
+};
+
+const ROOT_CACHE_SIZE: u64 = 1024;
+const CREATE_BATCHER_CHANNEL_CAPACITY: usize = 1024;
+const OPS_BATCHER_CHANNEL_CAPACITY: usize = 2048;
+
+type Registry = WorldIdRegistryInstance<Arc<DynProvider>>;
+
+/// Components and configuration shared by the gateway service.
+// TODO: Some of these components should be abstracted away behind traits
+pub struct Gateway {
+    pub(crate) config: GatewayConfig,
+    pub(crate) registry: Arc<Registry>,
+    pub(crate) submitter: Arc<TransactionSubmitter>,
+    pub(crate) batcher: Batcher,
+    pub(crate) root_cache: Cache<U256, U256>,
+    base_fee_cache: BaseFeeCache,
+}
+
+impl Gateway {
+    /// Build the gateway runtime without constructing routes or starting a server.
+    pub(crate) async fn new(
+        config: GatewayConfig,
+        registry: Arc<Registry>,
+        wallets: Vec<ProviderWallet>,
+    ) -> GatewayResult<Self> {
+        let batcher_config = config.batcher();
+        let batch_policy_config = config.batch_policy.clone();
+        let rate_limit = config.rate_limit();
+        let sweeper_config = config.sweeper();
+        let submitter = TransactionSubmitter::connect(
+            *registry.address(),
+            wallets,
+            &config.redis_url,
+            rate_limit,
+            Duration::from_secs(sweeper_config.interval_secs),
+            Duration::from_secs(sweeper_config.stale_submitted_threshold_secs),
+        )
+        .await?;
+
+        let base_fee_cache = BaseFeeCache::default();
+
+        let create_batcher = Arc::new(CreateBatcher::new(
+            registry.clone(),
+            submitter.clone(),
+            batcher_config.max_create_batch_size,
+            CREATE_BATCHER_CHANNEL_CAPACITY,
+            batch_policy_config.clone(),
+            base_fee_cache.clone(),
+        ));
+        let ops_batcher = Arc::new(OpsBatcher::new(
+            registry.clone(),
+            submitter.clone(),
+            batcher_config.max_ops_batch_size,
+            OPS_BATCHER_CHANNEL_CAPACITY,
+            batch_policy_config,
+            base_fee_cache.clone(),
+        ));
+
+        Ok(Self {
+            config,
+            registry,
+            submitter,
+            batcher: Batcher {
+                create: create_batcher,
+                ops: ops_batcher,
+            },
+            root_cache: Cache::builder()
+                .max_capacity(ROOT_CACHE_SIZE)
+                .expire_after(RootExpiry)
+                .build(),
+            base_fee_cache,
+        })
+    }
+}
+
+pub(crate) async fn build_gateway(config: GatewayConfig) -> GatewayResult<Gateway> {
+    let wallets = config.provider.clone().http_wallets().await?;
+    let provider = Arc::new(wallets[0].provider.clone());
+    let registry = Arc::new(WorldIdRegistryInstance::new(config.registry_addr, provider));
+    Gateway::new(config, registry, wallets).await
+}
+
+fn start_tasks(gateway: Arc<Gateway>) -> JoinSet<&'static str> {
+    let mut tasks = JoinSet::new();
+
+    let task_gateway = gateway.clone();
+    tasks.spawn(async move {
+        task_gateway.submitter.clone().run_tracker().await;
+        "transaction tracker"
+    });
+
+    let task_gateway = gateway.clone();
+    tasks.spawn(async move {
+        let provider = task_gateway.registry.provider().clone();
+        let interval = Duration::from_millis(task_gateway.config.batch_policy.reeval_ms);
+        let cache = task_gateway.base_fee_cache.clone();
+        run_base_fee_sampler(provider, interval, cache).await;
+        "base fee sampler"
+    });
+
+    let task_gateway = gateway.clone();
+    tasks.spawn(async move {
+        task_gateway.batcher.create.run().await;
+        "create batcher"
+    });
+
+    let task_gateway = gateway;
+    tasks.spawn(async move {
+        task_gateway.batcher.ops.run().await;
+        "ops batcher"
+    });
+
+    tasks
+}
+
+/// Set up the gateway routes, run the HTTP server, and supervise background tasks.
+pub(crate) async fn serve_gateway<F>(
+    gateway: Gateway,
+    listener: tokio::net::TcpListener,
+    shutdown: F,
+) -> GatewayResult<()>
+where
+    F: Future<Output = ()> + Send + 'static,
+{
+    let state: AppState = Arc::new(gateway);
+    let mut tasks = start_tasks(state.clone());
+    tracing::info!("Gateway background tasks started");
+
+    let app = routes::router(state.clone());
+    let server = axum::serve(listener, app)
+        .with_graceful_shutdown(shutdown)
+        .into_future();
+
+    let result = supervise(server, &mut tasks).await;
+
+    tasks.shutdown().await;
+    result
+}
+
+async fn supervise<F>(server: F, tasks: &mut JoinSet<&'static str>) -> GatewayResult<()>
+where
+    F: Future<Output = std::io::Result<()>>,
+{
+    tokio::pin!(server);
+
+    tokio::select! {
+        result = &mut server => result.map_err(|source| GatewayError::Serve {
+            source,
+            backtrace: std::backtrace::Backtrace::capture().to_string(),
+        }),
+        task = tasks.join_next() => match task {
+            Some(Ok(task)) => Err(GatewayError::BackgroundTaskExited(task)),
+            Some(Err(error)) => Err(error.into()),
+            None => Err(GatewayError::BackgroundTaskExited("task supervisor")),
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn supervisor_reports_background_task_exit() {
+        let mut tasks = JoinSet::new();
+        tasks.spawn(async { "test task" });
+
+        let error = supervise(std::future::pending(), &mut tasks)
+            .await
+            .expect_err("task exit should stop the gateway");
+
+        assert!(matches!(
+            error,
+            GatewayError::BackgroundTaskExited("test task")
+        ));
+    }
+
+    #[tokio::test]
+    async fn supervisor_reports_background_task_panic() {
+        let mut tasks = JoinSet::new();
+        tasks.spawn(async {
+            panic!("test task panic");
+            #[allow(unreachable_code)]
+            "test task"
+        });
+
+        let error = supervise(std::future::pending(), &mut tasks)
+            .await
+            .expect_err("task panic should stop the gateway");
+
+        assert!(matches!(error, GatewayError::Join { source, .. } if source.is_panic()));
+    }
+}

--- a/services/gateway/src/batch_policy.rs
+++ b/services/gateway/src/batch_policy.rs
@@ -299,21 +299,19 @@ fn high_cost_target_batch_size(max_batch_size: usize, urgency_score: f64) -> usi
     ((max_batch_size as f64) * ratio).ceil() as usize
 }
 
-/// Spawn a background task that refreshes latest base fee in a shared cache.
-pub fn spawn_base_fee_sampler(
+/// Refresh the latest base fee in a shared cache until the task is cancelled.
+pub async fn run_base_fee_sampler(
     provider: Arc<DynProvider>,
     interval: Duration,
     cache: BaseFeeCache,
-) -> tokio::task::JoinHandle<()> {
-    tokio::spawn(async move {
-        let mut ticker = tokio::time::interval(interval);
-        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
-        loop {
-            ticker.tick().await;
-            let fee = latest_base_fee_wei(provider.as_ref()).await;
-            cache.set_latest(fee);
-        }
-    })
+) {
+    let mut ticker = tokio::time::interval(interval);
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    loop {
+        ticker.tick().await;
+        let fee = latest_base_fee_wei(provider.as_ref()).await;
+        cache.set_latest(fee);
+    }
 }
 
 /// Fetch latest block base fee. Returns `None` for chains without EIP-1559

--- a/services/gateway/src/batcher/create.rs
+++ b/services/gateway/src/batcher/create.rs
@@ -5,18 +5,12 @@ use alloy::{
     providers::DynProvider,
     rpc::types::TransactionRequest,
 };
-use tokio::sync::mpsc;
 use world_id_primitives::api_types::CreateAccountRequest;
 use world_id_registries::world_id::WorldIdRegistry::WorldIdRegistryInstance;
 
 use crate::batch_type::BatchType;
 
-use super::{BatchSubmitStrategy, BatcherEnvelope, GenericBatcherRunner};
-
-#[derive(Clone)]
-pub struct CreateBatcherHandle {
-    pub tx: mpsc::Sender<CreateReqEnvelope>,
-}
+use super::{BatchSubmitStrategy, BatcherEnvelope, GenericBatcher};
 
 #[derive(Debug)]
 pub struct CreateReqEnvelope {
@@ -61,4 +55,4 @@ impl BatchSubmitStrategy<CreateReqEnvelope> for CreateStrategy {
     }
 }
 
-pub type CreateBatcherRunner = GenericBatcherRunner<CreateReqEnvelope, CreateStrategy>;
+pub type CreateBatcher = GenericBatcher<CreateReqEnvelope, CreateStrategy>;

--- a/services/gateway/src/batcher/mod.rs
+++ b/services/gateway/src/batcher/mod.rs
@@ -1,16 +1,19 @@
-//! Unified batcher abstraction: generic policy-driven runner, per-batcher
-//! strategies, and the public handle/command routing layer.
+//! Unified batcher abstraction: generic policy-driven batching, per-batcher
+//! strategies, and command routing.
 
 mod create;
 mod ops;
 
-pub(crate) use create::{CreateBatcherHandle, CreateBatcherRunner, CreateReqEnvelope};
-pub(crate) use ops::{OpsBatcherHandle, OpsBatcherRunner, OpsEnvelope};
+pub(crate) use create::{CreateBatcher, CreateReqEnvelope};
+pub(crate) use ops::{OpsBatcher, OpsEnvelope};
 
 use std::{collections::VecDeque, sync::Arc, time::Duration};
 
 use alloy::{primitives::Bytes, providers::DynProvider, rpc::types::TransactionRequest};
-use tokio::{sync::mpsc, time::Instant};
+use tokio::{
+    sync::{Mutex, mpsc},
+    time::Instant,
+};
 use uuid::Uuid;
 use world_id_primitives::api_types::{CreateAccountRequest, GatewayRequestState};
 use world_id_registries::world_id::WorldIdRegistry::WorldIdRegistryInstance;
@@ -26,14 +29,14 @@ use crate::{
     transaction_submitter::TransactionSubmitter,
 };
 
-/// Unified batcher handle that routes to the appropriate batcher.
+/// Unified batcher component that routes commands to the appropriate queue.
 #[derive(Clone)]
-pub struct BatcherHandle {
-    pub create: CreateBatcherHandle,
-    pub ops: OpsBatcherHandle,
+pub struct Batcher {
+    pub(crate) create: Arc<CreateBatcher>,
+    pub(crate) ops: Arc<OpsBatcher>,
 }
 
-impl BatcherHandle {
+impl Batcher {
     /// Submit a command to the appropriate batcher.
     pub async fn submit(&self, cmd: Command) -> bool {
         match cmd {
@@ -42,14 +45,14 @@ impl BatcherHandle {
                     id: id.to_string(),
                     req,
                 };
-                self.create.tx.send(envelope).await.is_ok()
+                self.create.enqueue(envelope).await
             }
             Command::Operation { id, calldata } => {
                 let envelope = OpsEnvelope {
                     id: id.to_string(),
                     calldata,
                 };
-                self.ops.tx.send(envelope).await.is_ok()
+                self.ops.enqueue(envelope).await
             }
         }
     }
@@ -82,7 +85,9 @@ pub(crate) trait BatcherEnvelope: Send + 'static {
 }
 
 /// Strategy trait that captures the per-batcher transaction construction.
-pub(crate) trait BatchSubmitStrategy<E: BatcherEnvelope>: Send + Default + 'static {
+pub(crate) trait BatchSubmitStrategy<E: BatcherEnvelope>:
+    Send + Sync + Default + 'static
+{
     fn batch_type(&self) -> BatchType;
 
     fn build_tx(
@@ -102,12 +107,13 @@ enum PolicyLoopEvent<T> {
     Recv(Option<T>),
 }
 
-pub(crate) struct GenericBatcherRunner<E, S>
+pub(crate) struct GenericBatcher<E, S>
 where
     E: BatcherEnvelope,
     S: BatchSubmitStrategy<E>,
 {
-    rx: mpsc::Receiver<E>,
+    tx: mpsc::Sender<E>,
+    rx: Mutex<mpsc::Receiver<E>>,
     registry: Arc<WorldIdRegistryInstance<Arc<DynProvider>>>,
     submitter: Arc<TransactionSubmitter>,
     max_batch_size: usize,
@@ -117,23 +123,24 @@ where
     strategy: S,
 }
 
-impl<E, S> GenericBatcherRunner<E, S>
+impl<E, S> GenericBatcher<E, S>
 where
     E: BatcherEnvelope,
     S: BatchSubmitStrategy<E>,
 {
-    #[allow(clippy::too_many_arguments)]
     pub fn new(
         registry: Arc<WorldIdRegistryInstance<Arc<DynProvider>>>,
         submitter: Arc<TransactionSubmitter>,
         max_batch_size: usize,
         local_queue_limit: usize,
-        rx: mpsc::Receiver<E>,
         batch_policy: BatchPolicyConfig,
         base_fee_cache: BaseFeeCache,
     ) -> Self {
+        let (tx, rx) = mpsc::channel(local_queue_limit.max(1));
+
         Self {
-            rx,
+            tx,
+            rx: Mutex::new(rx),
             registry,
             submitter,
             max_batch_size,
@@ -144,8 +151,13 @@ where
         }
     }
 
-    pub async fn run(mut self) {
-        self.run_policy_loop().await;
+    pub async fn enqueue(&self, envelope: E) -> bool {
+        self.tx.send(envelope).await.is_ok()
+    }
+
+    pub async fn run(&self) {
+        let mut rx = self.rx.lock().await;
+        self.run_policy_loop(&mut rx).await;
     }
 
     async fn submit_common(&self, batch: Vec<E>) {
@@ -190,7 +202,7 @@ where
         queue.clear();
     }
 
-    async fn run_policy_loop(&mut self) {
+    async fn run_policy_loop(&self, rx: &mut mpsc::Receiver<E>) {
         let mut policy_engine = BatchPolicyEngine::new(self.batch_policy.clone());
         let reeval_interval = Duration::from_millis(self.batch_policy.reeval_ms);
 
@@ -214,7 +226,7 @@ where
                     break;
                 }
 
-                let maybe_first = self.rx.recv().await;
+                let maybe_first = rx.recv().await;
                 match maybe_first {
                     Some(first) => {
                         queue.push_back(TimedEnvelope {
@@ -235,7 +247,7 @@ where
             let event = tokio::select! {
                 biased;
                 _ = tokio::time::sleep_until(next_eval) => PolicyLoopEvent::Tick,
-                maybe_req = self.rx.recv(), if can_recv => PolicyLoopEvent::Recv(maybe_req),
+                maybe_req = rx.recv(), if can_recv => PolicyLoopEvent::Recv(maybe_req),
             };
 
             match event {
@@ -303,5 +315,3 @@ where
         }
     }
 }
-
-// ── Public handle & command routing ─────────────────────────────────────

--- a/services/gateway/src/batcher/mod.rs
+++ b/services/gateway/src/batcher/mod.rs
@@ -10,10 +10,7 @@ pub(crate) use ops::{OpsBatcher, OpsEnvelope};
 use std::{collections::VecDeque, sync::Arc, time::Duration};
 
 use alloy::{primitives::Bytes, providers::DynProvider, rpc::types::TransactionRequest};
-use tokio::{
-    sync::{Mutex, mpsc},
-    time::Instant,
-};
+use tokio::time::Instant;
 use uuid::Uuid;
 use world_id_primitives::api_types::{CreateAccountRequest, GatewayRequestState};
 use world_id_registries::world_id::WorldIdRegistry::WorldIdRegistryInstance;
@@ -112,8 +109,8 @@ where
     E: BatcherEnvelope,
     S: BatchSubmitStrategy<E>,
 {
-    tx: mpsc::Sender<E>,
-    rx: Mutex<mpsc::Receiver<E>>,
+    tx: flume::Sender<E>,
+    rx: flume::Receiver<E>,
     registry: Arc<WorldIdRegistryInstance<Arc<DynProvider>>>,
     submitter: Arc<TransactionSubmitter>,
     max_batch_size: usize,
@@ -136,11 +133,11 @@ where
         batch_policy: BatchPolicyConfig,
         base_fee_cache: BaseFeeCache,
     ) -> Self {
-        let (tx, rx) = mpsc::channel(local_queue_limit.max(1));
+        let (tx, rx) = flume::bounded(local_queue_limit.max(1));
 
         Self {
             tx,
-            rx: Mutex::new(rx),
+            rx,
             registry,
             submitter,
             max_batch_size,
@@ -152,12 +149,11 @@ where
     }
 
     pub async fn enqueue(&self, envelope: E) -> bool {
-        self.tx.send(envelope).await.is_ok()
+        self.tx.send_async(envelope).await.is_ok()
     }
 
     pub async fn run(&self) {
-        let mut rx = self.rx.lock().await;
-        self.run_policy_loop(&mut rx).await;
+        self.run_policy_loop().await;
     }
 
     async fn submit_common(&self, batch: Vec<E>) {
@@ -202,7 +198,7 @@ where
         queue.clear();
     }
 
-    async fn run_policy_loop(&self, rx: &mut mpsc::Receiver<E>) {
+    async fn run_policy_loop(&self) {
         let mut policy_engine = BatchPolicyEngine::new(self.batch_policy.clone());
         let reeval_interval = Duration::from_millis(self.batch_policy.reeval_ms);
 
@@ -226,7 +222,7 @@ where
                     break;
                 }
 
-                let maybe_first = rx.recv().await;
+                let maybe_first = self.rx.recv_async().await.ok();
                 match maybe_first {
                     Some(first) => {
                         queue.push_back(TimedEnvelope {
@@ -247,7 +243,7 @@ where
             let event = tokio::select! {
                 biased;
                 _ = tokio::time::sleep_until(next_eval) => PolicyLoopEvent::Tick,
-                maybe_req = rx.recv(), if can_recv => PolicyLoopEvent::Recv(maybe_req),
+                maybe_req = self.rx.recv_async(), if can_recv => PolicyLoopEvent::Recv(maybe_req.ok()),
             };
 
             match event {

--- a/services/gateway/src/batcher/ops.rs
+++ b/services/gateway/src/batcher/ops.rs
@@ -11,12 +11,11 @@ use alloy::{
     providers::DynProvider,
     rpc::types::TransactionRequest,
 };
-use tokio::sync::mpsc;
 use world_id_registries::world_id::WorldIdRegistry::WorldIdRegistryInstance;
 
 use crate::batch_type::BatchType;
 
-use super::{BatchSubmitStrategy, BatcherEnvelope, GenericBatcherRunner};
+use super::{BatchSubmitStrategy, BatcherEnvelope, GenericBatcher};
 
 const MULTICALL3_ADDR: Address = address!("0xca11bde05977b3631167028862be2a173976ca11");
 
@@ -28,11 +27,6 @@ alloy::sol! {
         struct Result { bool success; bytes returnData; }
         function aggregate3(Call3[] calldata calls) payable returns (Result[] memory returnData);
     }
-}
-
-#[derive(Clone)]
-pub struct OpsBatcherHandle {
-    pub tx: mpsc::Sender<OpsEnvelope>,
 }
 
 /// Envelope for ops batcher containing pre-computed calldata for a single
@@ -80,4 +74,4 @@ impl BatchSubmitStrategy<OpsEnvelope> for OpsStrategy {
     }
 }
 
-pub type OpsBatcherRunner = GenericBatcherRunner<OpsEnvelope, OpsStrategy>;
+pub type OpsBatcher = GenericBatcher<OpsEnvelope, OpsStrategy>;

--- a/services/gateway/src/config.rs
+++ b/services/gateway/src/config.rs
@@ -11,7 +11,7 @@ pub mod defaults {
     pub const MAX_OPS_BATCH_SIZE: usize = 10;
     pub const REQUEST_TIMEOUT_SECS: u64 = 10;
     pub const LISTEN_ADDR: &str = "0.0.0.0:8081";
-    pub const SWEEPER_INTERVAL_SECS: u64 = 30;
+    pub const TRANSACTION_TRACKER_INTERVAL_SECS: u64 = 30;
     pub const STALE_QUEUED_THRESHOLD_SECS: u64 = 60;
     pub const STALE_SUBMITTED_THRESHOLD_SECS: u64 = 600;
 }
@@ -37,48 +37,24 @@ impl std::str::FromStr for RegistryVersion {
     }
 }
 
-/// Batching configuration for transaction submission.
-#[derive(Clone, Debug)]
-pub struct BatcherConfig {
-    pub max_create_batch_size: usize,
-    pub max_ops_batch_size: usize,
-}
-
-impl Default for BatcherConfig {
-    fn default() -> Self {
-        Self {
-            max_create_batch_size: defaults::MAX_CREATE_BATCH_SIZE,
-            max_ops_batch_size: defaults::MAX_OPS_BATCH_SIZE,
-        }
-    }
-}
-
 /// Rate limiting configuration for leaf_index-based requests.
-///
-/// Both fields are always present — the optionality is expressed at the
-/// call-site via `Option<RateLimitConfig>`.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default, clap::Args)]
 pub struct RateLimitConfig {
-    pub window_secs: u64,
-    pub max_requests: u64,
-}
+    /// Rate limit window in seconds (sliding window). Requires --rate-limit-max-requests.
+    #[arg(
+        long = "rate-limit-window-secs",
+        env = "RATE_LIMIT_WINDOW_SECS",
+        requires = "max_requests"
+    )]
+    pub window_secs: Option<u64>,
 
-/// Configuration for the orphan sweeper background task.
-#[derive(Clone, Debug)]
-pub struct OrphanSweeperConfig {
-    pub interval_secs: u64,
-    pub stale_queued_threshold_secs: u64,
-    pub stale_submitted_threshold_secs: u64,
-}
-
-impl Default for OrphanSweeperConfig {
-    fn default() -> Self {
-        Self {
-            interval_secs: defaults::SWEEPER_INTERVAL_SECS,
-            stale_queued_threshold_secs: defaults::STALE_QUEUED_THRESHOLD_SECS,
-            stale_submitted_threshold_secs: defaults::STALE_SUBMITTED_THRESHOLD_SECS,
-        }
-    }
+    /// Maximum requests per leaf_index within the rate limit window. Requires --rate-limit-window-secs.
+    #[arg(
+        long = "rate-limit-max-requests",
+        env = "RATE_LIMIT_MAX_REQUESTS",
+        requires = "window_secs"
+    )]
+    pub max_requests: Option<u64>,
 }
 
 /// Policy-driven batching configuration.
@@ -152,25 +128,16 @@ pub struct GatewayConfig {
     #[arg(long, env = "REDIS_URL")]
     pub redis_url: String,
 
-    /// Rate limit window in seconds (sliding window). Requires --rate-limit-max-requests.
-    #[arg(
-        long = "rate-limit-window-secs",
-        env = "RATE_LIMIT_WINDOW_SECS",
-        requires = "rate_limit_max_requests"
-    )]
-    pub rate_limit_window_secs: Option<u64>,
+    #[command(flatten)]
+    pub rate_limit: RateLimitConfig,
 
-    /// Maximum requests per leaf_index within the rate limit window. Requires --rate-limit-window-secs.
+    /// How often persisted transactions are checked for receipts, in seconds.
     #[arg(
-        long = "rate-limit-max-requests",
-        env = "RATE_LIMIT_MAX_REQUESTS",
-        requires = "rate_limit_window_secs"
+        long,
+        env = "TRANSACTION_TRACKER_INTERVAL_SECS",
+        default_value_t = defaults::TRANSACTION_TRACKER_INTERVAL_SECS
     )]
-    pub rate_limit_max_requests: Option<u64>,
-
-    /// How often the orphan sweeper runs, in seconds.
-    #[arg(long, env = "ORPHAN_SWEEPER_INTERVAL_SECS", default_value_t = defaults::SWEEPER_INTERVAL_SECS)]
-    pub sweeper_interval_secs: u64,
+    pub transaction_tracker_interval_secs: u64,
 
     #[command(flatten)]
     pub batch_policy: BatchPolicyConfig,
@@ -250,38 +217,13 @@ impl GatewayConfig {
             ));
         }
 
-        if self.sweeper().stale_queued_threshold_secs <= self.batch_policy.max_wait_secs {
+        if self.stale_queued_threshold_secs <= self.batch_policy.max_wait_secs {
             return Err(GatewayError::Config(
                 "STALE_QUEUED_THRESHOLD_SECS must be greater than BATCH_MAX_WAIT_SECS".to_string(),
             ));
         }
 
         Ok(())
-    }
-
-    pub fn batcher(&self) -> BatcherConfig {
-        BatcherConfig {
-            max_create_batch_size: self.max_create_batch_size,
-            max_ops_batch_size: self.max_ops_batch_size,
-        }
-    }
-
-    pub fn rate_limit(&self) -> Option<RateLimitConfig> {
-        match (self.rate_limit_window_secs, self.rate_limit_max_requests) {
-            (Some(window_secs), Some(max_requests)) => Some(RateLimitConfig {
-                window_secs,
-                max_requests,
-            }),
-            _ => None,
-        }
-    }
-
-    pub fn sweeper(&self) -> OrphanSweeperConfig {
-        OrphanSweeperConfig {
-            interval_secs: self.sweeper_interval_secs,
-            stale_queued_threshold_secs: self.stale_queued_threshold_secs,
-            stale_submitted_threshold_secs: self.stale_submitted_threshold_secs,
-        }
     }
 }
 
@@ -388,7 +330,8 @@ mod tests {
     #[test]
     fn rate_limit_disabled_when_omitted() {
         let config = parse_with_signer_args(&[]).expect("clap parsing should succeed");
-        assert!(config.rate_limit().is_none());
+        assert_eq!(config.rate_limit.window_secs, None);
+        assert_eq!(config.rate_limit.max_requests, None);
     }
 
     #[test]
@@ -400,9 +343,8 @@ mod tests {
             "100",
         ])
         .expect("clap parsing should succeed");
-        let rl = config.rate_limit().expect("rate_limit should be Some");
-        assert_eq!(rl.window_secs, 60);
-        assert_eq!(rl.max_requests, 100);
+        assert_eq!(config.rate_limit.window_secs, Some(60));
+        assert_eq!(config.rate_limit.max_requests, Some(100));
     }
 
     #[test]

--- a/services/gateway/src/error.rs
+++ b/services/gateway/src/error.rs
@@ -62,6 +62,8 @@ pub enum GatewayError {
         source: tokio::task::JoinError,
         backtrace: String,
     },
+    #[error("background task exited unexpectedly: {0}")]
+    BackgroundTaskExited(&'static str),
     #[error("config error: {0}")]
     Config(String),
 }

--- a/services/gateway/src/lib.rs
+++ b/services/gateway/src/lib.rs
@@ -2,10 +2,7 @@
 
 use crate::app::{build_gateway, serve_gateway};
 pub use crate::{
-    config::{
-        BatchPolicyConfig, BatcherConfig, GatewayConfig, OrphanSweeperConfig, RateLimitConfig,
-        RegistryVersion, defaults,
-    },
+    config::{BatchPolicyConfig, GatewayConfig, RateLimitConfig, RegistryVersion, defaults},
     transaction_submitter::{RequestRecord, now_unix_secs},
 };
 use std::{backtrace::Backtrace, net::SocketAddr};

--- a/services/gateway/src/lib.rs
+++ b/services/gateway/src/lib.rs
@@ -1,5 +1,6 @@
 #![recursion_limit = "256"]
 
+use crate::app::{build_gateway, serve_gateway};
 pub use crate::{
     config::{
         BatchPolicyConfig, BatcherConfig, GatewayConfig, OrphanSweeperConfig, RateLimitConfig,
@@ -7,11 +8,10 @@ pub use crate::{
     },
     transaction_submitter::{RequestRecord, now_unix_secs},
 };
-use crate::{routes::build_app, types::AppState};
-use std::{backtrace::Backtrace, net::SocketAddr, sync::Arc};
+use std::{backtrace::Backtrace, net::SocketAddr};
 use tokio::sync::oneshot;
-use world_id_registries::world_id::WorldIdRegistry::WorldIdRegistryInstance;
 
+mod app;
 mod batch_policy;
 mod batch_type;
 mod batcher;
@@ -26,6 +26,7 @@ mod types;
 
 // Re-export common types
 pub use crate::error::{GatewayError, GatewayResult};
+pub use app::Gateway;
 pub use world_id_services_common::{ProviderArgs, SignerArgs};
 
 #[derive(Debug)]
@@ -48,29 +49,6 @@ impl GatewayHandle {
 
 /// For tests only: spawn the gateway server and return a handle with shutdown.
 pub async fn spawn_gateway_for_tests(cfg: GatewayConfig) -> GatewayResult<GatewayHandle> {
-    let batcher_config = cfg.batcher();
-    let rate_limit = cfg.rate_limit();
-    let sweeper_config = cfg.sweeper();
-
-    let wallets = cfg.provider.clone().http_wallets().await?;
-    let provider = Arc::new(wallets[0].provider.clone());
-    let registry = Arc::new(WorldIdRegistryInstance::new(
-        cfg.registry_addr,
-        provider.clone(),
-    ));
-    let app = build_app(
-        registry,
-        wallets,
-        cfg.registry_version,
-        batcher_config,
-        cfg.redis_url,
-        rate_limit,
-        cfg.request_timeout_secs,
-        sweeper_config,
-        cfg.batch_policy.clone(),
-    )
-    .await?;
-
     let listener = tokio::net::TcpListener::bind(cfg.listen_addr)
         .await
         .map_err(|source| GatewayError::Bind {
@@ -83,17 +61,12 @@ pub async fn spawn_gateway_for_tests(cfg: GatewayConfig) -> GatewayResult<Gatewa
             source,
             backtrace: Backtrace::capture().to_string(),
         })?;
+    let gateway = build_gateway(cfg).await?;
 
     let (tx, rx) = oneshot::channel::<()>();
-    let server = axum::serve(listener, app).with_graceful_shutdown(async move {
+    let join = tokio::spawn(serve_gateway(gateway, listener, async move {
         let _ = rx.await;
-    });
-    let join = tokio::spawn(async move {
-        server.await.map_err(|e| GatewayError::Serve {
-            source: e,
-            backtrace: Backtrace::capture().to_string(),
-        })
-    });
+    }));
     Ok(GatewayHandle {
         shutdown: Some(tx),
         join,
@@ -104,45 +77,17 @@ pub async fn spawn_gateway_for_tests(cfg: GatewayConfig) -> GatewayResult<Gatewa
 // Public API: run to completion (blocking future) using env vars (bin-compatible)
 pub async fn run() -> GatewayResult<()> {
     let cfg = GatewayConfig::from_env()?;
-
-    let batcher_config = cfg.batcher();
-    let rate_limit = cfg.rate_limit();
-    let sweeper_config = cfg.sweeper();
-
-    let wallets = cfg.provider.clone().http_wallets().await?;
-    let provider = Arc::new(wallets[0].provider.clone());
-    let registry = Arc::new(WorldIdRegistryInstance::new(
-        cfg.registry_addr,
-        provider.clone(),
-    ));
-    tracing::info!(
-        registry_version = ?cfg.registry_version,
-        "Config is ready. Building app..."
-    );
-    let app = build_app(
-        registry,
-        wallets,
-        cfg.registry_version,
-        batcher_config,
-        cfg.redis_url,
-        rate_limit,
-        cfg.request_timeout_secs,
-        sweeper_config,
-        cfg.batch_policy.clone(),
-    )
-    .await?;
     let listener = tokio::net::TcpListener::bind(cfg.listen_addr)
         .await
         .map_err(|source| GatewayError::Bind {
             source,
             backtrace: Backtrace::capture().to_string(),
         })?;
+    tracing::info!(
+        registry_version = ?cfg.registry_version,
+        "Config is ready. Building gateway..."
+    );
     tracing::info!("HTTP server listening on {}", cfg.listen_addr);
-    axum::serve(listener, app)
-        .await
-        .map_err(|e| GatewayError::Serve {
-            source: e,
-            backtrace: Backtrace::capture().to_string(),
-        })?;
-    Ok(())
+    let gateway = build_gateway(cfg).await?;
+    serve_gateway(gateway, listener, std::future::pending()).await
 }

--- a/services/gateway/src/request.rs
+++ b/services/gateway/src/request.rs
@@ -1,17 +1,10 @@
 use std::sync::Arc;
 
 use crate::{
-    batcher::{BatcherHandle, Command},
-    config::RegistryVersion,
-    error::GatewayErrorResponse,
+    app::Gateway, batcher::Command, error::GatewayErrorResponse,
     routes::validation::RequestValidation,
-    transaction_submitter::TransactionSubmitter,
 };
-use alloy::{
-    primitives::{Bytes, U256},
-    providers::DynProvider,
-};
-use moka::future::Cache;
+use alloy::{primitives::Bytes, providers::DynProvider};
 use uuid::Uuid;
 use world_id_primitives::api_types::{
     CancelRecoveryAgentUpdateRequest, CreateAccountRequest, ExecuteRecoveryAgentUpdateRequest,
@@ -23,16 +16,6 @@ use world_id_registries::world_id::WorldIdRegistry::WorldIdRegistryInstance;
 
 /// Type alias for the registry instance.
 pub type Registry = WorldIdRegistryInstance<Arc<DynProvider>>;
-
-/// Context required for request validation and submission.
-#[derive(Clone)]
-pub struct GatewayContext {
-    pub registry: Arc<Registry>,
-    pub registry_version: RegistryVersion,
-    pub submitter: Arc<TransactionSubmitter>,
-    pub batcher: BatcherHandle,
-    pub root_cache: Cache<U256, U256>,
-}
 
 /// A request that has been validated and is ready for submission.
 pub struct Request<T> {
@@ -106,7 +89,7 @@ pub trait IntoRequest: RequestValidation + Sized {
     async fn into_request(
         self,
         id: Uuid,
-        ctx: &GatewayContext,
+        ctx: &Gateway,
     ) -> Result<Request<Self>, GatewayErrorResponse> {
         let calldata = self.validate_and_calldata(ctx).await?;
 
@@ -126,7 +109,7 @@ pub trait IntoRequestWithRateLimit: IntoRequest + HasLeafIndex {
     async fn into_request_with_rate_limit(
         self,
         id: Uuid,
-        ctx: &GatewayContext,
+        ctx: &Gateway,
     ) -> Result<Request<Self>, GatewayErrorResponse> {
         // Check rate limit first (before validation to save resources)
         // We do also count rate limitted requests.
@@ -154,10 +137,7 @@ impl IntoCommand for CreateAccountRequest {
 
 impl Request<CreateAccountRequest> {
     /// Submit the request for processing.
-    pub async fn submit(
-        self,
-        ctx: &GatewayContext,
-    ) -> Result<SubmittedRequest, GatewayErrorResponse> {
+    pub async fn submit(self, ctx: &Gateway) -> Result<SubmittedRequest, GatewayErrorResponse> {
         submit_request(self, ctx).await
     }
 }
@@ -185,10 +165,7 @@ impl IntoCommand for InsertAuthenticatorRequest {
 impl IntoRequestWithRateLimit for InsertAuthenticatorRequest {}
 
 impl Request<InsertAuthenticatorRequest> {
-    pub async fn submit(
-        self,
-        ctx: &GatewayContext,
-    ) -> Result<SubmittedRequest, GatewayErrorResponse> {
+    pub async fn submit(self, ctx: &Gateway) -> Result<SubmittedRequest, GatewayErrorResponse> {
         submit_request(self, ctx).await
     }
 }
@@ -216,10 +193,7 @@ impl IntoCommand for UpdateAuthenticatorRequest {
 impl IntoRequestWithRateLimit for UpdateAuthenticatorRequest {}
 
 impl Request<UpdateAuthenticatorRequest> {
-    pub async fn submit(
-        self,
-        ctx: &GatewayContext,
-    ) -> Result<SubmittedRequest, GatewayErrorResponse> {
+    pub async fn submit(self, ctx: &Gateway) -> Result<SubmittedRequest, GatewayErrorResponse> {
         submit_request(self, ctx).await
     }
 }
@@ -247,10 +221,7 @@ impl IntoCommand for RemoveAuthenticatorRequest {
 impl IntoRequestWithRateLimit for RemoveAuthenticatorRequest {}
 
 impl Request<RemoveAuthenticatorRequest> {
-    pub async fn submit(
-        self,
-        ctx: &GatewayContext,
-    ) -> Result<SubmittedRequest, GatewayErrorResponse> {
+    pub async fn submit(self, ctx: &Gateway) -> Result<SubmittedRequest, GatewayErrorResponse> {
         submit_request(self, ctx).await
     }
 }
@@ -278,10 +249,7 @@ impl IntoCommand for UpdateRecoveryAgentRequest {
 impl IntoRequestWithRateLimit for UpdateRecoveryAgentRequest {}
 
 impl Request<UpdateRecoveryAgentRequest> {
-    pub async fn submit(
-        self,
-        ctx: &GatewayContext,
-    ) -> Result<SubmittedRequest, GatewayErrorResponse> {
+    pub async fn submit(self, ctx: &Gateway) -> Result<SubmittedRequest, GatewayErrorResponse> {
         submit_request(self, ctx).await
     }
 }
@@ -309,10 +277,7 @@ impl IntoCommand for CancelRecoveryAgentUpdateRequest {
 impl IntoRequestWithRateLimit for CancelRecoveryAgentUpdateRequest {}
 
 impl Request<CancelRecoveryAgentUpdateRequest> {
-    pub async fn submit(
-        self,
-        ctx: &GatewayContext,
-    ) -> Result<SubmittedRequest, GatewayErrorResponse> {
+    pub async fn submit(self, ctx: &Gateway) -> Result<SubmittedRequest, GatewayErrorResponse> {
         submit_request(self, ctx).await
     }
 }
@@ -340,10 +305,7 @@ impl IntoCommand for ExecuteRecoveryAgentUpdateRequest {
 impl IntoRequestWithRateLimit for ExecuteRecoveryAgentUpdateRequest {}
 
 impl Request<ExecuteRecoveryAgentUpdateRequest> {
-    pub async fn submit(
-        self,
-        ctx: &GatewayContext,
-    ) -> Result<SubmittedRequest, GatewayErrorResponse> {
+    pub async fn submit(self, ctx: &Gateway) -> Result<SubmittedRequest, GatewayErrorResponse> {
         submit_request(self, ctx).await
     }
 }
@@ -375,10 +337,7 @@ impl IntoCommand for UpdateRecoveryAgentV2Request {
 impl IntoRequestWithRateLimit for UpdateRecoveryAgentV2Request {}
 
 impl Request<UpdateRecoveryAgentV2Request> {
-    pub async fn submit(
-        self,
-        ctx: &GatewayContext,
-    ) -> Result<SubmittedRequest, GatewayErrorResponse> {
+    pub async fn submit(self, ctx: &Gateway) -> Result<SubmittedRequest, GatewayErrorResponse> {
         submit_request(self, ctx).await
     }
 }
@@ -405,10 +364,7 @@ impl IntoCommand for RevertRecoveryAgentUpdateRequest {
 impl IntoRequestWithRateLimit for RevertRecoveryAgentUpdateRequest {}
 
 impl Request<RevertRecoveryAgentUpdateRequest> {
-    pub async fn submit(
-        self,
-        ctx: &GatewayContext,
-    ) -> Result<SubmittedRequest, GatewayErrorResponse> {
+    pub async fn submit(self, ctx: &Gateway) -> Result<SubmittedRequest, GatewayErrorResponse> {
         submit_request(self, ctx).await
     }
 }
@@ -436,10 +392,7 @@ impl IntoCommand for RecoverAccountRequest {
 impl IntoRequestWithRateLimit for RecoverAccountRequest {}
 
 impl Request<RecoverAccountRequest> {
-    pub async fn submit(
-        self,
-        ctx: &GatewayContext,
-    ) -> Result<SubmittedRequest, GatewayErrorResponse> {
+    pub async fn submit(self, ctx: &Gateway) -> Result<SubmittedRequest, GatewayErrorResponse> {
         submit_request(self, ctx).await
     }
 }
@@ -450,7 +403,7 @@ impl Request<RecoverAccountRequest> {
 /// locks), then submits the pre-built command to the batcher.
 async fn submit_request<T>(
     request: Request<T>,
-    ctx: &GatewayContext,
+    ctx: &Gateway,
 ) -> Result<SubmittedRequest, GatewayErrorResponse>
 where
     T: IntoCommand,
@@ -463,6 +416,9 @@ where
     } = request;
     let inflight_keys = payload.inflight_keys();
     let cmd = T::into_command(id, payload, calldata);
+
+    // TODO: We operate on both submitter & batcher here - we should consider extracting a single
+    //       entrypoint for this submission operation.
 
     ctx.submitter
         .new_request_with_id(id.to_string(), kind, inflight_keys)

--- a/services/gateway/src/routes.rs
+++ b/services/gateway/src/routes.rs
@@ -1,16 +1,5 @@
-use std::{sync::Arc, time::Duration};
-
 use crate::{
-    AppState,
-    batch_policy::{BaseFeeCache, spawn_base_fee_sampler},
-    batcher::{
-        BatcherHandle, CreateBatcherHandle, CreateBatcherRunner, OpsBatcherHandle, OpsBatcherRunner,
-    },
-    config::{
-        BatchPolicyConfig, BatcherConfig, OrphanSweeperConfig, RateLimitConfig, RegistryVersion,
-    },
-    error::{GatewayErrorBody, GatewayErrorResponse, GatewayResult},
-    request::GatewayContext,
+    error::{GatewayErrorBody, GatewayErrorResponse},
     routes::{
         cancel_recovery_agent_update::cancel_recovery_agent_update,
         create_account::create_account,
@@ -26,10 +15,8 @@ use crate::{
         update_authenticator::update_authenticator,
         update_recovery_agent::update_recovery_agent,
     },
-    transaction_submitter::TransactionSubmitter,
-    types::RootExpiry,
+    types::AppState,
 };
-use alloy::providers::DynProvider;
 use axum::{
     Json, Router,
     extract::{Path, State},
@@ -37,8 +24,6 @@ use axum::{
     response::IntoResponse,
     routing::{get, post},
 };
-use moka::future::Cache;
-use tokio::sync::mpsc;
 use utoipa::OpenApi;
 use world_id_primitives::api_types::{
     CancelRecoveryAgentUpdateRequest, CreateAccountRequest, ExecuteRecoveryAgentUpdateRequest,
@@ -47,8 +32,7 @@ use world_id_primitives::api_types::{
     RecoverAccountRequest, RemoveAuthenticatorRequest, UpdateAuthenticatorRequest,
     UpdateRecoveryAgentRequest,
 };
-use world_id_registries::world_id::WorldIdRegistry::WorldIdRegistryInstance;
-use world_id_services_common::{ProviderWallet, V1RecoveryAgentMethodsDeprecationLayer};
+use world_id_services_common::V1RecoveryAgentMethodsDeprecationLayer;
 
 // Health and status routes
 mod health;
@@ -77,87 +61,9 @@ mod is_valid_root;
 pub(crate) mod middleware;
 pub(crate) mod validation;
 
-const ROOT_CACHE_SIZE: u64 = 1024;
-const CREATE_BATCHER_CHANNEL_CAPACITY: usize = 1024;
-const OPS_BATCHER_CHANNEL_CAPACITY: usize = 2048;
-
-#[expect(clippy::too_many_arguments)]
-pub(crate) async fn build_app(
-    registry: Arc<WorldIdRegistryInstance<Arc<DynProvider>>>,
-    wallets: Vec<ProviderWallet>,
-    registry_version: RegistryVersion,
-    batcher_config: BatcherConfig,
-    redis_url: String,
-    rate_limit: Option<RateLimitConfig>,
-    request_timeout_secs: u64,
-    orphan_sweeper_config: OrphanSweeperConfig,
-    batch_policy_config: BatchPolicyConfig,
-) -> GatewayResult<Router> {
-    let submitter = TransactionSubmitter::connect(
-        *registry.address(),
-        wallets,
-        &redis_url,
-        rate_limit,
-        Duration::from_secs(orphan_sweeper_config.interval_secs),
-        Duration::from_secs(orphan_sweeper_config.stale_submitted_threshold_secs),
-    )
-    .await?;
-    let base_fee_cache = BaseFeeCache::default();
-
-    spawn_base_fee_sampler(
-        registry.provider().clone(),
-        Duration::from_millis(batch_policy_config.reeval_ms),
-        base_fee_cache.clone(),
-    );
-
-    let (tx, rx) = mpsc::channel(CREATE_BATCHER_CHANNEL_CAPACITY);
-    let batcher = CreateBatcherHandle { tx };
-    let runner = CreateBatcherRunner::new(
-        registry.clone(),
-        submitter.clone(),
-        batcher_config.max_create_batch_size,
-        CREATE_BATCHER_CHANNEL_CAPACITY,
-        rx,
-        batch_policy_config.clone(),
-        base_fee_cache.clone(),
-    );
-    tokio::spawn(runner.run());
-
-    // ops batcher (insert/remove/recover/update)
-    let (otx, orx) = mpsc::channel(OPS_BATCHER_CHANNEL_CAPACITY);
-    let ops_batcher = OpsBatcherHandle { tx: otx };
-    let ops_runner = OpsBatcherRunner::new(
-        registry.clone(),
-        submitter.clone(),
-        batcher_config.max_ops_batch_size,
-        OPS_BATCHER_CHANNEL_CAPACITY,
-        orx,
-        batch_policy_config,
-        base_fee_cache,
-    );
-    tokio::spawn(ops_runner.run());
-
-    tracing::info!("Ops batcher initialized");
-
-    let root_cache = Cache::builder()
-        .max_capacity(ROOT_CACHE_SIZE)
-        .expire_after(RootExpiry)
-        .build();
-
-    let batcher_handle = BatcherHandle {
-        create: batcher,
-        ops: ops_batcher,
-    };
-    let ctx = GatewayContext {
-        registry: registry.clone(),
-        registry_version,
-        submitter,
-        batcher: batcher_handle,
-        root_cache,
-    };
-    let state = AppState { ctx };
-
-    Ok(Router::new()
+pub(crate) fn router(state: AppState) -> Router {
+    let request_timeout_secs = state.config.request_timeout_secs;
+    Router::new()
         .route("/health", get(health))
         // account creation (batched)
         .route("/create-account", post(create_account))
@@ -201,7 +107,7 @@ pub(crate) async fn build_app(
             request_timeout_secs,
             GatewayErrorResponse::request_timeout(request_timeout_secs),
         ))
-        .layer(world_id_services_common::trace_layer()))
+        .layer(world_id_services_common::trace_layer())
 }
 
 #[utoipa::path(

--- a/services/gateway/src/routes/cancel_recovery_agent_update.rs
+++ b/services/gateway/src/routes/cancel_recovery_agent_update.rs
@@ -24,17 +24,17 @@ pub(crate) async fn cancel_recovery_agent_update(
     Extension(RequestId(id)): Extension<RequestId>,
     Json(payload): Json<CancelRecoveryAgentUpdateRequest>,
 ) -> Result<Json<GatewayStatusResponse>, GatewayErrorResponse> {
-    match state.ctx.registry_version {
+    match state.config.registry_version {
         RegistryVersion::V1 => payload
-            .into_request_with_rate_limit(id, &state.ctx)
+            .into_request_with_rate_limit(id, &state)
             .await?
-            .submit(&state.ctx)
+            .submit(&state)
             .await
             .map(|r| Json(r.into_response())),
         RegistryVersion::V2 => RevertRecoveryAgentUpdateRequest(payload)
-            .into_request_with_rate_limit(id, &state.ctx)
+            .into_request_with_rate_limit(id, &state)
             .await?
-            .submit(&state.ctx)
+            .submit(&state)
             .await
             .map(|r| Json(r.into_response())),
     }

--- a/services/gateway/src/routes/create_account.rs
+++ b/services/gateway/src/routes/create_account.rs
@@ -18,9 +18,9 @@ pub(crate) async fn create_account(
     Json(payload): Json<CreateAccountRequest>,
 ) -> Result<Json<GatewayStatusResponse>, GatewayErrorResponse> {
     payload
-        .into_request(id, &state.ctx)
+        .into_request(id, &state)
         .await?
-        .submit(&state.ctx)
+        .submit(&state)
         .await
         .map(|r| Json(r.into_response()))
 }

--- a/services/gateway/src/routes/execute_recovery_agent_update.rs
+++ b/services/gateway/src/routes/execute_recovery_agent_update.rs
@@ -25,11 +25,11 @@ pub(crate) async fn execute_recovery_agent_update(
     Extension(RequestId(id)): Extension<RequestId>,
     Json(payload): Json<ExecuteRecoveryAgentUpdateRequest>,
 ) -> Result<Json<GatewayStatusResponse>, GatewayErrorResponse> {
-    match state.ctx.registry_version {
+    match state.config.registry_version {
         RegistryVersion::V1 => payload
-            .into_request_with_rate_limit(id, &state.ctx)
+            .into_request_with_rate_limit(id, &state)
             .await?
-            .submit(&state.ctx)
+            .submit(&state)
             .await
             .map(|r| Json(r.into_response())),
         RegistryVersion::V2 => {
@@ -43,7 +43,6 @@ pub(crate) async fn execute_recovery_agent_update(
             };
 
             state
-                .ctx
                 .submitter
                 .new_terminal_request_with_id(id.to_string(), kind, status.clone())
                 .await?;

--- a/services/gateway/src/routes/initiate_recovery_agent_update.rs
+++ b/services/gateway/src/routes/initiate_recovery_agent_update.rs
@@ -24,17 +24,17 @@ pub(crate) async fn initiate_recovery_agent_update(
     Extension(RequestId(id)): Extension<RequestId>,
     Json(payload): Json<UpdateRecoveryAgentRequest>,
 ) -> Result<Json<GatewayStatusResponse>, GatewayErrorResponse> {
-    match state.ctx.registry_version {
+    match state.config.registry_version {
         RegistryVersion::V1 => payload
-            .into_request_with_rate_limit(id, &state.ctx)
+            .into_request_with_rate_limit(id, &state)
             .await?
-            .submit(&state.ctx)
+            .submit(&state)
             .await
             .map(|r| Json(r.into_response())),
         RegistryVersion::V2 => UpdateRecoveryAgentV2Request(payload)
-            .into_request_with_rate_limit(id, &state.ctx)
+            .into_request_with_rate_limit(id, &state)
             .await?
-            .submit(&state.ctx)
+            .submit(&state)
             .await
             .map(|r| Json(r.into_response())),
     }

--- a/services/gateway/src/routes/insert_authenticator.rs
+++ b/services/gateway/src/routes/insert_authenticator.rs
@@ -18,9 +18,9 @@ pub(crate) async fn insert_authenticator(
     Json(payload): Json<InsertAuthenticatorRequest>,
 ) -> Result<Json<GatewayStatusResponse>, GatewayErrorResponse> {
     payload
-        .into_request_with_rate_limit(id, &state.ctx)
+        .into_request_with_rate_limit(id, &state)
         .await?
-        .submit(&state.ctx)
+        .submit(&state)
         .await
         .map(|r| Json(r.into_response()))
 }

--- a/services/gateway/src/routes/is_valid_root.rs
+++ b/services/gateway/src/routes/is_valid_root.rs
@@ -33,7 +33,7 @@ fn is_expired(expires_at: U256, now: U256) -> bool {
 ///
 /// Expiration is handled automatically by moka's `Expiry` policy.
 async fn is_cached_root(state: &AppState, root: U256) -> bool {
-    state.ctx.root_cache.get(&root).await.is_some()
+    state.root_cache.get(&root).await.is_some()
 }
 
 /// Cache decision for a valid root.
@@ -92,7 +92,6 @@ pub(crate) async fn is_valid_root(
     let now = now_timestamp()?;
 
     let valid = state
-        .ctx
         .registry
         .isValidRoot(root)
         .call()
@@ -100,9 +99,9 @@ pub(crate) async fn is_valid_root(
         .map_err(|e| GatewayErrorResponse::from_simulation_error(e.to_string()))?;
     if valid {
         // Cache only valid roots to avoid serving stale negatives indefinitely.
-        match cache_policy_for_root(state.ctx.registry.clone(), root, now).await {
+        match cache_policy_for_root(state.registry.clone(), root, now).await {
             Ok(CachePolicy::Cache(expires_at)) => {
-                state.ctx.root_cache.insert(root, expires_at).await;
+                state.root_cache.insert(root, expires_at).await;
             }
             Ok(CachePolicy::Skip) => {}
             Err(err) => {

--- a/services/gateway/src/routes/recover_account.rs
+++ b/services/gateway/src/routes/recover_account.rs
@@ -18,9 +18,9 @@ pub(crate) async fn recover_account(
     Json(payload): Json<RecoverAccountRequest>,
 ) -> Result<Json<GatewayStatusResponse>, GatewayErrorResponse> {
     payload
-        .into_request_with_rate_limit(id, &state.ctx)
+        .into_request_with_rate_limit(id, &state)
         .await?
-        .submit(&state.ctx)
+        .submit(&state)
         .await
         .map(|r| Json(r.into_response()))
 }

--- a/services/gateway/src/routes/remove_authenticator.rs
+++ b/services/gateway/src/routes/remove_authenticator.rs
@@ -18,9 +18,9 @@ pub(crate) async fn remove_authenticator(
     Json(payload): Json<RemoveAuthenticatorRequest>,
 ) -> Result<Json<GatewayStatusResponse>, GatewayErrorResponse> {
     payload
-        .into_request_with_rate_limit(id, &state.ctx)
+        .into_request_with_rate_limit(id, &state)
         .await?
-        .submit(&state.ctx)
+        .submit(&state)
         .await
         .map(|r| Json(r.into_response()))
 }

--- a/services/gateway/src/routes/request_status.rs
+++ b/services/gateway/src/routes/request_status.rs
@@ -18,7 +18,6 @@ pub(crate) async fn request_status(
 ) -> Result<Json<GatewayStatusResponse>, GatewayErrorResponse> {
     let raw_id = id.as_str_without_prefix();
     let record = state
-        .ctx
         .submitter
         .snapshot(raw_id)
         .await

--- a/services/gateway/src/routes/revert_recovery_agent_update.rs
+++ b/services/gateway/src/routes/revert_recovery_agent_update.rs
@@ -24,7 +24,7 @@ pub(crate) async fn revert_recovery_agent_update(
     Extension(RequestId(id)): Extension<RequestId>,
     Json(payload): Json<CancelRecoveryAgentUpdateRequest>,
 ) -> Result<Json<GatewayStatusResponse>, GatewayErrorResponse> {
-    if state.ctx.registry_version == RegistryVersion::V1 {
+    if state.config.registry_version == RegistryVersion::V1 {
         return Err(GatewayErrorResponse::new(
             GatewayErrorCode::MethodNotAvailable,
             "POST /revert-recovery-agent-update requires the registry to be on V2 (WIP-102). \
@@ -34,9 +34,9 @@ pub(crate) async fn revert_recovery_agent_update(
         ));
     }
     RevertRecoveryAgentUpdateRequest(payload)
-        .into_request_with_rate_limit(id, &state.ctx)
+        .into_request_with_rate_limit(id, &state)
         .await?
-        .submit(&state.ctx)
+        .submit(&state)
         .await
         .map(|r| Json(r.into_response()))
 }

--- a/services/gateway/src/routes/update_authenticator.rs
+++ b/services/gateway/src/routes/update_authenticator.rs
@@ -18,9 +18,9 @@ pub(crate) async fn update_authenticator(
     Json(payload): Json<UpdateAuthenticatorRequest>,
 ) -> Result<Json<GatewayStatusResponse>, GatewayErrorResponse> {
     payload
-        .into_request_with_rate_limit(id, &state.ctx)
+        .into_request_with_rate_limit(id, &state)
         .await?
-        .submit(&state.ctx)
+        .submit(&state)
         .await
         .map(|r| Json(r.into_response()))
 }

--- a/services/gateway/src/routes/update_recovery_agent.rs
+++ b/services/gateway/src/routes/update_recovery_agent.rs
@@ -23,7 +23,7 @@ pub(crate) async fn update_recovery_agent(
     Extension(RequestId(id)): Extension<RequestId>,
     Json(payload): Json<UpdateRecoveryAgentRequest>,
 ) -> Result<Json<GatewayStatusResponse>, GatewayErrorResponse> {
-    if state.ctx.registry_version == RegistryVersion::V1 {
+    if state.config.registry_version == RegistryVersion::V1 {
         return Err(GatewayErrorResponse::new(
             GatewayErrorCode::MethodNotAvailable,
             "POST /update-recovery-agent requires the registry to be on V2 (WIP-102). \
@@ -33,9 +33,9 @@ pub(crate) async fn update_recovery_agent(
         ));
     }
     UpdateRecoveryAgentV2Request(payload)
-        .into_request_with_rate_limit(id, &state.ctx)
+        .into_request_with_rate_limit(id, &state)
         .await?
-        .submit(&state.ctx)
+        .submit(&state)
         .await
         .map(|r| Json(r.into_response()))
 }

--- a/services/gateway/src/routes/validation.rs
+++ b/services/gateway/src/routes/validation.rs
@@ -20,9 +20,7 @@ use world_id_registries::world_id::{
 };
 
 use crate::{
-    request::{
-        GatewayContext, Registry, RevertRecoveryAgentUpdateRequest, UpdateRecoveryAgentV2Request,
-    },
+    request::{Registry, RevertRecoveryAgentUpdateRequest, UpdateRecoveryAgentV2Request},
     types::MAX_AUTHENTICATORS,
 };
 
@@ -69,7 +67,7 @@ pub(crate) trait RequestValidation: Sized + Sync {
     /// and returns the already-encoded calldata for submission.
     fn validate_and_calldata(
         &self,
-        ctx: &GatewayContext,
+        ctx: &crate::app::Gateway,
     ) -> impl Future<Output = Result<Bytes, GatewayErrorResponse>> + Send {
         async move {
             let registry = ctx.registry.as_ref();
@@ -85,7 +83,7 @@ pub(crate) trait RequestValidation: Sized + Sync {
             let pre_flight_ctx = PreFlightContext {
                 chain_id,
                 verifying_contract: *registry.address(),
-                registry_version: ctx.registry_version,
+                registry_version: ctx.config.registry_version,
             };
 
             self.pre_flight(pre_flight_ctx)?;

--- a/services/gateway/src/transaction_submitter.rs
+++ b/services/gateway/src/transaction_submitter.rs
@@ -96,10 +96,6 @@ impl TransactionSubmitter {
             tracker_interval,
         });
 
-        // TODO: We should move task spawning to app initialization
-        //       and track each task's JoinHandle to catch panics
-        tokio::spawn(submitter.clone().run_tracker());
-
         Ok(submitter)
     }
 
@@ -237,10 +233,10 @@ impl TransactionSubmitter {
         leaf_index: u64,
         request_id: &str,
     ) -> Result<(), GatewayErrorResponse> {
-        let Some(ref rl) = self.rate_limit else {
+        let Some(ref rate_limit) = self.rate_limit else {
             return Ok(());
         };
-        let (window_secs, max_requests) = (rl.window_secs, rl.max_requests);
+        let (window_secs, max_requests) = (rate_limit.window_secs, rate_limit.max_requests);
 
         let result = self
             .request_store
@@ -389,7 +385,7 @@ impl TransactionSubmitter {
         Ok(())
     }
 
-    async fn run_tracker(self: Arc<Self>) {
+    pub(crate) async fn run_tracker(self: Arc<Self>) {
         loop {
             if let Err(error) = self.track_transactions().await {
                 tracing::error!(%error, "failed to track persisted wallet transactions");

--- a/services/gateway/src/transaction_submitter.rs
+++ b/services/gateway/src/transaction_submitter.rs
@@ -38,7 +38,7 @@ pub(crate) struct TransactionSubmitter {
     wallets: Vec<WalletEntry>,
     wallet_store: WalletStore,
     request_store: RequestStore,
-    rate_limit: Option<RateLimitConfig>,
+    rate_limit: RateLimitConfig,
     next_wallet: AtomicUsize,
     wallet_released: Notify,
     receipt_timeout: Duration,
@@ -57,7 +57,7 @@ impl TransactionSubmitter {
         registry_address: Address,
         wallets: Vec<ProviderWallet>,
         redis_url: &str,
-        rate_limit: Option<RateLimitConfig>,
+        rate_limit: RateLimitConfig,
         tracker_interval: Duration,
         receipt_timeout: Duration,
     ) -> GatewayResult<Arc<Self>> {
@@ -233,10 +233,11 @@ impl TransactionSubmitter {
         leaf_index: u64,
         request_id: &str,
     ) -> Result<(), GatewayErrorResponse> {
-        let Some(ref rate_limit) = self.rate_limit else {
+        let (Some(window_secs), Some(max_requests)) =
+            (self.rate_limit.window_secs, self.rate_limit.max_requests)
+        else {
             return Ok(());
         };
-        let (window_secs, max_requests) = (rate_limit.window_secs, rate_limit.max_requests);
 
         let result = self
             .request_store
@@ -664,7 +665,7 @@ mod tests {
             Address::ZERO,
             vec![provider_wallet(first), provider_wallet(second)],
             &url,
-            None,
+            RateLimitConfig::default(),
             Duration::from_secs(60),
             Duration::from_secs(60),
         )
@@ -695,7 +696,7 @@ mod tests {
             Address::ZERO,
             vec![provider_wallet(wallet)],
             &url,
-            None,
+            RateLimitConfig::default(),
             Duration::from_secs(60),
             Duration::from_secs(10),
         )

--- a/services/gateway/src/types.rs
+++ b/services/gateway/src/types.rs
@@ -1,7 +1,10 @@
-use crate::request::GatewayContext;
+use crate::app::Gateway;
 use alloy::primitives::U256;
 use moka::Expiry;
-use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+use std::{
+    sync::Arc,
+    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
+};
 
 /// Maximum number of authenticators per account (matches contract default).
 pub(crate) const MAX_AUTHENTICATORS: u32 = 7;
@@ -62,8 +65,4 @@ impl Expiry<U256, U256> for RootExpiry {
 }
 
 /// Shared application state for gateway handlers.
-#[derive(Clone)]
-pub(crate) struct AppState {
-    /// Gateway context for request validation and submission.
-    pub(crate) ctx: GatewayContext,
-}
+pub(crate) type AppState = Arc<Gateway>;

--- a/services/gateway/tests/common.rs
+++ b/services/gateway/tests/common.rs
@@ -6,8 +6,8 @@ use testcontainers_modules::{
     testcontainers::{ContainerAsync, ImageExt as _, runners::AsyncRunner as _},
 };
 use world_id_gateway::{
-    BatchPolicyConfig, GatewayConfig, GatewayHandle, RegistryVersion, SignerArgs, defaults,
-    spawn_gateway_for_tests,
+    BatchPolicyConfig, GatewayConfig, GatewayHandle, RateLimitConfig, RegistryVersion, SignerArgs,
+    defaults, spawn_gateway_for_tests,
 };
 use world_id_primitives::api_types::{GatewayRequestState, GatewayStatusResponse};
 use world_id_services_common::ProviderArgs;
@@ -65,7 +65,7 @@ fn spawn_test_anvil() -> TestAnvil {
 /// Spawn a test gateway backed by a forked anvil chain and a Redis container.
 ///
 /// * `batch_ms` – when `None` the gateway uses `BatchPolicyConfig::default()`
-///   and the standard sweeper/stale thresholds.  Pass `Some(ms)` to configure
+///   and the standard tracker/stale thresholds. Pass `Some(ms)` to configure
 ///   a custom batch window (used by `test_inflight.rs`).
 #[allow(dead_code)]
 pub(crate) async fn spawn_test_gateway(batch_ms: Option<u64>) -> TestGateway {
@@ -178,9 +178,8 @@ async fn spawn_test_gateway_for_registry(
             listen_addr: (std::net::Ipv4Addr::LOCALHOST, 0).into(),
             redis_url: redis_url.clone(),
             request_timeout_secs: 10,
-            rate_limit_window_secs: None,
-            rate_limit_max_requests: None,
-            sweeper_interval_secs: defaults::SWEEPER_INTERVAL_SECS,
+            rate_limit: RateLimitConfig::default(),
+            transaction_tracker_interval_secs: defaults::TRANSACTION_TRACKER_INTERVAL_SECS,
             stale_queued_threshold_secs: defaults::STALE_QUEUED_THRESHOLD_SECS,
             stale_submitted_threshold_secs: defaults::STALE_SUBMITTED_THRESHOLD_SECS,
             batch_policy: BatchPolicyConfig::default(),
@@ -206,9 +205,8 @@ async fn spawn_test_gateway_for_registry(
                 max_ops_batch_size: 10,
                 redis_url: redis_url.clone(),
                 request_timeout_secs: 10,
-                rate_limit_window_secs: None,
-                rate_limit_max_requests: None,
-                sweeper_interval_secs: max_wait_secs + 1,
+                rate_limit: RateLimitConfig::default(),
+                transaction_tracker_interval_secs: max_wait_secs + 1,
                 stale_queued_threshold_secs: max_wait_secs + 1,
                 stale_submitted_threshold_secs: 600,
             }

--- a/services/gateway/tests/test_rate_limiting.rs
+++ b/services/gateway/tests/test_rate_limiting.rs
@@ -7,7 +7,8 @@ use alloy::{
 };
 use reqwest::{Client, StatusCode};
 use world_id_gateway::{
-    BatchPolicyConfig, GatewayConfig, RegistryVersion, defaults, spawn_gateway_for_tests,
+    BatchPolicyConfig, GatewayConfig, RateLimitConfig, RegistryVersion, defaults,
+    spawn_gateway_for_tests,
 };
 use world_id_primitives::api_types::{InsertAuthenticatorRequest, UpdateAuthenticatorRequest};
 use world_id_registries::world_id::{InsertAuthenticatorTypedData, UpdateAuthenticatorTypedData};
@@ -75,9 +76,11 @@ async fn test_rate_limit_basic() {
         listen_addr: (std::net::Ipv4Addr::LOCALHOST, 0).into(),
         redis_url: redis_url.clone(),
         request_timeout_secs: 10,
-        rate_limit_window_secs: Some(10),
-        rate_limit_max_requests: Some(3),
-        sweeper_interval_secs: defaults::SWEEPER_INTERVAL_SECS,
+        rate_limit: RateLimitConfig {
+            window_secs: Some(10),
+            max_requests: Some(3),
+        },
+        transaction_tracker_interval_secs: defaults::TRANSACTION_TRACKER_INTERVAL_SECS,
         stale_queued_threshold_secs: defaults::STALE_QUEUED_THRESHOLD_SECS,
         stale_submitted_threshold_secs: defaults::STALE_SUBMITTED_THRESHOLD_SECS,
         batch_policy: BatchPolicyConfig::default(),
@@ -283,9 +286,11 @@ async fn test_rate_limit_different_leaf_indexes() {
         listen_addr: (std::net::Ipv4Addr::LOCALHOST, 0).into(),
         redis_url: redis_url.clone(),
         request_timeout_secs: 10,
-        rate_limit_window_secs: Some(10),
-        rate_limit_max_requests: Some(2),
-        sweeper_interval_secs: defaults::SWEEPER_INTERVAL_SECS,
+        rate_limit: RateLimitConfig {
+            window_secs: Some(10),
+            max_requests: Some(2),
+        },
+        transaction_tracker_interval_secs: defaults::TRANSACTION_TRACKER_INTERVAL_SECS,
         stale_queued_threshold_secs: defaults::STALE_QUEUED_THRESHOLD_SECS,
         stale_submitted_threshold_secs: defaults::STALE_SUBMITTED_THRESHOLD_SECS,
         batch_policy: BatchPolicyConfig::default(),
@@ -440,9 +445,11 @@ async fn test_rate_limit_sliding_window() {
         listen_addr: (std::net::Ipv4Addr::LOCALHOST, 0).into(),
         redis_url: redis_url.clone(),
         request_timeout_secs: 10,
-        rate_limit_window_secs: Some(3),
-        rate_limit_max_requests: Some(2),
-        sweeper_interval_secs: defaults::SWEEPER_INTERVAL_SECS,
+        rate_limit: RateLimitConfig {
+            window_secs: Some(3),
+            max_requests: Some(2),
+        },
+        transaction_tracker_interval_secs: defaults::TRANSACTION_TRACKER_INTERVAL_SECS,
         stale_queued_threshold_secs: defaults::STALE_QUEUED_THRESHOLD_SECS,
         stale_submitted_threshold_secs: defaults::STALE_SUBMITTED_THRESHOLD_SECS,
         batch_policy: BatchPolicyConfig::default(),
@@ -594,9 +601,11 @@ async fn test_rate_limit_multiple_endpoints() {
         listen_addr: (std::net::Ipv4Addr::LOCALHOST, 0).into(),
         redis_url: redis_url.clone(),
         request_timeout_secs: 10,
-        rate_limit_window_secs: Some(10),
-        rate_limit_max_requests: Some(3),
-        sweeper_interval_secs: defaults::SWEEPER_INTERVAL_SECS,
+        rate_limit: RateLimitConfig {
+            window_secs: Some(10),
+            max_requests: Some(3),
+        },
+        transaction_tracker_interval_secs: defaults::TRANSACTION_TRACKER_INTERVAL_SECS,
         stale_queued_threshold_secs: defaults::STALE_QUEUED_THRESHOLD_SECS,
         stale_submitted_threshold_secs: defaults::STALE_SUBMITTED_THRESHOLD_SECS,
         batch_policy: BatchPolicyConfig::default(),

--- a/services/gateway/tests/test_with_redis.rs
+++ b/services/gateway/tests/test_with_redis.rs
@@ -7,7 +7,8 @@ use alloy::{
 use redis::{AsyncTypedCommands, IntegerReplyOrNoOp, aio::ConnectionManager};
 use reqwest::{Client, StatusCode};
 use world_id_gateway::{
-    BatchPolicyConfig, GatewayConfig, RegistryVersion, defaults, spawn_gateway_for_tests,
+    BatchPolicyConfig, GatewayConfig, RateLimitConfig, RegistryVersion, defaults,
+    spawn_gateway_for_tests,
 };
 use world_id_primitives::api_types::GatewayStatusResponse;
 use world_id_services_common::{ProviderArgs, SignerArgs};
@@ -50,9 +51,11 @@ async fn redis_integration() {
         listen_addr: (std::net::Ipv4Addr::LOCALHOST, 0).into(),
         redis_url: redis_url.clone(),
         request_timeout_secs: 10,
-        rate_limit_window_secs: Some(5),
-        rate_limit_max_requests: Some(10),
-        sweeper_interval_secs: defaults::SWEEPER_INTERVAL_SECS,
+        rate_limit: RateLimitConfig {
+            window_secs: Some(5),
+            max_requests: Some(10),
+        },
+        transaction_tracker_interval_secs: defaults::TRANSACTION_TRACKER_INTERVAL_SECS,
         stale_queued_threshold_secs: defaults::STALE_QUEUED_THRESHOLD_SECS,
         stale_submitted_threshold_secs: defaults::STALE_SUBMITTED_THRESHOLD_SECS,
         batch_policy: BatchPolicyConfig::default(),

--- a/tools/generate-solidity-fixtures/src/main.rs
+++ b/tools/generate-solidity-fixtures/src/main.rs
@@ -34,7 +34,7 @@ use world_id_core::{
     requests::{ProofRequest, ProofType, RequestItem, RequestVersion},
 };
 use world_id_gateway::{
-    BatchPolicyConfig, GatewayConfig, RegistryVersion, SignerArgs, defaults,
+    BatchPolicyConfig, GatewayConfig, RateLimitConfig, RegistryVersion, SignerArgs, defaults,
     spawn_gateway_for_tests,
 };
 use world_id_primitives::{
@@ -94,9 +94,8 @@ async fn main() -> Result<()> {
         redis_url: std::env::var("REDIS_URL")
             .unwrap_or_else(|_| "redis://localhost:6379".to_string()),
         request_timeout_secs: 10,
-        rate_limit_max_requests: None,
-        rate_limit_window_secs: None,
-        sweeper_interval_secs: defaults::SWEEPER_INTERVAL_SECS,
+        rate_limit: RateLimitConfig::default(),
+        transaction_tracker_interval_secs: defaults::TRANSACTION_TRACKER_INTERVAL_SECS,
         stale_queued_threshold_secs: defaults::STALE_QUEUED_THRESHOLD_SECS,
         stale_submitted_threshold_secs: defaults::STALE_SUBMITTED_THRESHOLD_SECS,
         batch_policy: BatchPolicyConfig::default(),


### PR DESCRIPTION
## Summary

This PR is mostly a refactor but one change should be noted - now every long-term, background tokio task is spawned and supervised for unexpected exits or panics. Previously a thread could panic which would disable e.g. base fee sampling without crashing the service possibly imparining gateway's functionality.

- introduce a central `Gateway` struct which serves as a "lite" version of a dependency container
- simplify gateway configuration and flatten rate-limit arguments
- replace the batch queues with bounded Flume MPMC channels (to avoid using a Mutex on the receiver)

## Testing

- cargo +nightly fmt --all -- --check
- cargo clippy -p world-id-gateway --all-targets --no-deps --target-dir /private/tmp/world-id-protocol-gateway-refactor-clippy -- -D warnings
- cargo test -p world-id-gateway --lib app::tests
- cargo test -p world-id-gateway --lib config::tests