### PR TITLE
test: provision integration dependencies with testcontainers

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -257,11 +257,6 @@ jobs:
           name: contract-build-output
           path: contracts/out
 
-      - name: Run services
-        run: |
-          docker compose up -d
-          sleep 5
-
       - name: Install cargo-nextest
         uses: taiki-e/install-action@e24b8b7a939c6a537188f34a4163cb153dd85cf6 # v2.69.1 https://github.com/taiki-e/install-action/releases/tag/v2.69.1
         with:
@@ -274,10 +269,6 @@ jobs:
         run: |
           cargo nextest run --locked --profile ci --all-features --workspace
           cargo test --locked --doc --all-features --workspace
-
-      - name: Clean up services
-        run: |
-          docker compose down
 
   setup-test:
     name: Local Setup Test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13334,6 +13334,7 @@ dependencies = [
  "taceo-nodes-common",
  "taceo-oprf",
  "testcontainers",
+ "testcontainers-modules",
  "tokio",
  "tokio-util",
  "tracing",

--- a/crates/core/tests/authenticator_registration.rs
+++ b/crates/core/tests/authenticator_registration.rs
@@ -18,7 +18,7 @@ use world_id_gateway::{
     spawn_gateway_for_tests,
 };
 use world_id_primitives::{Config, ServiceEndpoint};
-use world_id_test_utils::anvil::TestAnvil;
+use world_id_test_utils::{anvil::TestAnvil, redis_testcontainer};
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_authenticator_registration() {
@@ -26,6 +26,9 @@ async fn test_authenticator_registration() {
         .install_default()
         .expect("can install");
     let anvil = TestAnvil::spawn().expect("failed to spawn anvil");
+    let (_redis, redis_url) = redis_testcontainer()
+        .await
+        .expect("failed to start Redis testcontainer");
 
     let deployer = anvil.signer(0).unwrap();
 
@@ -47,8 +50,7 @@ async fn test_authenticator_registration() {
         listen_addr: (std::net::Ipv4Addr::LOCALHOST, 0).into(),
         max_create_batch_size: 10,
         max_ops_batch_size: 10,
-        redis_url: std::env::var("REDIS_URL")
-            .unwrap_or_else(|_| "redis://localhost:6379".to_string()),
+        redis_url,
         request_timeout_secs: 10,
         rate_limit_max_requests: None,
         rate_limit_window_secs: None,

--- a/crates/core/tests/e2e_authenticator_insert_update_remove.rs
+++ b/crates/core/tests/e2e_authenticator_insert_update_remove.rs
@@ -23,6 +23,7 @@ use world_id_primitives::{Config, ServiceEndpoint, TREE_DEPTH, merkle::AccountIn
 use world_id_test_utils::{
     anvil::{TestAnvil, WorldIDRegistry},
     fixtures::{MerkleFixture, single_leaf_merkle_fixture},
+    redis_testcontainer,
     stubs::MutableIndexerStub,
 };
 
@@ -108,6 +109,9 @@ async fn e2e_authenticator_insert_update_remove() {
     let anvil = TestAnvil::spawn_with_multicall3()
         .await
         .expect("failed to spawn anvil with multicall3");
+    let (_redis, redis_url) = redis_testcontainer()
+        .await
+        .expect("failed to start Redis testcontainer");
     let deployer = anvil.signer(0).unwrap();
     // This test covers the legacy updateAuthenticator route, which V2 removes.
     let registry_address = anvil
@@ -127,8 +131,7 @@ async fn e2e_authenticator_insert_update_remove() {
         listen_addr: (std::net::Ipv4Addr::LOCALHOST, 0).into(),
         max_create_batch_size: 10,
         max_ops_batch_size: 10,
-        redis_url: std::env::var("REDIS_URL")
-            .unwrap_or_else(|_| "redis://localhost:6379".to_string()),
+        redis_url,
         request_timeout_secs: 10,
         rate_limit_max_requests: None,
         rate_limit_window_secs: None,

--- a/crates/core/tests/generate_proof.rs
+++ b/crates/core/tests/generate_proof.rs
@@ -40,6 +40,7 @@ use world_id_test_utils::{
         MerkleFixture, RegistryTestContext, build_base_credential, generate_rp_fixture,
         single_leaf_merkle_fixture,
     },
+    redis_testcontainer,
     stubs::spawn_indexer_stub,
 };
 
@@ -80,6 +81,7 @@ async fn e2e_authenticator_generate_proof() -> Result<()> {
     let deployer = anvil
         .signer(0)
         .wrap_err("failed to fetch deployer signer for anvil")?;
+    let (_redis, redis_url) = redis_testcontainer().await?;
 
     // Spawn the gateway wired to this Anvil instance.
     let signer_args = SignerArgs::from_wallet(hex::encode(deployer.to_bytes()));
@@ -94,8 +96,7 @@ async fn e2e_authenticator_generate_proof() -> Result<()> {
         listen_addr: (std::net::Ipv4Addr::LOCALHOST, 0).into(),
         max_create_batch_size: 10,
         max_ops_batch_size: 10,
-        redis_url: std::env::var("REDIS_URL")
-            .unwrap_or_else(|_| "redis://localhost:6379".to_string()),
+        redis_url,
         request_timeout_secs: 10,
         rate_limit_max_requests: None,
         rate_limit_window_secs: None,

--- a/crates/test-utils/Cargo.toml
+++ b/crates/test-utils/Cargo.toml
@@ -36,5 +36,6 @@ reqwest = { workspace = true }
 secrecy = { workspace = true }
 semver = { workspace = true }
 testcontainers = { workspace = true }
+testcontainers-modules = { workspace = true }
 tracing = { workspace = true }
 world-id-primitives = { workspace = true }

--- a/crates/test-utils/src/lib.rs
+++ b/crates/test-utils/src/lib.rs
@@ -6,3 +6,18 @@ pub mod merkle;
 pub mod stubs;
 
 pub use taceo_nodes_common::test_utils::shared_postgres_testcontainer;
+
+use testcontainers_modules::{
+    redis::{REDIS_PORT, Redis},
+    testcontainers::{ContainerAsync, ImageExt as _, runners::AsyncRunner as _},
+};
+
+/// Starts an isolated Redis instance for a test and returns its connection URL.
+///
+/// Keep the returned container alive for as long as the test uses the URL.
+pub async fn redis_testcontainer() -> eyre::Result<(ContainerAsync<Redis>, String)> {
+    let container = Redis::default().with_tag("latest").start().await?;
+    let host = container.get_host().await?;
+    let port = container.get_host_port_ipv4(REDIS_PORT).await?;
+    Ok((container, format!("redis://{host}:{port}")))
+}

--- a/services/gateway/tests/common.rs
+++ b/services/gateway/tests/common.rs
@@ -1,10 +1,7 @@
 use alloy::primitives::Address;
 use reqwest::{Client, StatusCode};
 use std::time::Duration;
-use testcontainers_modules::{
-    redis::{REDIS_PORT, Redis},
-    testcontainers::{ContainerAsync, ImageExt as _, runners::AsyncRunner as _},
-};
+use testcontainers_modules::{redis::Redis, testcontainers::ContainerAsync};
 use world_id_gateway::{
     BatchPolicyConfig, GatewayConfig, GatewayHandle, RegistryVersion, SignerArgs, defaults,
     spawn_gateway_for_tests,
@@ -167,22 +164,9 @@ async fn spawn_test_gateway_for_registry(
 /// test that needs the Redis instance.
 #[allow(dead_code)]
 pub(crate) async fn start_redis() -> (String, ContainerAsync<Redis>) {
-    // Use redis:latest so CI (which already pulls this tag via docker-compose)
-    // can start the container from the local image cache with no network pull.
-    let container = Redis::default()
-        .with_tag("latest")
-        .start()
+    let (container, url) = world_id_test_utils::redis_testcontainer()
         .await
         .expect("failed to start Redis container");
-    let host = container
-        .get_host()
-        .await
-        .expect("failed to get Redis host");
-    let port = container
-        .get_host_port_ipv4(REDIS_PORT)
-        .await
-        .expect("failed to get Redis port");
-    let url = format!("redis://{host}:{port}");
     (url, container)
 }
 

--- a/services/gateway/tests/test_orphan_sweeper.rs
+++ b/services/gateway/tests/test_orphan_sweeper.rs
@@ -9,6 +9,7 @@ use alloy::{
 };
 use redis::{AsyncCommands, aio::ConnectionManager};
 use reqwest::{Client, StatusCode};
+use testcontainers_modules::{redis::Redis, testcontainers::ContainerAsync};
 use world_id_gateway::{
     BatchPolicyConfig, GatewayConfig, OrphanSweeperConfig, RegistryVersion, RequestRecord,
     RequestTracker, defaults, now_unix_secs, request_tracker::BacklogScope,
@@ -28,92 +29,12 @@ async fn setup_redis(redis_url: &str) -> ConnectionManager {
     client.get_connection_manager().await.unwrap()
 }
 
-async fn flush_redis_preserving_lock(redis: &mut ConnectionManager) {
-    let script = redis::Script::new(
-        r#"
-        local keys = redis.call('KEYS', '*')
-        for _, key in ipairs(keys) do
-            if key ~= KEYS[1] then
-                redis.call('DEL', key)
-            end
-        end
-        return 1
-        "#,
-    );
-    let _: i64 = script
-        .key(TEST_DB_LOCK_KEY)
-        .invoke_async(redis)
+async fn setup_isolated_redis_for_test() -> (String, ContainerAsync<Redis>, ConnectionManager) {
+    let (container, url) = world_id_test_utils::redis_testcontainer()
         .await
-        .unwrap();
-}
-
-fn redis_url() -> String {
-    std::env::var("REDIS_URL").unwrap_or_else(|_| "redis://localhost:6379".to_string())
-}
-
-fn redis_url_with_db(base: &str, db: u8) -> String {
-    let mut url = reqwest::Url::parse(base).expect("invalid REDIS_URL");
-    url.set_path(&format!("/{db}"));
-    url.to_string()
-}
-
-const TEST_DB_LOCK_KEY: &str = "gateway:test:orphan_sweeper:db_lock";
-const TEST_DB_LOCK_TTL_SECS: usize = 120;
-
-async fn acquire_isolated_redis_url(base: &str) -> (String, String) {
-    let token = uuid::Uuid::new_v4().to_string();
-    for db in 1..=15 {
-        let candidate = redis_url_with_db(base, db);
-        let Ok(client) = redis::Client::open(candidate.as_str()) else {
-            continue;
-        };
-        let Ok(mut conn) = client.get_connection_manager().await else {
-            continue;
-        };
-
-        let acquired: Option<String> = redis::cmd("SET")
-            .arg(TEST_DB_LOCK_KEY)
-            .arg(&token)
-            .arg("NX")
-            .arg("EX")
-            .arg(TEST_DB_LOCK_TTL_SECS)
-            .query_async(&mut conn)
-            .await
-            .unwrap_or(None);
-        if acquired.is_some() {
-            return (candidate, token);
-        }
-    }
-    panic!("no isolated Redis DB available for test");
-}
-
-async fn release_isolated_redis_lock(redis_url: &str, token: &str) {
-    let client = redis::Client::open(redis_url).expect("invalid redis url for release");
-    let mut conn = client
-        .get_connection_manager()
-        .await
-        .expect("failed to connect redis for release");
-    let script = redis::Script::new(
-        r#"
-        if redis.call('GET', KEYS[1]) == ARGV[1] then
-            return redis.call('DEL', KEYS[1])
-        end
-        return 0
-        "#,
-    );
-    let _: i64 = script
-        .key(TEST_DB_LOCK_KEY)
-        .arg(token)
-        .invoke_async(&mut conn)
-        .await
-        .unwrap_or(0);
-}
-
-async fn setup_isolated_redis_for_test() -> (String, String, ConnectionManager) {
-    let (url, lock_token) = acquire_isolated_redis_url(&redis_url()).await;
-    let mut redis = setup_redis(&url).await;
-    flush_redis_preserving_lock(&mut redis).await;
-    (url, lock_token, redis)
+        .expect("failed to start Redis testcontainer");
+    let redis = setup_redis(&url).await;
+    (url, container, redis)
 }
 
 fn assert_age_in_range(actual: u64, expected_min: u64) {
@@ -173,7 +94,7 @@ async fn is_in_pending_set(redis: &mut ConnectionManager, id: &str) -> bool {
 /// transitioning to `Finalized` atomically removes it.
 #[tokio::test]
 async fn pending_set_lifecycle_finalized() {
-    let (url, lock_token, _redis) = setup_isolated_redis_for_test().await;
+    let (url, _redis_container, _redis) = setup_isolated_redis_for_test().await;
     let tracker =
         RequestTracker::new(url.clone(), None, defaults::STALE_SUBMITTED_THRESHOLD_SECS).await;
     let id = "test-pending-lifecycle-fin".to_string();
@@ -203,14 +124,12 @@ async fn pending_set_lifecycle_finalized() {
         !pending.contains(&id),
         "finalized request should be removed from pending set"
     );
-
-    release_isolated_redis_lock(&url, &lock_token).await;
 }
 
 /// Verifies that failing a request also removes it from the pending set.
 #[tokio::test]
 async fn pending_set_lifecycle_failed() {
-    let (url, lock_token, mut redis) = setup_isolated_redis_for_test().await;
+    let (url, _redis_container, mut redis) = setup_isolated_redis_for_test().await;
     let tracker =
         RequestTracker::new(url.clone(), None, defaults::STALE_SUBMITTED_THRESHOLD_SECS).await;
     let id = "test-pending-lifecycle-fail".to_string();
@@ -227,14 +146,13 @@ async fn pending_set_lifecycle_failed() {
         .await;
 
     assert!(!is_in_pending_set(&mut redis, &id).await);
-    release_isolated_redis_lock(&url, &lock_token).await;
 }
 
 /// Verifies that `updated_at` is set on creation and bumped on status
 /// changes. This timestamp drives staleness calculations in the sweeper.
 #[tokio::test]
 async fn updated_at_written_and_updated() {
-    let (url, lock_token, mut redis) = setup_isolated_redis_for_test().await;
+    let (url, _redis_container, mut redis) = setup_isolated_redis_for_test().await;
     let tracker =
         RequestTracker::new(url.clone(), None, defaults::STALE_SUBMITTED_THRESHOLD_SECS).await;
     let id = "test-updated-at".to_string();
@@ -262,14 +180,13 @@ async fn updated_at_written_and_updated() {
 
     let record = read_record(&mut redis, &id).await.unwrap();
     assert!(record.updated_at > created_at);
-    release_isolated_redis_lock(&url, &lock_token).await;
 }
 
 /// Verifies that `snapshot_batch` (MGET) returns records for existing keys
 /// and `None` for missing keys, preserving input order.
 #[tokio::test]
 async fn snapshot_batch_returns_records() {
-    let (url, lock_token, _redis) = setup_isolated_redis_for_test().await;
+    let (url, _redis_container, _redis) = setup_isolated_redis_for_test().await;
     let tracker =
         RequestTracker::new(url.clone(), None, defaults::STALE_SUBMITTED_THRESHOLD_SECS).await;
 
@@ -303,15 +220,13 @@ async fn snapshot_batch_returns_records() {
     assert!(results[0].1.is_some());
     assert!(results[1].1.is_some());
     assert!(results[2].1.is_none());
-
-    release_isolated_redis_lock(&url, &lock_token).await;
 }
 
 /// Verifies queued backlog stats only consider `Queued` requests and use
 /// `updated_at` age for urgency calculations.
 #[tokio::test]
 async fn queued_backlog_stats_from_updated_at() {
-    let (url, lock_token, mut redis) = setup_isolated_redis_for_test().await;
+    let (url, _redis_container, mut redis) = setup_isolated_redis_for_test().await;
 
     let tracker =
         RequestTracker::new(url.clone(), None, defaults::STALE_SUBMITTED_THRESHOLD_SECS).await;
@@ -353,14 +268,12 @@ async fn queued_backlog_stats_from_updated_at() {
     let stats = tracker.queued_backlog_stats().await.unwrap();
     assert_eq!(stats.queued_count, 3);
     assert_age_in_range(stats.oldest_age_secs, 30);
-
-    release_isolated_redis_lock(&url, &lock_token).await;
 }
 
 /// Verifies backlog urgency stats are isolated by batcher scope (`Create` vs `Ops`).
 #[tokio::test]
 async fn queued_backlog_stats_scoped_by_kind() {
-    let (url, lock_token, mut redis) = setup_isolated_redis_for_test().await;
+    let (url, _redis_container, mut redis) = setup_isolated_redis_for_test().await;
 
     let tracker =
         RequestTracker::new(url.clone(), None, defaults::STALE_SUBMITTED_THRESHOLD_SECS).await;
@@ -414,8 +327,6 @@ async fn queued_backlog_stats_scoped_by_kind() {
         .unwrap();
     assert_eq!(all_stats.queued_count, 3);
     assert_age_in_range(all_stats.oldest_age_secs, 40);
-
-    release_isolated_redis_lock(&url, &lock_token).await;
 }
 
 // =========================================================================
@@ -426,7 +337,7 @@ async fn queued_backlog_stats_scoped_by_kind() {
 /// marked as `Failed` with an "orphaned" error and removed from the pending set.
 #[tokio::test]
 async fn sweep_stale_queued_request() {
-    let (url, lock_token, mut redis) = setup_isolated_redis_for_test().await;
+    let (url, _redis_container, mut redis) = setup_isolated_redis_for_test().await;
     let tracker =
         RequestTracker::new(url.clone(), None, defaults::STALE_SUBMITTED_THRESHOLD_SECS).await;
     let five_min_ago = now_unix_secs() - 300;
@@ -456,14 +367,13 @@ async fn sweep_stale_queued_request() {
         other => panic!("expected Failed, got {other:?}"),
     }
     assert!(!is_in_pending_set(&mut redis, "stale-queued").await);
-    release_isolated_redis_lock(&url, &lock_token).await;
 }
 
 /// Verifies that a recently-created `Queued` request is left alone by the
 /// sweeper. Ensures the sweeper only acts on stale requests.
 #[tokio::test]
 async fn sweep_fresh_queued_untouched() {
-    let (url, lock_token, mut redis) = setup_isolated_redis_for_test().await;
+    let (url, _redis_container, mut redis) = setup_isolated_redis_for_test().await;
     let tracker =
         RequestTracker::new(url.clone(), None, defaults::STALE_SUBMITTED_THRESHOLD_SECS).await;
 
@@ -487,14 +397,13 @@ async fn sweep_fresh_queued_untouched() {
     let record = read_record(&mut redis, "fresh-queued").await.unwrap();
     assert!(matches!(record.status, GatewayRequestState::Queued));
     assert!(is_in_pending_set(&mut redis, "fresh-queued").await);
-    release_isolated_redis_lock(&url, &lock_token).await;
 }
 
 /// Verifies that a `Batching` request older than the queued threshold is
 /// marked as `Failed`. Batching and Queued share the same staleness logic.
 #[tokio::test]
 async fn sweep_stale_batching_request() {
-    let (url, lock_token, mut redis) = setup_isolated_redis_for_test().await;
+    let (url, _redis_container, mut redis) = setup_isolated_redis_for_test().await;
     let tracker =
         RequestTracker::new(url.clone(), None, defaults::STALE_SUBMITTED_THRESHOLD_SECS).await;
     let five_min_ago = now_unix_secs() - 300;
@@ -519,14 +428,13 @@ async fn sweep_stale_batching_request() {
     let record = read_record(&mut redis, "stale-batching").await.unwrap();
     assert!(matches!(record.status, GatewayRequestState::Failed { .. }));
     assert!(!is_in_pending_set(&mut redis, "stale-batching").await);
-    release_isolated_redis_lock(&url, &lock_token).await;
 }
 
 /// Verifies that a pending set entry with no corresponding request record
 /// in Redis is cleaned up (e.g. the record expired or was never written).
 #[tokio::test]
 async fn sweep_dangling_set_member() {
-    let (url, lock_token, mut redis) = setup_isolated_redis_for_test().await;
+    let (url, _redis_container, mut redis) = setup_isolated_redis_for_test().await;
     let tracker =
         RequestTracker::new(url.clone(), None, defaults::STALE_SUBMITTED_THRESHOLD_SECS).await;
 
@@ -545,14 +453,13 @@ async fn sweep_dangling_set_member() {
         !is_in_pending_set(&mut redis, "dangling-id").await,
         "dangling set member should be removed"
     );
-    release_isolated_redis_lock(&url, &lock_token).await;
 }
 
 /// Verifies that a `Finalized` request left in the pending set gets cleaned
 /// out without changing its status. A safety-net for inconsistent state.
 #[tokio::test]
 async fn sweep_already_terminal_in_set() {
-    let (url, lock_token, mut redis) = setup_isolated_redis_for_test().await;
+    let (url, _redis_container, mut redis) = setup_isolated_redis_for_test().await;
     let tracker =
         RequestTracker::new(url.clone(), None, defaults::STALE_SUBMITTED_THRESHOLD_SECS).await;
 
@@ -584,14 +491,13 @@ async fn sweep_already_terminal_in_set() {
         matches!(record.status, GatewayRequestState::Finalized { .. }),
         "status should remain unchanged"
     );
-    release_isolated_redis_lock(&url, &lock_token).await;
 }
 
 /// Verifies that a `Submitted` request with no on-chain receipt that exceeds
 /// the submitted threshold is marked as `Failed`. Covers dropped transactions.
 #[tokio::test]
 async fn sweep_submitted_no_receipt_stale() {
-    let (url, lock_token, mut redis) = setup_isolated_redis_for_test().await;
+    let (url, _redis_container, mut redis) = setup_isolated_redis_for_test().await;
     let tracker =
         RequestTracker::new(url.clone(), None, defaults::STALE_SUBMITTED_THRESHOLD_SECS).await;
     let five_min_ago = now_unix_secs() - 300;
@@ -627,14 +533,13 @@ async fn sweep_submitted_no_receipt_stale() {
         other => panic!("expected Failed, got {other:?}"),
     }
     assert!(!is_in_pending_set(&mut redis, "stale-submitted").await);
-    release_isolated_redis_lock(&url, &lock_token).await;
 }
 
 /// Verifies that a recently-submitted request without a receipt is left
 /// alone. The transaction may still be pending in the sequencer's mempool.
 #[tokio::test]
 async fn sweep_submitted_no_receipt_fresh() {
-    let (url, lock_token, mut redis) = setup_isolated_redis_for_test().await;
+    let (url, _redis_container, mut redis) = setup_isolated_redis_for_test().await;
     let tracker =
         RequestTracker::new(url.clone(), None, defaults::STALE_SUBMITTED_THRESHOLD_SECS).await;
 
@@ -664,7 +569,6 @@ async fn sweep_submitted_no_receipt_fresh() {
         "fresh submitted request should not be touched"
     );
     assert!(is_in_pending_set(&mut redis, "fresh-submitted").await);
-    release_isolated_redis_lock(&url, &lock_token).await;
 }
 
 /// End-to-end: submits a real transaction, then injects an orphaned request
@@ -672,7 +576,7 @@ async fn sweep_submitted_no_receipt_fresh() {
 /// actual on-chain receipt.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn sweep_submitted_with_real_receipt() {
-    let (url, lock_token, mut redis) = setup_isolated_redis_for_test().await;
+    let (url, _redis_container, mut redis) = setup_isolated_redis_for_test().await;
 
     let anvil = TestAnvil::spawn().unwrap();
     let deployer = anvil.signer(0).unwrap();
@@ -760,5 +664,4 @@ async fn sweep_submitted_with_real_receipt() {
     assert!(!is_in_pending_set(&mut redis, "orphan-with-receipt").await);
 
     let _ = gw.shutdown().await;
-    release_isolated_redis_lock(&url, &lock_token).await;
 }

--- a/services/indexer/tests/helpers/db_helpers.rs
+++ b/services/indexer/tests/helpers/db_helpers.rs
@@ -8,11 +8,13 @@ use world_id_indexer::{
     db::{DB, DBResult},
     tree::{self, TreeState, VersionedTreeState},
 };
+use world_id_test_utils::shared_postgres_testcontainer;
 
 /// RAII guard that ensures test database cleanup on drop
 pub struct TestDatabase {
     pub db: DB,
     db_url: String,
+    base_url: String,
     db_name: Option<String>,
 }
 
@@ -37,7 +39,7 @@ impl TestDatabase {
     /// if you want to handle cleanup errors
     pub async fn cleanup(mut self) {
         if let Some(db_name) = self.db_name.take() {
-            cleanup_test_db(&db_name).await;
+            cleanup_test_db(&self.base_url, &db_name).await;
         }
     }
 }
@@ -45,6 +47,7 @@ impl TestDatabase {
 impl Drop for TestDatabase {
     fn drop(&mut self) {
         if let Some(db_name) = self.db_name.take() {
+            let base_url = self.base_url.clone();
             // Best effort cleanup - spawn a thread with its own runtime
             // This is not ideal but necessary since Drop is synchronous
             let _ = std::thread::spawn(move || {
@@ -53,7 +56,7 @@ impl Drop for TestDatabase {
                     .build()
                 {
                     rt.block_on(async {
-                        cleanup_test_db(&db_name).await;
+                        cleanup_test_db(&base_url, &db_name).await;
                     });
                 }
             })
@@ -66,8 +69,10 @@ impl Drop for TestDatabase {
 /// Returns a TestDatabase guard that will automatically cleanup on drop
 pub async fn create_unique_test_db() -> TestDatabase {
     let unique_name = format!("test_db_{}", Uuid::new_v4().to_string().replace('-', "_"));
-    let base_url = std::env::var("TEST_DATABASE_URL")
-        .unwrap_or_else(|_| "postgresql://postgres:postgres@localhost:5432/postgres".to_string());
+    let base_url = shared_postgres_testcontainer()
+        .await
+        .expect("failed to start Postgres testcontainer")
+        .to_owned();
 
     // Connect to postgres database to create our test database
     let pool = PgPoolOptions::new()
@@ -101,18 +106,16 @@ pub async fn create_unique_test_db() -> TestDatabase {
     TestDatabase {
         db,
         db_url: test_db_url,
+        base_url,
         db_name: Some(unique_name),
     }
 }
 
 /// Cleanup test database
-pub async fn cleanup_test_db(db_name: &str) {
-    let base_url = std::env::var("TEST_DATABASE_URL")
-        .unwrap_or_else(|_| "postgresql://postgres:postgres@localhost:5432/postgres".to_string());
-
+pub async fn cleanup_test_db(base_url: &str, db_name: &str) {
     if let Ok(pool) = PgPoolOptions::new()
         .max_connections(1)
-        .connect(&base_url)
+        .connect(base_url)
         .await
     {
         // Terminate connections to the database first

--- a/services/indexer/tests/rollback_tests.rs
+++ b/services/indexer/tests/rollback_tests.rs
@@ -5,14 +5,8 @@
 //!
 //! # Running these tests
 //!
-//! These tests require a PostgreSQL database to be running. Use Docker Compose:
-//!
-//! ```bash
-//! docker compose up -d postgres
-//! cargo test -p world-id-indexer --test rollback_tests
-//! ```
-//!
-//! The tests will automatically create unique test databases for isolation.
+//! These tests start a PostgreSQL testcontainer and create unique databases for
+//! isolation. Run them with `cargo test -p world-id-indexer --test rollback_tests`.
 
 mod helpers;
 

--- a/services/indexer/tests/rollback_to_last_valid_root_tests.rs
+++ b/services/indexer/tests/rollback_to_last_valid_root_tests.rs
@@ -1,11 +1,6 @@
 //! Integration tests for `rollback_to_last_valid_root`.
 //!
-//! These tests require a PostgreSQL database and Anvil.
-//!
-//! ```bash
-//! docker compose up -d postgres
-//! cargo test -p world-id-indexer --test rollback_to_last_valid_root_tests
-//! ```
+//! These tests start a PostgreSQL testcontainer and an Anvil instance.
 
 mod helpers;
 

--- a/tools/generate-solidity-fixtures/src/main.rs
+++ b/tools/generate-solidity-fixtures/src/main.rs
@@ -46,6 +46,7 @@ use world_id_test_utils::{
         MerkleFixture, RegistryTestContext, build_base_credential, generate_rp_fixture,
         single_leaf_merkle_fixture,
     },
+    redis_testcontainer,
     stubs::spawn_indexer_stub,
 };
 
@@ -76,6 +77,7 @@ async fn main() -> Result<()> {
     let deployer = anvil
         .signer(0)
         .wrap_err("failed to fetch deployer signer for anvil")?;
+    let (_redis, redis_url) = redis_testcontainer().await?;
 
     // Spawn the gateway.
     let gw_port: u16 = 4105;
@@ -91,8 +93,7 @@ async fn main() -> Result<()> {
         listen_addr: (std::net::Ipv4Addr::LOCALHOST, gw_port).into(),
         max_create_batch_size: 10,
         max_ops_batch_size: 10,
-        redis_url: std::env::var("REDIS_URL")
-            .unwrap_or_else(|_| "redis://localhost:6379".to_string()),
+        redis_url,
         request_timeout_secs: 10,
         rate_limit_max_requests: None,
         rate_limit_window_secs: None,


### PR DESCRIPTION
## Summary
- Provision Redis and Postgres dependencies through testcontainers in Rust tests.
- Give every orphan-sweeper test its own Redis container; remove Redis database leasing, locking, and cleanup plumbing.
- Remove the Docker Compose lifecycle from the workspace-test CI job.
- Retain Docker Compose for the interactive local setup and service-image smoke workflow.

## Validation
- cargo +nightly fmt --all -- --check
- cargo check --offline -p world-id-test-utils -p world-id-core -p world-id-indexer -p world-id-gateway -p generate-solidity-fixtures
- cargo test --offline -p world-id-indexer --test db_tests test_insert_account -- --exact
- cargo test --offline -p world-id-core --test authenticator_registration -- --exact
- cargo test --offline -p world-id-gateway --features integration-tests --test test_orphan_sweeper -- --test-threads=1

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test and CI infrastructure only; production services and runtime config are unchanged.
> 
> **Overview**
> Integration tests no longer assume **Redis** or **Postgres** from Docker Compose or `REDIS_URL` / `TEST_DATABASE_URL`. They spin up dependencies via **testcontainers** instead.
> 
> **`world-id-test-utils`** adds a shared **`redis_testcontainer()`** helper (and pulls in `testcontainers-modules`). Core, gateway, and fixture tooling wire gateway configs to that URL and keep the container handle alive for the test.
> 
> **Gateway orphan-sweeper tests** drop the old pattern of leasing Redis logical DBs with locks and scripted flushes; each case gets its own Redis container. Gateway **`common::start_redis`** delegates to the shared helper.
> 
> **Indexer** test DB setup uses **`shared_postgres_testcontainer()`** for the admin connection URL; cleanup passes that base URL explicitly. Rollback test docs no longer tell you to run `docker compose up postgres`.
> 
> **Rust CI** workspace test job removes **`docker compose up` / `down`** around `cargo nextest`; Compose remains for setup-test and docker image jobs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 369eae8d8d92f8cd56f79c32727e2abb4d96c61a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->