### PR TITLE
fix(contracts): add controlled RP registration and recovery

### DIFF
--- a/contracts/src/core/RpRegistryV2.sol
+++ b/contracts/src/core/RpRegistryV2.sol
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import {RpRegistry} from "./RpRegistry.sol";
+import {IRpRegistry} from "./interfaces/IRpRegistry.sol";
+import {IRpRegistryV2} from "./interfaces/IRpRegistryV2.sol";
+
+/**
+ * @title RpRegistryV2 (World ID)
+ * @author World Contributors
+ * @notice Adds registrar authorization and owner-governed recovery to the RP registry.
+ * @dev V1 allowed any account to permanently claim any uninitialized RP identifier. V2 restricts
+ *      initial registration to owner-approved registrars and adds a recovery path for incorrect
+ *      first registrations while preserving the existing proxy storage layout.
+ * @custom:repo https://github.com/world-id/world-id-protocol
+ */
+contract RpRegistryV2 is IRpRegistryV2, RpRegistry {
+    ////////////////////////////////////////////////////////////
+    //                        Members                         //
+    ////////////////////////////////////////////////////////////
+
+    /// @dev Accounts authorized by the owner to register new RPs.
+    mapping(address => bool) internal _authorizedRegistrars;
+
+    ////////////////////////////////////////////////////////////
+    //                        Modifiers                       //
+    ////////////////////////////////////////////////////////////
+
+    /// @dev Restricts initial RP registration to owner-approved accounts.
+    modifier onlyRegistrar() {
+        if (!_authorizedRegistrars[msg.sender]) revert UnauthorizedRegistrar(msg.sender);
+        _;
+    }
+
+    ////////////////////////////////////////////////////////////
+    //                    PUBLIC FUNCTIONS                    //
+    ////////////////////////////////////////////////////////////
+
+    /// @inheritdoc IRpRegistryV2
+    function initializeV2(address initialRegistrar) external virtual reinitializer(2) onlyOwner {
+        _setRegistrar(initialRegistrar, true);
+    }
+
+    /// @inheritdoc IRpRegistry
+    function register(uint64 rpId, address manager, address signer, string calldata unverifiedWellKnownDomain)
+        external
+        virtual
+        override(IRpRegistry, RpRegistry)
+        onlyProxy
+        onlyInitialized
+        onlyRegistrar
+    {
+        _register(rpId, manager, signer, unverifiedWellKnownDomain);
+    }
+
+    /// @inheritdoc IRpRegistry
+    function registerMany(
+        uint64[] calldata rpIds,
+        address[] calldata managers,
+        address[] calldata signers,
+        string[] calldata unverifiedWellKnownDomains
+    ) external virtual override(IRpRegistry, RpRegistry) onlyProxy onlyInitialized onlyRegistrar {
+        if (
+            rpIds.length != managers.length || rpIds.length != signers.length
+                || rpIds.length != unverifiedWellKnownDomains.length
+        ) {
+            revert MismatchingArrayLengths();
+        }
+
+        for (uint256 i = 0; i < rpIds.length; i++) {
+            _register(rpIds[i], managers[i], signers[i], unverifiedWellKnownDomains[i]);
+        }
+    }
+
+    /// @inheritdoc IRpRegistryV2
+    function isRegistrar(address registrar) external view virtual onlyProxy onlyInitialized returns (bool) {
+        return _authorizedRegistrars[registrar];
+    }
+
+    ////////////////////////////////////////////////////////////
+    //                    OWNER FUNCTIONS                     //
+    ////////////////////////////////////////////////////////////
+
+    /// @inheritdoc IRpRegistryV2
+    function setRegistrar(address registrar, bool authorized) external virtual onlyOwner onlyProxy onlyInitialized {
+        _setRegistrar(registrar, authorized);
+    }
+
+    /// @inheritdoc IRpRegistryV2
+    function recoverRp(uint64 rpId, address manager, address signer, string calldata unverifiedWellKnownDomain)
+        external
+        virtual
+        onlyOwner
+        onlyProxy
+        onlyInitialized
+    {
+        RelyingParty storage rp = _relyingParties[rpId];
+        if (!rp.initialized) revert RpIdDoesNotExist();
+        if (manager == address(0)) revert ManagerCannotBeZeroAddress();
+        if (signer == address(0)) revert SignerCannotBeZeroAddress();
+
+        address previousManager = rp.manager;
+        rp.active = true;
+        rp.manager = manager;
+        rp.signer = signer;
+        rp.unverifiedWellKnownDomain = unverifiedWellKnownDomain;
+
+        // A recovery establishes a new management epoch. Advancing the nonce also prevents a
+        // replacement manager from accidentally replaying an authorization from an earlier epoch.
+        _rpIdToSignatureNonce[rpId]++;
+
+        emit RpRecovered(rpId, previousManager, manager, signer);
+        emit RpUpdated(rpId, rp.oprfKeyId, rp.active, manager, signer, unverifiedWellKnownDomain);
+    }
+
+    ////////////////////////////////////////////////////////////
+    //                   INTERNAL FUNCTIONS                   //
+    ////////////////////////////////////////////////////////////
+
+    /**
+     * @dev Updates registrar authorization after validating the account.
+     */
+    function _setRegistrar(address registrar, bool authorized) internal virtual {
+        if (registrar == address(0)) revert RegistrarCannotBeZeroAddress();
+        _authorizedRegistrars[registrar] = authorized;
+        emit RegistrarAuthorizationUpdated(registrar, authorized);
+    }
+}

