### PR TITLE
feat: tolerate unknown JSON fields in proof request/response envelopes

### DIFF
--- a/crates/primitives/src/request/mod.rs
+++ b/crates/primitives/src/request/mod.rs
@@ -85,8 +85,13 @@ impl ProofType {
 }
 
 /// A proof request from a Relying Party (RP) for an Authenticator.
+///
+/// Unknown JSON fields are ignored during deserialization so that older
+/// Authenticators keep accepting requests from RPs speaking a newer minor
+/// revision of the protocol. The RP signature only covers the enumerated
+/// fields (see [`ProofRequest::digest_hash`]), so tolerated fields are
+/// never part of any signed or hashed message.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
 pub struct ProofRequest {
     /// Unique identifier for this request.
     pub id: String,
@@ -135,8 +140,10 @@ pub struct ProofRequest {
 }
 
 /// Per-credential request payload.
+///
+/// Unknown JSON fields are ignored during deserialization; see
+/// [`ProofRequest`] for the forward-compatibility rationale.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
 pub struct RequestItem {
     /// An RP-defined identifier for this request item used to match against constraints and responses.
     ///
@@ -229,8 +236,12 @@ impl RequestItem {
 }
 
 /// Overall response from the Authenticator to the RP
+///
+/// Unknown JSON fields are ignored during deserialization so that older
+/// RPs keep accepting responses from Authenticators speaking a newer minor
+/// revision of the protocol (e.g. one that discloses additional
+/// credential data on response items).
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
 pub struct ProofResponse {
     /// The response id references request id
     pub id: String,
@@ -271,8 +282,10 @@ pub struct ProofResponse {
 ///   The contract's `verifySession()` function expects `uint256[2] sessionNullifier`.
 ///
 /// Exactly one of `nullifier` or `session_nullifier` should be present.
+///
+/// Unknown JSON fields are ignored during deserialization; see
+/// [`ProofResponse`] for the forward-compatibility rationale.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
 pub struct ResponseItem {
     /// An RP-defined identifier for this request item used to match against constraints and responses.
     ///
@@ -1844,6 +1857,63 @@ mod tests {
         let req = ProofRequest::from_json(without_signal).expect("parse without signal");
         assert!(req.requests[0].signal.is_none());
         assert_eq!(req.requests[0].signal_hash(), FieldElement::ZERO);
+    }
+
+    #[test]
+    fn request_json_tolerates_unknown_fields() {
+        // A request from an RP speaking a newer minor protocol revision must
+        // still parse: unknown fields are ignored at every nesting level.
+        let json = r#"{
+  "id": "req_abc123",
+  "version": 1,
+  "created_at": 1725381192,
+  "expires_at": 1725381492,
+  "rp_id": "rp_0000000000000001",
+  "oprf_key_id": "0x1",
+  "session_id": null,
+  "action": "0x000000000000000000000000000000000000000000000000000000000000002a",
+  "signature": "0xa1fd06f0d8ceb541f6096fe2e865063eac1ff085c9d2bac2eedcc9ed03804bfc18d956b38c5ac3a8f7e71fde43deff3bda254d369c699f3c7a3f8e6b8477a5f51c",
+  "nonce": "0x0000000000000000000000000000000000000000000000000000000000000001",
+  "from_the_future": true,
+  "proof_requests": [
+    {
+      "identifier": "orb",
+      "issuer_schema_id": 1,
+      "also_from_the_future": {"nested": [1, 2, 3]}
+    }
+  ]
+}"#;
+
+        let req = ProofRequest::from_json(json).expect("unknown fields must be tolerated");
+        assert_eq!(req.id, "req_abc123");
+        assert_eq!(req.requests.len(), 1);
+        assert_eq!(req.requests[0].identifier, "orb");
+    }
+
+    #[test]
+    fn response_json_tolerates_unknown_fields() {
+        // A response from an Authenticator speaking a newer minor protocol
+        // revision must still parse: unknown fields are ignored at every
+        // nesting level.
+        let json = r#"{
+  "id": "req_18c0f7f03e7d",
+  "version": 1,
+  "from_the_future": "yes",
+  "responses": [
+    {
+      "identifier": "orb",
+      "issuer_schema_id": 100,
+      "proof": "00000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000000",
+      "nullifier": "nil_00000000000000000000000000000000000000000000000000000000000003e9",
+      "expires_at_min": 1725381192,
+      "claims": ["0x01", "0x02"]
+    }
+  ]
+}"#;
+
+        let resp = ProofResponse::from_json(json).expect("unknown fields must be tolerated");
+        assert_eq!(resp.successful_credentials(), vec![100]);
+        assert!(resp.responses[0].is_uniqueness());
     }
 
     #[test]


### PR DESCRIPTION
### Problem

`ProofRequest`, `RequestItem`, `ProofResponse`, and `ResponseItem` all carry `#[serde(deny_unknown_fields)]`, which makes every minor protocol addition a breaking change for deployed counterparties. An RP that adds a field to a request breaks every older Authenticator, and an Authenticator that adds a field to a response breaks every older RP.

I want Authenticators to optionally disclose credential `claims` on response items so relying parties can consume them, bound into the mobile app-integrity signature. With strict parsing, emitting any new response field breaks all existing verifiers with a `serde` error, so the field can never be rolled out incrementally.

As far as I can tell the strictness was not a documented protocol decision — the attribute has been on these structs unchanged and uncommented since they were introduced in #141, with no mention in the PR, review threads, or the specs. If it *was* deliberate, I'd love to hear the reasoning; this PR is as much a design question as a change.

### What deliberately stays strict

`ConstraintExpr` / `ConstraintNode` keep `deny_unknown_fields`: they are `#[serde(untagged)]` enums where the attribute is load-bearing for variant disambiguation — without it, `{"all": [...], "any": [...]}` would silently match `All` and drop the `any` branch, changing constraint semantics. That is a correctness guard, not forward-compat friction.

### Solution

* Remove `deny_unknown_fields` from the four envelope structs and document the forward-compatibility policy on each.
* Add tests pinning the tolerance at every nesting level for both requests and responses.

### Testing

* `cargo test -p world-id-primitives --lib` — 167 passed, including the two new tolerance tests.
* `cargo clippy -p world-id-primitives` — clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This is a wire-format compatibility change for core proof envelopes; behavior is safer for signatures but loosens parsing, so downstream code must not assume unknown fields imply rejection.
> 
> **Overview**
> **Relaxes JSON parsing** on `ProofRequest`, `RequestItem`, `ProofResponse`, and `ResponseItem` by dropping `#[serde(deny_unknown_fields)]`, so minor protocol additions no longer break older Authenticators (extra request fields) or older RPs (extra response fields such as future `claims`).
> 
> Doc comments on each struct state that unknown keys are ignored on deserialize and that RP signing / `digest_hash` still cover only enumerated fields, not extra JSON.
> 
> **Tests** `request_json_tolerates_unknown_fields` and `response_json_tolerates_unknown_fields` assert parsing succeeds with unknown keys at the root and inside nested `proof_requests` / `responses` items. `ConstraintExpr` / `ConstraintNode` are unchanged and remain strict.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 302f2c1c3e8673f5491eef3c15ffa53bfae81816. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->