### PR TITLE
feat(services): enable CORS for gateway and indexer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10983,6 +10983,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "test-case"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2550dd13afcd286853192af8601920d959b14c401fcece38071d53bf0768a8"
+dependencies = [
+ "test-case-macros",
+]
+
+[[package]]
+name = "test-case-core"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adcb7fd841cd518e279be3d5a3eb0636409487998a4aff22f3de87b81e88384f"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "test-case-macros"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "test-case-core",
+]
+
+[[package]]
 name = "testcontainers"
 version = "0.27.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13269,6 +13302,7 @@ dependencies = [
  "serde",
  "telemetry-batteries",
  "tempfile",
+ "test-case",
  "thiserror 2.0.18",
  "tokio",
  "tower",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,7 +91,7 @@ strum = { version = "0.27", features = ["derive"] }
 thiserror = "2"
 tokio = { version = "1", default-features = false }
 toml = "1"
-tower-http = { version = "0.6", features = ["trace", "timeout"] }
+tower-http = { version = "0.6", features = ["cors", "trace", "timeout"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 url = { version = "2", features = ["serde"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,7 @@ serde_json = "1"
 sha3 = { version = "0.10", default-features = false }
 strum = { version = "0.27", features = ["derive"] }
 thiserror = "2"
+test-case = "3"
 tokio = { version = "1", default-features = false }
 toml = "1"
 tower-http = { version = "0.6", features = ["cors", "trace", "timeout"] }

--- a/services/common/Cargo.toml
+++ b/services/common/Cargo.toml
@@ -46,5 +46,6 @@ metrics = { workspace = true }
 [dev-dependencies]
 axum = { workspace = true }
 tempfile = { workspace = true }
+test-case = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 metrics-util = { workspace = true }

--- a/services/common/src/axum/server_layers/cors.rs
+++ b/services/common/src/axum/server_layers/cors.rs
@@ -23,6 +23,7 @@ mod tests {
             ACCESS_CONTROL_REQUEST_HEADERS, ACCESS_CONTROL_REQUEST_METHOD, ORIGIN,
         },
     };
+    use test_case::test_case;
     use tower::ServiceExt;
 
     use super::*;
@@ -33,30 +34,30 @@ mod tests {
             .layer(cors_layer())
     }
 
+    #[test_case("https://app.example.com" ; "app origin")]
+    #[test_case("https://unrelated.example" ; "unrelated origin")]
     #[tokio::test]
-    async fn every_origin_is_allowed_without_credentials() {
-        for origin in ["https://app.example.com", "https://unrelated.example"] {
-            let response = app()
-                .oneshot(
-                    Request::get("/resource")
-                        .header(ORIGIN, origin)
-                        .body(axum::body::Body::empty())
-                        .unwrap(),
-                )
-                .await
-                .unwrap();
+    async fn every_origin_is_allowed_without_credentials(origin: &str) {
+        let response = app()
+            .oneshot(
+                Request::get("/resource")
+                    .header(ORIGIN, origin)
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
 
-            assert_eq!(response.status(), StatusCode::NO_CONTENT);
-            assert_eq!(
-                response.headers().get(ACCESS_CONTROL_ALLOW_ORIGIN),
-                Some(&http::HeaderValue::from_static("*"))
-            );
-            assert!(
-                !response
-                    .headers()
-                    .contains_key(ACCESS_CONTROL_ALLOW_CREDENTIALS)
-            );
-        }
+        assert_eq!(response.status(), StatusCode::NO_CONTENT);
+        assert_eq!(
+            response.headers().get(ACCESS_CONTROL_ALLOW_ORIGIN),
+            Some(&http::HeaderValue::from_static("*"))
+        );
+        assert!(
+            !response
+                .headers()
+                .contains_key(ACCESS_CONTROL_ALLOW_CREDENTIALS)
+        );
     }
 
     #[tokio::test]

--- a/services/common/src/axum/server_layers/cors.rs
+++ b/services/common/src/axum/server_layers/cors.rs
@@ -1,0 +1,97 @@
+use http::{Method, header::CONTENT_TYPE};
+use tower_http::cors::{Any, CorsLayer};
+
+/// Builds the CORS policy shared by the public protocol HTTP services.
+///
+/// The gateway and indexer are public APIs, so browser requests from every
+/// origin are allowed. Credentials remain disabled.
+pub fn cors_layer() -> CorsLayer {
+    CorsLayer::new()
+        .allow_origin(Any)
+        .allow_methods([Method::GET, Method::POST, Method::OPTIONS])
+        .allow_headers([CONTENT_TYPE])
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::{Router, routing::get};
+    use http::{
+        Method, Request, StatusCode,
+        header::{
+            ACCESS_CONTROL_ALLOW_CREDENTIALS, ACCESS_CONTROL_ALLOW_HEADERS,
+            ACCESS_CONTROL_ALLOW_METHODS, ACCESS_CONTROL_ALLOW_ORIGIN,
+            ACCESS_CONTROL_REQUEST_HEADERS, ACCESS_CONTROL_REQUEST_METHOD, ORIGIN,
+        },
+    };
+    use tower::ServiceExt;
+
+    use super::*;
+
+    fn app() -> Router {
+        Router::new()
+            .route("/resource", get(|| async { StatusCode::NO_CONTENT }))
+            .layer(cors_layer())
+    }
+
+    #[tokio::test]
+    async fn every_origin_is_allowed_without_credentials() {
+        for origin in ["https://app.example.com", "https://unrelated.example"] {
+            let response = app()
+                .oneshot(
+                    Request::get("/resource")
+                        .header(ORIGIN, origin)
+                        .body(axum::body::Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+
+            assert_eq!(response.status(), StatusCode::NO_CONTENT);
+            assert_eq!(
+                response.headers().get(ACCESS_CONTROL_ALLOW_ORIGIN),
+                Some(&http::HeaderValue::from_static("*"))
+            );
+            assert!(
+                !response
+                    .headers()
+                    .contains_key(ACCESS_CONTROL_ALLOW_CREDENTIALS)
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn preflight_allows_public_api_methods_and_json_header() {
+        let response = app()
+            .oneshot(
+                Request::builder()
+                    .method(Method::OPTIONS)
+                    .uri("/resource")
+                    .header(ORIGIN, "https://app.example.com")
+                    .header(ACCESS_CONTROL_REQUEST_METHOD, Method::POST.as_str())
+                    .header(ACCESS_CONTROL_REQUEST_HEADERS, CONTENT_TYPE.as_str())
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response.headers().get(ACCESS_CONTROL_ALLOW_ORIGIN),
+            Some(&http::HeaderValue::from_static("*"))
+        );
+        assert_eq!(
+            response.headers().get(ACCESS_CONTROL_ALLOW_METHODS),
+            Some(&http::HeaderValue::from_static("GET,POST,OPTIONS"))
+        );
+        assert_eq!(
+            response.headers().get(ACCESS_CONTROL_ALLOW_HEADERS),
+            Some(&http::HeaderValue::from_static("content-type"))
+        );
+        assert!(
+            !response
+                .headers()
+                .contains_key(ACCESS_CONTROL_ALLOW_CREDENTIALS)
+        );
+    }
+}

--- a/services/common/src/axum/server_layers/cors.rs
+++ b/services/common/src/axum/server_layers/cors.rs
@@ -4,7 +4,7 @@ use tower_http::cors::{Any, CorsLayer};
 /// Builds the CORS policy shared by the public protocol HTTP services.
 ///
 /// The gateway and indexer are public APIs, so browser requests from every
-/// origin are allowed. Credentials remain disabled.
+/// origin are allowed.
 pub fn cors_layer() -> CorsLayer {
     CorsLayer::new()
         .allow_origin(Any)

--- a/services/common/src/axum/server_layers/mod.rs
+++ b/services/common/src/axum/server_layers/mod.rs
@@ -1,8 +1,10 @@
+mod cors;
 mod deprecation;
 mod request_metrics;
 mod timeout;
 mod trace;
 
+pub use cors::cors_layer;
 pub use deprecation::{
     Deprecation, DeprecationLayer, DeprecationService, METRICS_DEPRECATED_ENDPOINT_REQUESTS,
     V1RecoveryAgentMethodsDeprecation, V1RecoveryAgentMethodsDeprecationLayer,

--- a/services/common/src/lib.rs
+++ b/services/common/src/lib.rs
@@ -16,7 +16,7 @@ pub use self::{
     axum::server_layers::{
         Deprecation, DeprecationLayer, DeprecationService, METRICS_DEPRECATED_ENDPOINT_REQUESTS,
         METRICS_HTTP_LATENCY_MS, V1RecoveryAgentMethodsDeprecation,
-        V1RecoveryAgentMethodsDeprecationLayer, describe_deprecated_endpoint_metrics,
+        V1RecoveryAgentMethodsDeprecationLayer, cors_layer, describe_deprecated_endpoint_metrics,
         describe_http_request_metrics, request_latency_middleware, timeout_layer, trace_layer,
     },
 };

--- a/services/gateway/src/routes.rs
+++ b/services/gateway/src/routes.rs
@@ -211,7 +211,8 @@ pub(crate) async fn build_app(
             request_timeout_secs,
             GatewayErrorResponse::request_timeout(request_timeout_secs),
         ))
-        .layer(world_id_services_common::trace_layer()))
+        .layer(world_id_services_common::trace_layer())
+        .layer(world_id_services_common::cors_layer()))
 }
 
 #[utoipa::path(

--- a/services/indexer/src/routes.rs
+++ b/services/indexer/src/routes.rs
@@ -86,4 +86,5 @@ pub(crate) fn handler(state: AppState, request_timeout_secs: u64) -> Router {
             IndexerErrorResponse::request_timeout(request_timeout_secs),
         ))
         .layer(world_id_services_common::trace_layer())
+        .layer(world_id_services_common::cors_layer())
 }


### PR DESCRIPTION
## Summary

- add one shared CORS layer for protocol HTTP services
- apply it outermost to every gateway and indexer route, including preflight handling
- intentionally allow every origin with `Access-Control-Allow-Origin: *` because these are public APIs
- allow only `GET`, `POST`, and `OPTIONS`, and allow `Content-Type` for browser JSON requests
- keep credentials disabled; responses do not emit `Access-Control-Allow-Credentials`

## Policy and deployment

This intentionally uses a code-defined public-API policy rather than a deployment allowlist. No deployment configuration is required. Existing deployment repositories identify the public gateway/indexer hosts but do not define product-owned browser origins; the explicit decision for this change is to support all origins.

## Validation

- `cargo test -p world-id-services-common --lib axum::server_layers::cors::tests`
- `cargo check -p world-id-gateway -p world-id-indexer`
- `cargo clippy -p world-id-services-common -p world-id-gateway -p world-id-indexer --lib -- -D warnings`
- `cargo +nightly fmt --all -- --check`
- `git diff --check`

A broader `cargo test -p world-id-services-common` run passed all 22 unit tests (including CORS) and the deprecation integration test. Its 8 provider integration tests could not bind local sockets in the managed sandbox (`Operation not permitted`), so those unrelated tests were not validated here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Public CORS on protocol APIs is intentional but broad (`*` origins); misconfiguration could ease browser-based abuse of already-public endpoints, though credentials remain off.
> 
> **Overview**
> Adds a shared **`cors_layer()`** in `world-id-services-common` so browser clients can call the public **gateway** and **indexer** APIs cross-origin.
> 
> The policy allows **any origin** (`Access-Control-Allow-Origin: *`), **GET/POST/OPTIONS**, and **`Content-Type`**, with **credentials disabled** (no `Access-Control-Allow-Credentials`). Gateway and indexer routers apply this layer **outermost** on the stack so preflight and simple CORS requests are handled for all routes.
> 
> Workspace deps add **`tower-http`’s `cors` feature** and **`test-case`**; unit tests assert origin reflection, preflight headers, and absence of credential headers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 394818cb3bc40ed99f54f8d72edd2b754c7a5f40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->