--- a/contracts/src/core/interfaces/IRpRegistryV2.sol
+++ b/contracts/src/core/interfaces/IRpRegistryV2.sol
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import {IRpRegistry} from "./IRpRegistry.sol";
+
+/**
+ * @title IRpRegistryV2
+ * @author World Contributors
+ * @notice Interface for the access-controlled and recoverable RP registry.
+ */
+interface IRpRegistryV2 is IRpRegistry {
+    ////////////////////////////////////////////////////////////
+    //                        ERRORS                          //
+    ////////////////////////////////////////////////////////////
+
+    /**
+     * @dev Thrown when an account that is not an authorized registrar attempts to register an RP.
+     * @param caller The unauthorized caller.
+     */
+    error UnauthorizedRegistrar(address caller);
+
+    /**
+     * @dev Thrown when attempting to configure the zero address as a registrar.
+     */
+    error RegistrarCannotBeZeroAddress();
+
+    ////////////////////////////////////////////////////////////
+    //                        EVENTS                          //
+    ////////////////////////////////////////////////////////////
+
+    /**
+     * @dev Emitted when the owner changes an account's registrar authorization.
+     * @param registrar The account whose authorization changed.
+     * @param authorized Whether the account is authorized to register RPs.
+     */
+    event RegistrarAuthorizationUpdated(address indexed registrar, bool authorized);
+
+    /**
+     * @dev Emitted when the owner recovers an RP record from an incorrect manager.
+     * @param rpId The recovered RP identifier.
+     * @param previousManager The manager configured before recovery.
+     * @param newManager The manager configured by the recovery.
+     * @param newSigner The signer configured by the recovery.
+     */
+    event RpRecovered(uint64 indexed rpId, address indexed previousManager, address newManager, address newSigner);
+
+    ////////////////////////////////////////////////////////////
+    //                    PUBLIC FUNCTIONS                    //
+    ////////////////////////////////////////////////////////////
+
+    /**
+     * @notice Initializes V2 registrar authorization during a proxy upgrade.
+     * @param initialRegistrar The first account authorized to register RPs.
+     */
+    function initializeV2(address initialRegistrar) external;
+
+    /**
+     * @notice Returns whether an account may register RPs.
+     * @param registrar The account to inspect.
+     */
+    function isRegistrar(address registrar) external view returns (bool);
+
+    ////////////////////////////////////////////////////////////
+    //                    OWNER FUNCTIONS                     //
+    ////////////////////////////////////////////////////////////
+
+    /**
+     * @notice Grants or revokes an account's ability to register RPs.
+     * @param registrar The account to update.
+     * @param authorized Whether the account should be authorized.
+     */
+    function setRegistrar(address registrar, bool authorized) external;
+
+    /**
+     * @notice Reassigns an existing RP after an incorrect or unauthorized first registration.
+     * @param rpId The RP identifier to recover.
+     * @param manager The replacement manager.
+     * @param signer The replacement proof-request signer.
+     * @param unverifiedWellKnownDomain The replacement well-known domain.
+     */
+    function recoverRp(uint64 rpId, address manager, address signer, string calldata unverifiedWellKnownDomain) external;
+}

