### PR TITLE
fix: pass current time into nullifier generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13236,6 +13236,7 @@ dependencies = [
  "taceo-groth16-sol",
  "taceo-oprf",
  "tar",
+ "test-case",
  "thiserror 2.0.18",
  "toml 1.0.6+spec-1.1.0",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12924,6 +12924,7 @@ dependencies = [
  "base64 0.22.1",
  "bhttp",
  "eyre",
+ "getrandom 0.2.17",
  "getrandom 0.3.4",
  "hex",
  "mockito",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,6 +125,7 @@ config = "0.15.19"
 dotenvy = "0.15"
 futures-util = "0.3"
 getrandom = "0.3"
+# `rand` 0.8's `OsRng` still uses `getrandom` 0.2, while OHTTP/HPKE uses 0.3.
 getrandom-02 = { package = "getrandom", version = "0.2" }
 governor = "0.10.4"
 http = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,6 +125,7 @@ config = "0.15.19"
 dotenvy = "0.15"
 futures-util = "0.3"
 getrandom = "0.3"
+getrandom-02 = { package = "getrandom", version = "0.2" }
 governor = "0.10.4"
 http = "1"
 humantime = "2"

--- a/crates/authenticator/Cargo.toml
+++ b/crates/authenticator/Cargo.toml
@@ -77,9 +77,11 @@ rustls = { workspace = true }
 webpki-roots = { workspace = true }
 world-id-proof = { workspace = true }
 
-# Enable getrandom's JS backend for OHTTP/HPKE on wasm32-unknown-unknown.
+# Enable the JS backends used by OHTTP/HPKE (`getrandom` 0.3) and
+# `rand` 0.8's `OsRng` (`getrandom` 0.2) on wasm32-unknown-unknown.
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { workspace = true, features = ["wasm_js"] }
+getrandom-02 = { workspace = true, features = ["js"] }
 
 [dev-dependencies]
 axum = { workspace = true }

--- a/crates/authenticator/src/prove.rs
+++ b/crates/authenticator/src/prove.rs
@@ -111,6 +111,7 @@ impl Authenticator {
     ///
     /// # Arguments
     /// - `proof_request`: the request received from the RP.
+    /// - `now`: the current Unix timestamp, used to reject expired requests.
     /// - `account_inclusion_proof`: an optionally cached object can be passed to
     ///   avoid an additional network call. If not passed, it'll be fetched from the indexer.
     ///
@@ -129,6 +130,7 @@ impl Authenticator {
     pub async fn generate_nullifier(
         &self,
         proof_request: &ProofRequest,
+        now: u64,
         account_inclusion_proof: Option<AccountInclusionProof<TREE_DEPTH>>,
     ) -> Result<FullOprfOutput, AuthenticatorError> {
         proof_request.validate_proof_type()?;
@@ -143,7 +145,7 @@ impl Authenticator {
             .await?;
 
         Ok(oprf_entrypoint
-            .gen_nullifier(&mut rng, proof_request)
+            .gen_nullifier(&mut rng, proof_request, now)
             .await?)
     }
 
@@ -261,7 +263,7 @@ impl Authenticator {
     /// # Typical flow
     /// ```rust,ignore
     /// // <- check request can be fulfilled with available credentials
-    /// let nullifier = authenticator.generate_nullifier(&request, None).await?;
+    /// let nullifier = authenticator.generate_nullifier(&request, now, None).await?;
     /// // <- check replay guard using nullifier.oprf_output()
     /// let (response, meta) = authenticator.generate_proof(&request, nullifier, &creds, ...).await?;
     /// // <- cache `session_id_r_seed` (to speed future proofs) and `nullifier` (to prevent replays)

--- a/crates/core/tests/generate_proof.rs
+++ b/crates/core/tests/generate_proof.rs
@@ -319,7 +319,7 @@ async fn e2e_authenticator_generate_proof() -> Result<()> {
         constraints: None,
     };
     let nullifier = authenticator
-        .generate_nullifier(&proof_request, None)
+        .generate_nullifier(&proof_request, rp_fixture.current_timestamp, None)
         .await?;
     assert_ne!(nullifier.oprf_output(), FieldElement::ZERO);
 
@@ -384,7 +384,7 @@ async fn e2e_authenticator_generate_proof() -> Result<()> {
         ..proof_request.clone()
     };
     let create_nullifier = authenticator
-        .generate_nullifier(&create_request, None)
+        .generate_nullifier(&create_request, rp_fixture.current_timestamp, None)
         .await?;
     let create_result = authenticator
         .generate_proof(&create_request, create_nullifier, &credentials, None, None)

--- a/crates/proof/Cargo.toml
+++ b/crates/proof/Cargo.toml
@@ -77,5 +77,6 @@ provekit-common = { workspace = true }
 provekit-r1cs-compiler = { workspace = true, optional = true }
 
 [dev-dependencies]
+test-case = { workspace = true }
 toml = { workspace = true }
 world-id-test-utils = { workspace = true }

--- a/crates/proof/src/oprf_query.rs
+++ b/crates/proof/src/oprf_query.rs
@@ -1,11 +1,7 @@
 //! Shared helpers for generating query proofs and executing
 //! distributed generic OPRF computations.
 
-use std::{
-    io::Read,
-    path::Path,
-    time::{SystemTime, UNIX_EPOCH},
-};
+use std::{io::Read, path::Path};
 
 use ark_bn254::Bn254;
 use ark_groth16::Proof;
@@ -201,6 +197,7 @@ impl<'a> OprfEntrypoint<'a> {
         &self,
         rng: &mut R,
         proof_request: &ProofRequest,
+        now: u64,
     ) -> Result<FullOprfOutput, ProofError> {
         proof_request
             .validate_proof_type()
@@ -217,27 +214,8 @@ impl<'a> OprfEntrypoint<'a> {
             (action, OprfModule::Nullifier)
         };
 
-        // quick validation before performing the compute heavy `generate_query_proof` fn
-        if proof_request.created_at > proof_request.expires_at {
-            return Err(ProofError::ProofInputError(
-                errors::ProofInputError::InvalidExpiresAt {
-                    created_at: proof_request.created_at,
-                    expires_at: proof_request.expires_at,
-                },
-            ));
-        }
-        let now = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("time cannot go backward")
-            .as_secs();
-        if proof_request.is_expired(now) {
-            return Err(ProofError::ProofInputError(
-                errors::ProofInputError::ProofRequestExpired {
-                    current_timestamp: now,
-                    expires_at: proof_request.expires_at,
-                },
-            ));
-        }
+        // Quick validation before performing the compute-heavy `generate_query_proof` fn.
+        validate_proof_request_timestamps(proof_request.created_at, proof_request.expires_at, now)?;
 
         let result = Self::generate_query_proof(
             self.query_material,
@@ -340,6 +318,30 @@ impl<'a> OprfEntrypoint<'a> {
     }
 }
 
+fn validate_proof_request_timestamps(
+    created_at: u64,
+    expires_at: u64,
+    now: u64,
+) -> Result<(), ProofError> {
+    if created_at > expires_at {
+        return Err(ProofError::ProofInputError(
+            errors::ProofInputError::InvalidExpiresAt {
+                created_at,
+                expires_at,
+            },
+        ));
+    }
+    if now > expires_at {
+        return Err(ProofError::ProofInputError(
+            errors::ProofInputError::ProofRequestExpired {
+                current_timestamp: now,
+                expires_at,
+            },
+        ));
+    }
+    Ok(())
+}
+
 impl<'a> OprfEntrypoint<'a> {
     /// Generates a query proof: creates a blinding factor, computes
     /// the query hash, signs it, builds [`QueryProofCircuitInput`], and
@@ -430,4 +432,23 @@ struct QueryProofResult {
     proof: Proof<Bn254>,
     query_hash: ark_babyjubjub::Fq,
     blinding_factor: BlindingFactor,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn proof_request_expiry_uses_caller_timestamp() {
+        assert!(validate_proof_request_timestamps(100, 200, 150).is_ok());
+        assert!(matches!(
+            validate_proof_request_timestamps(100, 200, 201),
+            Err(ProofError::ProofInputError(
+                errors::ProofInputError::ProofRequestExpired {
+                    current_timestamp: 201,
+                    expires_at: 200,
+                }
+            ))
+        ));
+    }
 }

--- a/crates/proof/src/oprf_query.rs
+++ b/crates/proof/src/oprf_query.rs
@@ -182,6 +182,11 @@ impl<'a> OprfEntrypoint<'a> {
     /// Generates a nullifier through the provided OPRF nodes for
     /// a specific proof request.
     ///
+    /// # Arguments
+    /// - `rng`: cryptographically secure randomness for generating the query proof.
+    /// - `proof_request`: the request to authenticate and fulfill.
+    /// - `now`: the caller-supplied current Unix timestamp, used to reject expired requests.
+    ///
     /// # Note on Session Proofs
     /// A randomized action is required on Session Proofs to ensure the output nullifier from the Uniqueness Proof
     /// circuit is unique (otherwise the one-time use property of nullifiers would fail). Please see the "Future"

--- a/crates/proof/src/oprf_query.rs
+++ b/crates/proof/src/oprf_query.rs
@@ -439,35 +439,18 @@ mod tests {
     use super::*;
     use test_case::test_case;
 
-    #[derive(Debug, PartialEq, Eq)]
-    enum TimestampValidation {
-        Valid,
-        InvalidExpiresAt { created_at: u64, expires_at: u64 },
-        Expired { now: u64, expires_at: u64 },
-    }
-
-    #[test_case(100, 200, 150 => TimestampValidation::Valid; "valid")]
-    #[test_case(201, 200, 150 => TimestampValidation::InvalidExpiresAt { created_at: 201, expires_at: 200 }; "created after expiration")]
-    #[test_case(100, 200, 201 => TimestampValidation::Expired { now: 201, expires_at: 200 }; "expired at caller time")]
+    #[test_case(100, 200, 150 => matches Ok(()); "valid")]
+    #[test_case(201, 200, 150 => matches Err(ProofError::ProofInputError(
+        errors::ProofInputError::InvalidExpiresAt { created_at: 201, expires_at: 200 }
+    )); "created after expiration")]
+    #[test_case(100, 200, 201 => matches Err(ProofError::ProofInputError(
+        errors::ProofInputError::ProofRequestExpired { current_timestamp: 201, expires_at: 200 }
+    )); "expired at caller time")]
     fn proof_request_timestamp_validation(
         created_at: u64,
         expires_at: u64,
         now: u64,
-    ) -> TimestampValidation {
-        match validate_proof_request_timestamps(created_at, expires_at, now) {
-            Ok(()) => TimestampValidation::Valid,
-            Err(ProofError::ProofInputError(errors::ProofInputError::InvalidExpiresAt {
-                created_at,
-                expires_at,
-            })) => TimestampValidation::InvalidExpiresAt {
-                created_at,
-                expires_at,
-            },
-            Err(ProofError::ProofInputError(errors::ProofInputError::ProofRequestExpired {
-                current_timestamp: now,
-                expires_at,
-            })) => TimestampValidation::Expired { now, expires_at },
-            Err(error) => panic!("unexpected validation error: {error}"),
-        }
+    ) -> Result<(), ProofError> {
+        validate_proof_request_timestamps(created_at, expires_at, now)
     }
 }

--- a/crates/proof/src/oprf_query.rs
+++ b/crates/proof/src/oprf_query.rs
@@ -437,18 +437,37 @@ struct QueryProofResult {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use test_case::test_case;
 
-    #[test]
-    fn proof_request_expiry_uses_caller_timestamp() {
-        assert!(validate_proof_request_timestamps(100, 200, 150).is_ok());
-        assert!(matches!(
-            validate_proof_request_timestamps(100, 200, 201),
-            Err(ProofError::ProofInputError(
-                errors::ProofInputError::ProofRequestExpired {
-                    current_timestamp: 201,
-                    expires_at: 200,
-                }
-            ))
-        ));
+    #[derive(Debug, PartialEq, Eq)]
+    enum TimestampValidation {
+        Valid,
+        InvalidExpiresAt { created_at: u64, expires_at: u64 },
+        Expired { now: u64, expires_at: u64 },
+    }
+
+    #[test_case(100, 200, 150 => TimestampValidation::Valid; "valid")]
+    #[test_case(201, 200, 150 => TimestampValidation::InvalidExpiresAt { created_at: 201, expires_at: 200 }; "created after expiration")]
+    #[test_case(100, 200, 201 => TimestampValidation::Expired { now: 201, expires_at: 200 }; "expired at caller time")]
+    fn proof_request_timestamp_validation(
+        created_at: u64,
+        expires_at: u64,
+        now: u64,
+    ) -> TimestampValidation {
+        match validate_proof_request_timestamps(created_at, expires_at, now) {
+            Ok(()) => TimestampValidation::Valid,
+            Err(ProofError::ProofInputError(errors::ProofInputError::InvalidExpiresAt {
+                created_at,
+                expires_at,
+            })) => TimestampValidation::InvalidExpiresAt {
+                created_at,
+                expires_at,
+            },
+            Err(ProofError::ProofInputError(errors::ProofInputError::ProofRequestExpired {
+                current_timestamp: now,
+                expires_at,
+            })) => TimestampValidation::Expired { now, expires_at },
+            Err(error) => panic!("unexpected validation error: {error}"),
+        }
     }
 }

--- a/services/oprf-dev-client/src/bin/world-id-dev-client-rp.rs
+++ b/services/oprf-dev-client/src/bin/world-id-dev-client-rp.rs
@@ -126,16 +126,20 @@ impl DevClient for WorldIdRpDevClient {
 
         let account_inclusion_proof =
             AccountInclusionProof::new(setup.inclusion_proof.clone(), setup.key_set.clone());
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time after epoch")
+            .as_secs();
 
         let (uniquness_nullifier, session_nullifier) = tokio::join!(
             self.components.authenticator.generate_nullifier(
                 &proof_request_uniqueness,
-                proof_request_uniqueness.created_at,
+                now,
                 Some(account_inclusion_proof.clone())
             ),
             self.components.authenticator.generate_nullifier(
                 &proof_request_session,
-                proof_request_session.created_at,
+                now,
                 Some(account_inclusion_proof),
             )
         );

--- a/services/oprf-dev-client/src/bin/world-id-dev-client-rp.rs
+++ b/services/oprf-dev-client/src/bin/world-id-dev-client-rp.rs
@@ -130,11 +130,14 @@ impl DevClient for WorldIdRpDevClient {
         let (uniquness_nullifier, session_nullifier) = tokio::join!(
             self.components.authenticator.generate_nullifier(
                 &proof_request_uniqueness,
+                proof_request_uniqueness.created_at,
                 Some(account_inclusion_proof.clone())
             ),
-            self.components
-                .authenticator
-                .generate_nullifier(&proof_request_session, Some(account_inclusion_proof),)
+            self.components.authenticator.generate_nullifier(
+                &proof_request_session,
+                proof_request_session.created_at,
+                Some(account_inclusion_proof),
+            )
         );
 
         let uniqueness_epoch = uniquness_nullifier

--- a/tools/generate-solidity-fixtures/src/main.rs
+++ b/tools/generate-solidity-fixtures/src/main.rs
@@ -293,7 +293,7 @@ async fn main() -> Result<()> {
     }];
 
     let nullifier_data = authenticator
-        .generate_nullifier(&uniqueness_request, None)
+        .generate_nullifier(&uniqueness_request, rp_fixture.current_timestamp, None)
         .await?;
 
     let uniqueness_result = authenticator
@@ -356,7 +356,7 @@ async fn main() -> Result<()> {
     };
 
     let bound_create_nullifier = authenticator
-        .generate_nullifier(&bound_create_request, None)
+        .generate_nullifier(&bound_create_request, rp_fixture.current_timestamp, None)
         .await?;
 
     let bound_create_result = authenticator
@@ -429,7 +429,7 @@ async fn main() -> Result<()> {
     };
 
     let session_nullifier_data = authenticator
-        .generate_nullifier(&session_request, None)
+        .generate_nullifier(&session_request, rp_fixture.current_timestamp, None)
         .await?;
 
     let session_result = authenticator


### PR DESCRIPTION
## Summary

[SystemTime::now is not implemented for wasm32-unknown-unknown only for WASI](https://doc.rust-lang.org/std/time/struct.SystemTime.html#platform-specific-behavior). This change will allow us to supply the timestamp externally in a method defined by the host platform.

Also as a drive by change excplicitly enable the `getrandom` JS backend for rand 0.8


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Public API break on `generate_nullifier`; incorrect or stale `now` from callers could accept expired requests or reject valid ones, though behavior matches the previous clock-based checks when hosts pass accurate time.
> 
> **Overview**
> **Nullifier generation no longer reads wall clock internally.** `Authenticator::generate_nullifier` and `OprfEntrypoint::gen_nullifier` take a caller-supplied Unix `now` and use it to reject invalid or expired proof requests before the OPRF query path runs. Expiry checks that previously used `SystemTime::now()` are centralized in `validate_proof_request_timestamps`, with `test-case` unit tests in `oprf_query.rs`.
> 
> Call sites (e2e tests, solidity fixture tool, OPRF dev client) pass an explicit timestamp—typically from `SystemTime` on native targets—so hosts on **`wasm32-unknown-unknown`** can supply time from the JS/runtime instead of relying on std time.
> 
> **WASM follow-up:** the workspace adds `getrandom-02` and enables the `js` feature for `rand` 0.8’s `OsRng` on wasm, alongside the existing `getrandom` 0.3 `wasm_js` path for OHTTP/HPKE.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c7c24a1ff2f4d19ea5947ce2ae1532abc4d87a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->