--- a/contracts/test/core/RpRegistryV2.t.sol
+++ b/contracts/test/core/RpRegistryV2.t.sol
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import {Test} from "forge-std/Test.sol";
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import {ERC20Mock} from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
+import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import {RpRegistry} from "../../src/core/RpRegistry.sol";
+import {RpRegistryV2} from "../../src/core/RpRegistryV2.sol";
+import {IRpRegistry} from "../../src/core/interfaces/IRpRegistry.sol";
+import {IRpRegistryV2} from "../../src/core/interfaces/IRpRegistryV2.sol";
+
+contract OprfKeyRegistryV2Mock {
+    error AlreadySubmitted();
+
+    mapping(uint160 => bool) public registeredKeys;
+
+    function initKeyGen(uint160 oprfKeyId) external {
+        if (registeredKeys[oprfKeyId]) revert AlreadySubmitted();
+        registeredKeys[oprfKeyId] = true;
+    }
+}
+
+contract RpRegistryV2Test is Test {
+    uint64 private constant LEGACY_RP_ID = 42;
+
+    RpRegistryV2 private registry;
+    ERC20Mock private feeToken;
+    OprfKeyRegistryV2Mock private oprfKeyRegistry;
+
+    address private registrar;
+    address private secondRegistrar;
+    address private attacker;
+    address private manager;
+    address private signer;
+
+    function setUp() public {
+        registrar = makeAddr("registrar");
+        secondRegistrar = makeAddr("secondRegistrar");
+        attacker = makeAddr("attacker");
+        manager = makeAddr("manager");
+        signer = makeAddr("signer");
+
+        feeToken = new ERC20Mock();
+        oprfKeyRegistry = new OprfKeyRegistryV2Mock();
+
+        RpRegistry implementationV1 = new RpRegistry();
+        bytes memory initData = abi.encodeWithSelector(
+            RpRegistry.initialize.selector, address(0), address(feeToken), 0, address(oprfKeyRegistry)
+        );
+        ERC1967Proxy proxy = new ERC1967Proxy(address(implementationV1), initData);
+        RpRegistry registryV1 = RpRegistry(address(proxy));
+
+        // Preserve a V1 registration across the upgrade.
+        vm.prank(attacker);
+        registryV1.register(LEGACY_RP_ID, manager, signer, "legacy.example.org");
+
+        RpRegistryV2 implementationV2 = new RpRegistryV2();
+        registryV1.upgradeToAndCall(address(implementationV2), abi.encodeCall(RpRegistryV2.initializeV2, (registrar)));
+        registry = RpRegistryV2(address(proxy));
+    }
+
+    function testUpgradePreservesExistingRegistration() public view {
+        IRpRegistry.RelyingParty memory rp = registry.getRpUnchecked(LEGACY_RP_ID);
+
+        assertTrue(rp.initialized);
+        assertTrue(rp.active);
+        assertEq(rp.manager, manager);
+        assertEq(rp.signer, signer);
+        assertEq(rp.unverifiedWellKnownDomain, "legacy.example.org");
+        assertTrue(registry.isRegistrar(registrar));
+    }
+
+    function testUnauthorizedAccountCannotRegister() public {
+        vm.prank(attacker);
+        vm.expectRevert(abi.encodeWithSelector(IRpRegistryV2.UnauthorizedRegistrar.selector, attacker));
+        registry.register(1, manager, signer, "example.org");
+    }
+
+    function testAuthorizedRegistrarCanRegister() public {
+        vm.prank(registrar);
+        registry.register(1, manager, signer, "example.org");
+
+        IRpRegistry.RelyingParty memory rp = registry.getRpUnchecked(1);
+        assertEq(rp.manager, manager);
+        assertEq(rp.signer, signer);
+    }
+
+    function testUnauthorizedAccountCannotRegisterMany() public {
+        uint64[] memory rpIds = new uint64[](1);
+        rpIds[0] = 1;
+        address[] memory managers = new address[](1);
+        managers[0] = manager;
+        address[] memory signers = new address[](1);
+        signers[0] = signer;
+        string[] memory domains = new string[](1);
+        domains[0] = "example.org";
+
+        vm.prank(attacker);
+        vm.expectRevert(abi.encodeWithSelector(IRpRegistryV2.UnauthorizedRegistrar.selector, attacker));
+        registry.registerMany(rpIds, managers, signers, domains);
+    }
+
+    function testOwnerCanAuthorizeAndRevokeRegistrar() public {
+        vm.expectEmit(true, false, false, true);
+        emit IRpRegistryV2.RegistrarAuthorizationUpdated(secondRegistrar, true);
+        registry.setRegistrar(secondRegistrar, true);
+        assertTrue(registry.isRegistrar(secondRegistrar));
+
+        registry.setRegistrar(secondRegistrar, false);
+        assertFalse(registry.isRegistrar(secondRegistrar));
+
+        vm.prank(secondRegistrar);
+        vm.expectRevert(abi.encodeWithSelector(IRpRegistryV2.UnauthorizedRegistrar.selector, secondRegistrar));
+        registry.register(1, manager, signer, "example.org");
+    }
+
+    function testNonOwnerCannotAuthorizeRegistrar() public {
+        vm.prank(attacker);
+        vm.expectRevert(abi.encodeWithSelector(OwnableUpgradeable.OwnableUnauthorizedAccount.selector, attacker));
+        registry.setRegistrar(secondRegistrar, true);
+    }
+
+    function testCannotAuthorizeZeroAddressRegistrar() public {
+        vm.expectRevert(IRpRegistryV2.RegistrarCannotBeZeroAddress.selector);
+        registry.setRegistrar(address(0), true);
+    }
+
+    function testOwnerCanRecoverRp() public {
+        address recoveredManager = makeAddr("recoveredManager");
+        address recoveredSigner = makeAddr("recoveredSigner");
+
+        vm.expectEmit(true, true, false, true);
+        emit IRpRegistryV2.RpRecovered(LEGACY_RP_ID, manager, recoveredManager, recoveredSigner);
+        registry.recoverRp(LEGACY_RP_ID, recoveredManager, recoveredSigner, "recovered.example.org");
+
+        IRpRegistry.RelyingParty memory rp = registry.getRpUnchecked(LEGACY_RP_ID);
+        assertTrue(rp.active);
+        assertEq(rp.manager, recoveredManager);
+        assertEq(rp.signer, recoveredSigner);
+        assertEq(rp.unverifiedWellKnownDomain, "recovered.example.org");
+        assertEq(registry.nonceOf(LEGACY_RP_ID), 1);
+    }
+
+    function testNonOwnerCannotRecoverRp() public {
+        vm.prank(attacker);
+        vm.expectRevert(abi.encodeWithSelector(OwnableUpgradeable.OwnableUnauthorizedAccount.selector, attacker));
+        registry.recoverRp(LEGACY_RP_ID, attacker, attacker, "attacker.example.org");
+    }
+
+    function testCannotRecoverMissingRp() public {
+        vm.expectRevert(IRpRegistry.RpIdDoesNotExist.selector);
+        registry.recoverRp(999, manager, signer, "example.org");
+    }
+
+    function testCannotRecoverWithZeroAddressManager() public {
+        vm.expectRevert(IRpRegistry.ManagerCannotBeZeroAddress.selector);
+        registry.recoverRp(LEGACY_RP_ID, address(0), signer, "example.org");
+    }
+
+    function testCannotRecoverWithZeroAddressSigner() public {
+        vm.expectRevert(IRpRegistry.SignerCannotBeZeroAddress.selector);
+        registry.recoverRp(LEGACY_RP_ID, manager, address(0), "example.org");
+    }
+}


### PR DESCRIPTION
## Summary

- add a V2 RP registry implementation with owner-managed registrar authorization
- restrict registration entry points to approved registrars
- add owner-controlled recovery for existing registrations
- preserve existing registrations across the upgrade

## Related work

- https://github.com/worldcoin/developer-portal/pull/2221

<!-- CURSOR_SUMMARY -->
---

> **Overview**
> Introduces an upgradeable **RpRegistryV2** that closes the V1 gap where any account could claim an uninitialized RP ID, while keeping proxy storage layout compatible with existing deployments.
> 
> **Registration** is now gated by an owner-managed registrar allowlist: `initializeV2` seeds the first registrar on upgrade, `setRegistrar` / `isRegistrar` manage access, and both `register` and `registerMany` require `onlyRegistrar`. **Recovery** adds owner-only `recoverRp` to reassign manager, signer, and domain on an existing RP (e.g. after a bad V1 claim), bumps the per-RP signature nonce to invalidate prior-epoch authorizations, and emits `RpRecovered` plus the usual `RpUpdated`.
> 
> New **IRpRegistryV2** documents the errors, events, and API. **Forge tests** cover V1→V2 proxy upgrade with a legacy registration preserved, registrar auth/revocation, blocked unauthorized registration, and recovery access and validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa23f9420a3bc76f41913d61a3568f81a8489e62. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->