### PR TITLE
feat(proof): add private claims co-proof POC

### DIFF
--- a/crates/authenticator/Cargo.toml
+++ b/crates/authenticator/Cargo.toml
@@ -23,10 +23,17 @@ embed-zkeys = ["world-id-proof/embed-zkeys"]
 compress-zkeys = ["embed-zkeys", "world-id-proof/compress-zkeys"]
 # Compress the tar archive with zstd
 zstd-compress-zkeys = ["embed-zkeys", "world-id-proof/zstd-compress-zkeys"]
-# Embed the Noir ownership prover/verifier (built ad-hoc with nargo)
+# Embed Noir prover/verifier artifacts (built ad-hoc with nargo)
 embed-ownership-prover = ["world-id-proof/embed-ownership-prover"]
 embed-ownership-verifier = ["world-id-proof/embed-ownership-verifier"]
-embed-noir-artifacts = ["embed-ownership-prover", "embed-ownership-verifier"]
+embed-claims-prover = ["world-id-proof/embed-claims-prover"]
+embed-claims-verifier = ["world-id-proof/embed-claims-verifier"]
+embed-noir-artifacts = [
+    "embed-ownership-prover",
+    "embed-ownership-verifier",
+    "embed-claims-prover",
+    "embed-claims-verifier",
+]
 # Embed everything
 embed-zk-artifacts = ["embed-zkeys", "embed-noir-artifacts"]
 

--- a/crates/authenticator/README.md
+++ b/crates/authenticator/README.md
@@ -4,4 +4,9 @@ World ID is an anonymous proof of human for the age of AI.
 
 This crate provides the functionality for a World ID Authenticator.
 
+An RP can optionally attach sparse private-claim predicates to a credential request. On native
+targets, `generate_proof` then returns the regular Circom nullifier proof and a Noir claims
+co-proof in the same response item. The two proofs are bound through their shared nullifier,
+credential issuer, RP/action, and credential time policy.
+
 More information can be found in the [World ID Developer Documentation](https://docs.world.org/world-id).

--- a/crates/authenticator/src/prove.rs
+++ b/crates/authenticator/src/prove.rs
@@ -18,7 +18,9 @@ use world_id_primitives::OwnershipProof;
 use world_id_primitives::TREE_DEPTH;
 #[cfg(not(target_arch = "wasm32"))]
 use world_id_proof::{
+    ClaimsProver,
     circuit_inputs::OwnershipProofCircuitInput,
+    claims_proof::{ClaimsProofContext, ClaimsProofInput, generate_claims_proof_with_prover},
     ownership_proof::generate_ownership_proof_with_prover,
 };
 
@@ -336,6 +338,24 @@ impl Authenticator {
             .nullifier_material()
             .map_err(AuthenticatorError::ZkArtifactError)?;
 
+        #[cfg(not(target_arch = "wasm32"))]
+        let claims_prover = if items_to_prove.iter().any(|item| item.claims.is_some()) {
+            Some(
+                self.zk_artifact_source
+                    .claims_prover()
+                    .map_err(AuthenticatorError::ZkArtifactError)?,
+            )
+        } else {
+            None
+        };
+
+        #[cfg(target_arch = "wasm32")]
+        if items_to_prove.iter().any(|item| item.claims.is_some()) {
+            return Err(AuthenticatorError::Generic(
+                "claims proofs are not available on wasm32".to_owned(),
+            ));
+        }
+
         // 3. Generate per-credential proofs for the selected items
         let creds_by_schema: std::collections::HashMap<u64, &CredentialInput> = credentials
             .iter()
@@ -356,6 +376,8 @@ impl Authenticator {
                 resolved_session_id,
                 proof_request.proof_type,
                 proof_request.created_at,
+                #[cfg(not(target_arch = "wasm32"))]
+                claims_prover.as_ref(),
             )?;
             responses.push(response_item);
         }
@@ -415,11 +437,14 @@ impl Authenticator {
         session_id: Option<SessionId>,
         proof_type: ProofType,
         request_timestamp: u64,
+        #[cfg(not(target_arch = "wasm32"))] claims_prover: Option<&ClaimsProver>,
     ) -> Result<ResponseItem, AuthenticatorError> {
         let mut rng = rand::rngs::OsRng;
 
         let merkle_root: FieldElement = oprf_nullifier.query_proof_input.merkle_root.into();
         let action_from_query: FieldElement = oprf_nullifier.query_proof_input.action.into();
+        let rp_id: FieldElement = oprf_nullifier.query_proof_input.rp_id.into();
+        let oprf_response = oprf_nullifier.verifiable_oprf_output.unblinded_response;
 
         let expires_at_min = request_item.effective_expires_at_min(request_timestamp);
 
@@ -439,7 +464,7 @@ impl Authenticator {
 
         // Construct the appropriate response item based on proof type
         let nullifier_fe: FieldElement = nullifier.into();
-        let response_item = if proof_type.is_session() {
+        let mut response_item = if proof_type.is_session() {
             let session_nullifier = SessionNullifier::new(nullifier_fe, action_from_query)?;
             ResponseItem::new_session(
                 request_item.identifier.clone(),
@@ -457,6 +482,35 @@ impl Authenticator {
                 expires_at_min,
             )
         };
+
+        #[cfg(not(target_arch = "wasm32"))]
+        if let Some(claims_request) = &request_item.claims {
+            let prover = claims_prover.ok_or_else(|| {
+                AuthenticatorError::Generic(
+                    "claims prover was not loaded for a claims proof request".to_owned(),
+                )
+            })?;
+            let context = ClaimsProofContext {
+                issuer_schema_id: credential.issuer_schema_id.into(),
+                credential_public_key: credential.issuer.clone(),
+                current_timestamp: expires_at_min.into(),
+                cred_genesis_issued_at_min: request_item.genesis_issued_at_min.unwrap_or(0).into(),
+                nullifier: nullifier_fe,
+                rp_id,
+                action: action_from_query,
+            };
+            response_item.claims_proof = Some(generate_claims_proof_with_prover(
+                ClaimsProofInput {
+                    credential,
+                    credential_sub_blinding_factor,
+                    leaf_index: self.leaf_index(),
+                    oprf_response,
+                    context,
+                    request: claims_request,
+                },
+                prover.clone(),
+            )?);
+        }
 
         Ok(response_item)
     }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -25,10 +25,17 @@ embed-zkeys = ["authenticator", "world-id-proof/embed-zkeys"]
 compress-zkeys = ["authenticator", "embed-zkeys", "world-id-proof/compress-zkeys"]
 # Compress the tar archive with zstd
 zstd-compress-zkeys = ["authenticator", "embed-zkeys", "world-id-proof/zstd-compress-zkeys"]
-# Embed the Noir ownership prover/verifier (built ad-hoc with nargo)
+# Embed Noir prover/verifier artifacts (built ad-hoc with nargo)
 embed-ownership-prover = ["authenticator", "world-id-proof/embed-ownership-prover"]
 embed-ownership-verifier = ["authenticator", "world-id-proof/embed-ownership-verifier"]
-embed-noir-artifacts = ["embed-ownership-prover", "embed-ownership-verifier"]
+embed-claims-prover = ["authenticator", "world-id-proof/embed-claims-prover"]
+embed-claims-verifier = ["authenticator", "world-id-proof/embed-claims-verifier"]
+embed-noir-artifacts = [
+    "embed-ownership-prover",
+    "embed-ownership-verifier",
+    "embed-claims-prover",
+    "embed-claims-verifier",
+]
 # Embed everything
 embed-zk-artifacts = ["embed-zkeys", "embed-noir-artifacts"]
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -30,6 +30,9 @@ pub use world_id_primitives::Signer;
 #[cfg(feature = "authenticator")]
 pub use world_id_proof::{artifacts, nullifier_proof};
 
+#[cfg(all(feature = "authenticator", not(target_arch = "wasm32")))]
+pub use world_id_proof::claims_proof;
+
 #[cfg(any(feature = "authenticator", feature = "rp"))]
 pub use world_id_primitives::request as requests;
 

--- a/crates/core/tests/generate_proof.rs
+++ b/crates/core/tests/generate_proof.rs
@@ -315,6 +315,7 @@ async fn e2e_authenticator_generate_proof() -> Result<()> {
             signal: Some(b"my_signal".to_vec()),
             genesis_issued_at_min: None,
             expires_at_min: None,
+            claims: None,
         }],
         constraints: None,
     };

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -61,7 +61,9 @@ pub use session::{SessionId, SessionNullifier, SessionRef};
 
 /// Contains the quintessential zero-knowledge proof type.
 pub mod proof;
-pub use proof::{OwnershipProof, ZeroKnowledgeProof};
+pub use proof::{
+    ClaimStatement, ClaimsProof, ClaimsProofRequest, OwnershipProof, ZeroKnowledgeProof,
+};
 
 /// Contains types specifically related to relying parties.
 pub mod rp;

--- a/crates/primitives/src/proof.rs
+++ b/crates/primitives/src/proof.rs
@@ -3,6 +3,31 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer, de::Error as _};
 
 use crate::FieldElement;
 
+/// A strict range predicate over one credential claim.
+///
+/// At least one bound must be present. The claim remains private; only the predicate and
+/// whether it was satisfied are disclosed by the claims proof.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ClaimStatement {
+    /// Zero-based index of the claim in the credential's fixed claim vector.
+    pub claim_index: u8,
+    /// When present, proves `min_exclusive < claim`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub min_exclusive: Option<FieldElement>,
+    /// When present, proves `claim < max_exclusive`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_exclusive: Option<FieldElement>,
+}
+
+/// Optional claims predicates requested alongside a nullifier proof.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ClaimsProofRequest {
+    /// Predicates to prove. Each claim index may occur at most once.
+    pub statements: Vec<ClaimStatement>,
+}
+
 /// Encoded World ID Proof.
 ///
 /// Internally, the first 4 elements are a compressed Groth16 proof
@@ -108,6 +133,18 @@ pub struct OwnershipProof {
     pub merkle_root: FieldElement,
 }
 
+/// A presentation-specific proof over private issuer-attested credential claims.
+///
+/// The verifier supplies the remaining public inputs from the RP request, nullifier response,
+/// and issuer registry. The statements are repeated here so the response is self-describing.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ClaimsProof {
+    /// The WHIR R1CS proof from ProveKit.
+    pub proof: provekit_common::WhirR1CSProof,
+    /// Public predicates proven over the private claims.
+    pub statements: Vec<ClaimStatement>,
+}
+
 #[cfg(test)]
 mod tests {
     use ruint::uint;
@@ -194,6 +231,27 @@ mod tests {
         assert!(json.contains("proof"));
         assert!(json.contains("merkle_root"));
         let decoded: OwnershipProof = serde_json::from_str(&json).unwrap();
+        assert_eq!(proof, decoded);
+    }
+
+    #[test]
+    fn test_claims_proof_json_roundtrip() {
+        let proof = ClaimsProof {
+            proof: provekit_common::WhirR1CSProof {
+                narg_string: vec![1, 2, 3],
+                hints: vec![4, 5],
+                #[cfg(debug_assertions)]
+                pattern: vec![],
+            },
+            statements: vec![ClaimStatement {
+                claim_index: 3,
+                min_exclusive: Some(FieldElement::from(18u64)),
+                max_exclusive: Some(FieldElement::from(65u64)),
+            }],
+        };
+
+        let json = serde_json::to_string(&proof).unwrap();
+        let decoded: ClaimsProof = serde_json::from_str(&json).unwrap();
         assert_eq!(proof, decoded);
     }
 

--- a/crates/primitives/src/request/mod.rs
+++ b/crates/primitives/src/request/mod.rs
@@ -6,8 +6,9 @@ mod constraints;
 pub use constraints::{ConstraintExpr, ConstraintKind, ConstraintNode, MAX_CONSTRAINT_NODES};
 
 use crate::{
-    FieldElement, Nullifier, OprfPrefix, OprfPrefixedFieldElement as _, PrimitiveError, SessionId,
-    SessionNullifier, SessionRef, ZeroKnowledgeProof, rp::RpId,
+    ClaimsProof, ClaimsProofRequest, FieldElement, Nullifier, OprfPrefix,
+    OprfPrefixedFieldElement as _, PrimitiveError, SessionId, SessionNullifier, SessionRef,
+    ZeroKnowledgeProof, rp::RpId,
 };
 use serde::{Deserialize, Serialize, de::Error as _};
 use std::collections::HashSet;
@@ -191,6 +192,10 @@ pub struct RequestItem {
     ///
     /// If not provided, this will default to the [`ProofRequest::created_at`] attribute.
     pub expires_at_min: Option<u64>,
+
+    /// Optional predicates to prove over the credential's private claims.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub claims: Option<ClaimsProofRequest>,
 }
 
 impl RequestItem {
@@ -209,6 +214,7 @@ impl RequestItem {
             signal,
             genesis_issued_at_min,
             expires_at_min,
+            claims: None,
         }
     }
 
@@ -314,6 +320,10 @@ pub struct ResponseItem {
     ///
     /// This precise value must be used when verifying the proof on-chain.
     pub expires_at_min: u64,
+
+    /// Optional proof of the claims predicates requested for this credential.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub claims_proof: Option<ClaimsProof>,
 }
 
 impl ProofResponse {
@@ -353,6 +363,7 @@ impl ResponseItem {
             nullifier: Some(nullifier),
             session_nullifier: None,
             expires_at_min,
+            claims_proof: None,
         }
     }
 
@@ -372,6 +383,7 @@ impl ResponseItem {
             nullifier: None,
             session_nullifier: Some(session_nullifier),
             expires_at_min,
+            claims_proof: None,
         }
     }
 
@@ -668,6 +680,26 @@ impl ProofRequest {
                     response_item.expires_at_min,
                 ));
             }
+
+            match (&request_item.claims, &response_item.claims_proof) {
+                (Some(request), Some(proof)) if request.statements == proof.statements => {}
+                (Some(_), Some(_)) => {
+                    return Err(ValidationError::ClaimsStatementsMismatch(
+                        response_item.identifier.clone(),
+                    ));
+                }
+                (Some(_), None) => {
+                    return Err(ValidationError::MissingClaimsProof(
+                        response_item.identifier.clone(),
+                    ));
+                }
+                (None, Some(_)) => {
+                    return Err(ValidationError::UnexpectedClaimsProof(
+                        response_item.identifier.clone(),
+                    ));
+                }
+                (None, None) => {}
+            }
         }
 
         match &self.constraints {
@@ -792,6 +824,15 @@ pub enum ValidationError {
     /// The `expires_at_min` value in the response does not match the expected value from the request
     #[error("Invalid expires_at_min for credential '{0}': expected {1}, got {2}")]
     ExpiresAtMinMismatch(String, u64, u64),
+    /// A request item asked for claims predicates but the response omitted the co-proof.
+    #[error("Missing claims proof for credential '{0}'")]
+    MissingClaimsProof(String),
+    /// A response included a claims co-proof that the request did not ask for.
+    #[error("Unexpected claims proof for credential '{0}'")]
+    UnexpectedClaimsProof(String),
+    /// The claims statements in a response do not match those requested by the RP.
+    #[error("Claims proof statements do not match request for credential '{0}'")]
+    ClaimsStatementsMismatch(String),
     /// Session ID doesn't match between request and response
     #[error("Session ID doesn't match between request and response")]
     SessionIdMismatch,
@@ -915,6 +956,87 @@ mod tests {
         .expect("valid session id")
     }
 
+    fn test_claims_proof(statements: Vec<crate::ClaimStatement>) -> ClaimsProof {
+        ClaimsProof {
+            proof: provekit_common::WhirR1CSProof {
+                narg_string: vec![1, 2, 3],
+                hints: vec![],
+                #[cfg(debug_assertions)]
+                pattern: vec![],
+            },
+            statements,
+        }
+    }
+
+    #[test]
+    fn validate_response_binds_requested_claims_proof() {
+        let statements = vec![crate::ClaimStatement {
+            claim_index: 3,
+            min_exclusive: Some(test_field_element(18)),
+            max_exclusive: Some(test_field_element(65)),
+        }];
+        let request = ProofRequest {
+            id: "claims-request".into(),
+            version: RequestVersion::V1,
+            proof_type: ProofType::Uniqueness,
+            created_at: 1_735_689_600,
+            expires_at: 1_735_689_900,
+            rp_id: RpId::new(1),
+            oprf_key_id: OprfKeyId::new(uint!(1_U160)),
+            session_id: SessionRef::None,
+            action: Some(FieldElement::ZERO),
+            signature: test_signature(),
+            nonce: test_nonce(),
+            requests: vec![RequestItem {
+                identifier: "document".into(),
+                issuer_schema_id: 1,
+                signal: None,
+                genesis_issued_at_min: None,
+                expires_at_min: None,
+                claims: Some(ClaimsProofRequest {
+                    statements: statements.clone(),
+                }),
+            }],
+            constraints: None,
+        };
+        let mut item = ResponseItem::new_uniqueness(
+            "document".into(),
+            1,
+            ZeroKnowledgeProof::default(),
+            test_field_element(1001).into(),
+            request.created_at,
+        );
+        item.claims_proof = Some(test_claims_proof(statements));
+        let response = ProofResponse {
+            id: request.id.clone(),
+            version: request.version,
+            session_id: None,
+            error: None,
+            responses: vec![item],
+        };
+
+        request.validate_response(&response).unwrap();
+
+        let mut missing = response.clone();
+        missing.responses[0].claims_proof = None;
+        assert!(matches!(
+            request.validate_response(&missing),
+            Err(ValidationError::MissingClaimsProof(_))
+        ));
+
+        let mut mismatched = response;
+        mismatched.responses[0]
+            .claims_proof
+            .as_mut()
+            .unwrap()
+            .statements[0]
+            .claim_index = 4;
+        assert!(matches!(
+            request.validate_response(&mismatched),
+            Err(ValidationError::ClaimsStatementsMismatch(_))
+        ));
+    }
+
     #[test]
     fn constraints_all_any_nested() {
         // Build a response that has test_req_1 and test_req_2 provided
@@ -1031,6 +1153,7 @@ mod tests {
                 signal: Some("test_signal".into()),
                 genesis_issued_at_min: None,
                 expires_at_min: None,
+                claims: None,
             }],
             constraints: None,
         };
@@ -1072,6 +1195,7 @@ mod tests {
                 signal: None,
                 genesis_issued_at_min: None,
                 expires_at_min: None,
+                claims: None,
             }],
             constraints: None,
         };
@@ -1115,6 +1239,7 @@ mod tests {
                     signal: None,
                     genesis_issued_at_min: None,
                     expires_at_min: None,
+                    claims: None,
                 },
                 RequestItem {
                     identifier: "document".into(),
@@ -1122,6 +1247,7 @@ mod tests {
                     signal: None,
                     genesis_issued_at_min: None,
                     expires_at_min: None,
+                    claims: None,
                 },
             ],
             constraints: None,
@@ -1260,6 +1386,7 @@ mod tests {
                 signal: None,
                 genesis_issued_at_min: None,
                 expires_at_min: None,
+                claims: None,
             }],
             constraints: Some(deep),
         };
@@ -1329,6 +1456,7 @@ mod tests {
                     signal: None,
                     genesis_issued_at_min: None,
                     expires_at_min: None,
+                    claims: None,
                 },
                 RequestItem {
                     identifier: "test_req_11".into(),
@@ -1336,6 +1464,7 @@ mod tests {
                     signal: None,
                     genesis_issued_at_min: None,
                     expires_at_min: None,
+                    claims: None,
                 },
                 RequestItem {
                     identifier: "test_req_12".into(),
@@ -1343,6 +1472,7 @@ mod tests {
                     signal: None,
                     genesis_issued_at_min: None,
                     expires_at_min: None,
+                    claims: None,
                 },
                 RequestItem {
                     identifier: "test_req_13".into(),
@@ -1350,6 +1480,7 @@ mod tests {
                     signal: None,
                     genesis_issued_at_min: None,
                     expires_at_min: None,
+                    claims: None,
                 },
                 RequestItem {
                     identifier: "test_req_14".into(),
@@ -1357,6 +1488,7 @@ mod tests {
                     signal: None,
                     genesis_issued_at_min: None,
                     expires_at_min: None,
+                    claims: None,
                 },
                 RequestItem {
                     identifier: "test_req_15".into(),
@@ -1364,6 +1496,7 @@ mod tests {
                     signal: None,
                     genesis_issued_at_min: None,
                     expires_at_min: None,
+                    claims: None,
                 },
                 RequestItem {
                     identifier: "test_req_16".into(),
@@ -1371,6 +1504,7 @@ mod tests {
                     signal: None,
                     genesis_issued_at_min: None,
                     expires_at_min: None,
+                    claims: None,
                 },
                 RequestItem {
                     identifier: "test_req_17".into(),
@@ -1378,6 +1512,7 @@ mod tests {
                     signal: None,
                     genesis_issued_at_min: None,
                     expires_at_min: None,
+                    claims: None,
                 },
                 RequestItem {
                     identifier: "test_req_18".into(),
@@ -1385,6 +1520,7 @@ mod tests {
                     signal: None,
                     genesis_issued_at_min: None,
                     expires_at_min: None,
+                    claims: None,
                 },
             ],
             constraints: Some(expr),
@@ -1472,6 +1608,7 @@ mod tests {
                     signal: None,
                     genesis_issued_at_min: None,
                     expires_at_min: None,
+                    claims: None,
                 },
                 RequestItem {
                     identifier: "test_req_21".into(),
@@ -1479,6 +1616,7 @@ mod tests {
                     signal: None,
                     genesis_issued_at_min: None,
                     expires_at_min: None,
+                    claims: None,
                 },
                 RequestItem {
                     identifier: "test_req_22".into(),
@@ -1486,6 +1624,7 @@ mod tests {
                     signal: None,
                     genesis_issued_at_min: None,
                     expires_at_min: None,
+                    claims: None,
                 },
                 RequestItem {
                     identifier: "test_req_23".into(),
@@ -1493,6 +1632,7 @@ mod tests {
                     signal: None,
                     genesis_issued_at_min: None,
                     expires_at_min: None,
+                    claims: None,
                 },
                 RequestItem {
                     identifier: "test_req_24".into(),
@@ -1500,6 +1640,7 @@ mod tests {
                     signal: None,
                     genesis_issued_at_min: None,
                     expires_at_min: None,
+                    claims: None,
                 },
                 RequestItem {
                     identifier: "test_req_25".into(),
@@ -1507,6 +1648,7 @@ mod tests {
                     signal: None,
                     genesis_issued_at_min: None,
                     expires_at_min: None,
+                    claims: None,
                 },
                 RequestItem {
                     identifier: "test_req_26".into(),
@@ -1514,6 +1656,7 @@ mod tests {
                     signal: None,
                     genesis_issued_at_min: None,
                     expires_at_min: None,
+                    claims: None,
                 },
                 RequestItem {
                     identifier: "test_req_27".into(),
@@ -1521,6 +1664,7 @@ mod tests {
                     signal: None,
                     genesis_issued_at_min: None,
                     expires_at_min: None,
+                    claims: None,
                 },
                 RequestItem {
                     identifier: "test_req_28".into(),
@@ -1528,6 +1672,7 @@ mod tests {
                     signal: None,
                     genesis_issued_at_min: None,
                     expires_at_min: None,
+                    claims: None,
                 },
                 RequestItem {
                     identifier: "test_req_29".into(),
@@ -1535,6 +1680,7 @@ mod tests {
                     signal: None,
                     genesis_issued_at_min: None,
                     expires_at_min: None,
+                    claims: None,
                 },
             ],
             constraints: Some(expr),
@@ -1579,6 +1725,7 @@ mod tests {
                 signal: Some("abcd-efgh-ijkl".into()),
                 genesis_issued_at_min: Some(1_725_381_192),
                 expires_at_min: None,
+                claims: None,
             }],
             constraints: None,
         };
@@ -1624,6 +1771,7 @@ mod tests {
                     signal: Some("abcd-efgh-ijkl".into()),
                     genesis_issued_at_min: Some(1_725_381_192),
                     expires_at_min: None,
+                    claims: None,
                 },
                 RequestItem {
                     identifier: "test_req_2".into(),
@@ -1631,6 +1779,7 @@ mod tests {
                     signal: Some("abcd-efgh-ijkl".into()),
                     genesis_issued_at_min: Some(1_725_381_192),
                     expires_at_min: None,
+                    claims: None,
                 },
             ],
             constraints: Some(ConstraintExpr::All {
@@ -1681,6 +1830,7 @@ mod tests {
                     signal: Some("abcd-efgh-ijkl".into()),
                     genesis_issued_at_min: None,
                     expires_at_min: None,
+                    claims: None,
                 },
                 RequestItem {
                     identifier: "test_req_2".into(),
@@ -1688,6 +1838,7 @@ mod tests {
                     signal: Some("mnop-qrst-uvwx".into()),
                     genesis_issued_at_min: None,
                     expires_at_min: None,
+                    claims: None,
                 },
                 RequestItem {
                     identifier: "test_req_3".into(),
@@ -1695,6 +1846,7 @@ mod tests {
                     signal: Some("abcd-efgh-ijkl".into()),
                     genesis_issued_at_min: None,
                     expires_at_min: None,
+                    claims: None,
                 },
             ],
             constraints: Some(ConstraintExpr::All {
@@ -1758,6 +1910,7 @@ mod tests {
                     signal: None,
                     genesis_issued_at_min: None,
                     expires_at_min: None,
+                    claims: None,
                 },
                 RequestItem {
                     identifier: "national_id".into(),
@@ -1765,6 +1918,7 @@ mod tests {
                     signal: None,
                     genesis_issued_at_min: None,
                     expires_at_min: None,
+                    claims: None,
                 },
             ],
             constraints: Some(ConstraintExpr::Enumerate {
@@ -1989,6 +2143,7 @@ mod tests {
                     signal: None,
                     genesis_issued_at_min: None,
                     expires_at_min: None,
+                    claims: None,
                 },
                 RequestItem {
                     identifier: "test_req_2".into(),
@@ -1996,6 +2151,7 @@ mod tests {
                     signal: None,
                     genesis_issued_at_min: None,
                     expires_at_min: None,
+                    claims: None,
                 },
             ],
             constraints: None,
@@ -2031,6 +2187,7 @@ mod tests {
                 signal: None,
                 genesis_issued_at_min: None,
                 expires_at_min: None,
+                claims: None,
             }],
             constraints: None,
         };
@@ -2098,6 +2255,7 @@ mod tests {
                     signal: None,
                     genesis_issued_at_min: None,
                     expires_at_min: None,
+                    claims: None,
                 },
                 RequestItem {
                     identifier: "passport".into(),
@@ -2105,6 +2263,7 @@ mod tests {
                     signal: None,
                     genesis_issued_at_min: None,
                     expires_at_min: None,
+                    claims: None,
                 },
             ],
             constraints: None,
@@ -2146,6 +2305,7 @@ mod tests {
                     signal: None,
                     genesis_issued_at_min: None,
                     expires_at_min: None,
+                    claims: None,
                 },
                 RequestItem {
                     identifier: "passport".into(),
@@ -2153,6 +2313,7 @@ mod tests {
                     signal: None,
                     genesis_issued_at_min: None,
                     expires_at_min: None,
+                    claims: None,
                 },
                 RequestItem {
                     identifier: "national_id".into(),
@@ -2160,6 +2321,7 @@ mod tests {
                     signal: None,
                     genesis_issued_at_min: None,
                     expires_at_min: None,
+                    claims: None,
                 },
             ],
             constraints: Some(ConstraintExpr::All {
@@ -2219,6 +2381,7 @@ mod tests {
                     signal: None,
                     genesis_issued_at_min: None,
                     expires_at_min: None,
+                    claims: None,
                 },
                 RequestItem {
                     identifier: "passport".into(),
@@ -2226,6 +2389,7 @@ mod tests {
                     signal: None,
                     genesis_issued_at_min: None,
                     expires_at_min: None,
+                    claims: None,
                 },
                 RequestItem {
                     identifier: "national_id".into(),
@@ -2233,6 +2397,7 @@ mod tests {
                     signal: None,
                     genesis_issued_at_min: None,
                     expires_at_min: None,
+                    claims: None,
                 },
             ],
             constraints: Some(ConstraintExpr::Enumerate {
@@ -2286,6 +2451,7 @@ mod tests {
                     signal: None,
                     genesis_issued_at_min: None,
                     expires_at_min: None,
+                    claims: None,
                 },
                 RequestItem {
                     identifier: "passport".into(),
@@ -2293,6 +2459,7 @@ mod tests {
                     signal: None,
                     genesis_issued_at_min: None,
                     expires_at_min: None,
+                    claims: None,
                 },
                 RequestItem {
                     identifier: "national_id".into(),
@@ -2300,6 +2467,7 @@ mod tests {
                     signal: None,
                     genesis_issued_at_min: None,
                     expires_at_min: None,
+                    claims: None,
                 },
             ],
             constraints: Some(ConstraintExpr::All {
@@ -2347,6 +2515,7 @@ mod tests {
             signal: None,
             genesis_issued_at_min: None,
             expires_at_min: None,
+            claims: None,
         };
         assert_eq!(
             item_with_none.effective_expires_at_min(request_created_at),
@@ -2361,6 +2530,7 @@ mod tests {
             signal: None,
             genesis_issued_at_min: None,
             expires_at_min: Some(custom_expires_at),
+            claims: None,
         };
         assert_eq!(
             item_with_custom.effective_expires_at_min(request_created_at),
@@ -2395,6 +2565,7 @@ mod tests {
                     signal: None,
                     genesis_issued_at_min: None,
                     expires_at_min: None, // Should default to request_created_at
+                    claims: None,
                 },
                 RequestItem {
                     identifier: "document".into(),
@@ -2402,6 +2573,7 @@ mod tests {
                     signal: None,
                     genesis_issued_at_min: None,
                     expires_at_min: Some(custom_expires_at), // Explicit value
+                    claims: None,
                 },
             ],
             constraints: None,
@@ -2521,6 +2693,7 @@ mod tests {
                 signal: None,
                 genesis_issued_at_min: None,
                 expires_at_min: None,
+                claims: None,
             }],
             constraints: None,
         };
@@ -2634,6 +2807,7 @@ mod tests {
                 signal: None,
                 genesis_issued_at_min: None,
                 expires_at_min: None,
+                claims: None,
             }],
             constraints: None,
         };
@@ -2667,6 +2841,7 @@ mod tests {
                 signal: None,
                 genesis_issued_at_min: None,
                 expires_at_min: None,
+                claims: None,
             }],
             constraints: None,
         };
@@ -2704,6 +2879,7 @@ mod tests {
                 signal: None,
                 genesis_issued_at_min: None,
                 expires_at_min: None,
+                claims: None,
             }],
             constraints: None,
         };
@@ -2786,6 +2962,7 @@ mod tests {
                 signal: None,
                 genesis_issued_at_min: None,
                 expires_at_min: None,
+                claims: None,
             }],
             constraints: None,
         };
@@ -2835,6 +3012,7 @@ mod tests {
                 signal: None,
                 genesis_issued_at_min: None,
                 expires_at_min: None,
+                claims: None,
             }],
             constraints: None,
         };
@@ -2885,6 +3063,7 @@ mod tests {
                 signal: None,
                 genesis_issued_at_min: None,
                 expires_at_min: None,
+                claims: None,
             }],
             constraints: None,
         };
@@ -2931,6 +3110,7 @@ mod tests {
                 signal: None,
                 genesis_issued_at_min: None,
                 expires_at_min: None,
+                claims: None,
             }],
             constraints: None,
         };
@@ -2980,6 +3160,7 @@ mod tests {
                 signal: None,
                 genesis_issued_at_min: None,
                 expires_at_min: None,
+                claims: None,
             }],
             constraints: None,
         };

--- a/crates/proof/Cargo.toml
+++ b/crates/proof/Cargo.toml
@@ -23,7 +23,14 @@ zstd-compress-zkeys = ["embed-zkeys", "dep:zstd"]
 
 embed-ownership-prover = ["dep:provekit-r1cs-compiler"]
 embed-ownership-verifier = ["dep:provekit-r1cs-compiler"]
-embed-noir-artifacts = ["embed-ownership-prover", "embed-ownership-verifier"]
+embed-claims-prover = ["dep:provekit-r1cs-compiler"]
+embed-claims-verifier = ["dep:provekit-r1cs-compiler"]
+embed-noir-artifacts = [
+    "embed-ownership-prover",
+    "embed-ownership-verifier",
+    "embed-claims-prover",
+    "embed-claims-verifier",
+]
 
 # Embed everything
 embed-zk-artifacts = ["embed-zkeys", "embed-noir-artifacts"]

--- a/crates/proof/README.md
+++ b/crates/proof/README.md
@@ -15,7 +15,8 @@ Each ZK artifact type has exactly one way of being obtained:
   and otherwise downloads them from the GitHub release tag pinned in `build.rs`.
   Material loaders verify them against SHA-256 fingerprints pinned in `src/oprf_query.rs`
   (query proof) and `src/nullifier_proof.rs` (nullifier proof).
-- **Noir ownership proof artifacts** (`ownership_proof.pkp` / `.pkv`) are always built
+- **Noir proof artifacts** (`ownership_proof.pkp` / `.pkv` and
+  `claims_proof.pkp` / `.pkv`) are always built
   ad-hoc by `build.rs` from the checked-in circuit source using `nargo`. The required
   `nargo` version is pinned (see `flake.nix` and `REQUIRED_NARGO_VERSION` in `build.rs`); the build
   fails if a different version is on PATH, since a version mismatch can produce keys
@@ -42,7 +43,7 @@ At runtime, zkeys are decompressed in memory during initialization.
 
 ##### `embed-ownership-prover` / `embed-ownership-verifier`
 
-build.rs will build the Noir ownership proof artifacts with `nargo` and embed the selected
+build.rs will build the Noir ownership-proof artifacts with `nargo` and embed the selected
 one(s) into the binary. The prover is multi-MB; verifying-only consumers should enable just
 the verifier. Requires `nargo` on PATH at the pinned version — use `nix develop` or:
 
@@ -50,9 +51,14 @@ the verifier. Requires `nargo` on PATH at the pinned version — use `nix develo
 noirup --version v1.0.0-beta.11
 ```
 
+##### `embed-claims-prover` / `embed-claims-verifier`
+
+build.rs will build and embed the selected claims co-proof material. Authenticators need
+the prover; RP-side native verifiers need the verifier.
+
 ##### Umbrellas
 
-- `embed-noir-artifacts` = ownership prover + verifier
+- `embed-noir-artifacts` = ownership and claims provers + verifiers
 - `embed-zk-artifacts` = everything
 
 ## Circom circuit artifacts
@@ -76,8 +82,8 @@ attaches the Circom artifact files listed above (committed in this repository). 
 publishing a new tag, update both the pinned tag in `build.rs` and the pinned SHA-256
 fingerprints in `src/oprf_query.rs` and `src/nullifier_proof.rs`.
 
-## Noir ownership proof
+## Noir proofs
 
-The Noir ownership proof APIs are available on native targets. They can either use explicit
-prover/verifier material loaded from readers or paths, or embedded artifacts when the
-corresponding `embed-ownership-prover` / `embed-ownership-verifier` feature is enabled.
+The Noir ownership and claims proof interfaces are available on native targets. They can use
+explicit prover/verifier material loaded from readers or paths, or embedded artifacts when the
+corresponding feature is enabled.

--- a/crates/proof/build.rs
+++ b/crates/proof/build.rs
@@ -33,7 +33,9 @@ fn main() -> eyre::Result<()> {
 
     #[cfg(any(
         feature = "embed-ownership-prover",
-        feature = "embed-ownership-verifier"
+        feature = "embed-ownership-verifier",
+        feature = "embed-claims-prover",
+        feature = "embed-claims-verifier"
     ))]
     if noir_artifacts::should_embed() {
         noir_artifacts::setup(&out_dir)?;
@@ -228,7 +230,9 @@ fn ark_compress_zkeys(out_dir: &Path) -> eyre::Result<()> {
 
 #[cfg(any(
     feature = "embed-ownership-prover",
-    feature = "embed-ownership-verifier"
+    feature = "embed-ownership-verifier",
+    feature = "embed-claims-prover",
+    feature = "embed-claims-verifier"
 ))]
 mod noir_artifacts {
     use std::process::Command;
@@ -246,7 +250,9 @@ mod noir_artifacts {
         let target_arch = env::var("CARGO_CFG_TARGET_ARCH").ok();
         target_arch.as_deref() != Some("wasm32")
             && (env::var_os("CARGO_FEATURE_EMBED_OWNERSHIP_PROVER").is_some()
-                || env::var_os("CARGO_FEATURE_EMBED_OWNERSHIP_VERIFIER").is_some())
+                || env::var_os("CARGO_FEATURE_EMBED_OWNERSHIP_VERIFIER").is_some()
+                || env::var_os("CARGO_FEATURE_EMBED_CLAIMS_PROVER").is_some()
+                || env::var_os("CARGO_FEATURE_EMBED_CLAIMS_VERIFIER").is_some())
     }
 
     /// Checks that `nargo` is on PATH and is exactly [`REQUIRED_NARGO_VERSION`].
@@ -261,8 +267,8 @@ mod noir_artifacts {
             .map_err(|e| {
                 if e.kind() == std::io::ErrorKind::NotFound {
                     eyre::eyre!(
-                        "`nargo` was not found on PATH. It is required to build the Noir ownership \
-                         proof artifacts. Install it with `nix develop` (the repo flake pins the \
+                        "`nargo` was not found on PATH. It is required to build the Noir proof \
+                         artifacts. Install it with `nix develop` (the repo flake pins the \
                          right version) or `noirup --version v{REQUIRED_NARGO_VERSION}`"
                     )
                 } else {
@@ -282,15 +288,38 @@ mod noir_artifacts {
         Ok(())
     }
 
-    /// Builds the Noir ownership proof artifacts ad-hoc with `nargo` and the
+    /// Builds the selected Noir proof artifacts ad-hoc with `nargo` and the
     /// provekit R1CS compiler. This is the only way to obtain them: the
     /// proving/verifying keys must come from the checked-in circuit source, built
     /// with the pinned nargo toolchain (see `flake.nix`), so every builder
     /// produces identical bytes.
     pub(super) fn setup(out_dir: &Path) -> eyre::Result<()> {
         let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR")?);
-        let circuit_dir = manifest_dir.join("noir/ownership-proof");
+        check_nargo()?;
 
+        if env::var_os("CARGO_FEATURE_EMBED_OWNERSHIP_PROVER").is_some()
+            || env::var_os("CARGO_FEATURE_EMBED_OWNERSHIP_VERIFIER").is_some()
+        {
+            build_circuit(
+                &manifest_dir.join("noir/ownership-proof"),
+                "ownership_proof",
+                out_dir,
+            )?;
+        }
+        if env::var_os("CARGO_FEATURE_EMBED_CLAIMS_PROVER").is_some()
+            || env::var_os("CARGO_FEATURE_EMBED_CLAIMS_VERIFIER").is_some()
+        {
+            build_circuit(
+                &manifest_dir.join("noir/claims-proof"),
+                "claims_proof",
+                out_dir,
+            )?;
+        }
+
+        Ok(())
+    }
+
+    fn build_circuit(circuit_dir: &Path, artifact_name: &str, out_dir: &Path) -> eyre::Result<()> {
         println!(
             "cargo:rerun-if-changed={}",
             circuit_dir.join("src").display()
@@ -299,8 +328,6 @@ mod noir_artifacts {
             "cargo:rerun-if-changed={}",
             circuit_dir.join("Nargo.toml").display()
         );
-
-        check_nargo()?;
 
         let nargo_output = Command::new("nargo")
             .arg("compile")
@@ -313,18 +340,22 @@ mod noir_artifacts {
             eyre::bail!("nargo compile failed:\n{stderr}");
         }
 
-        let scheme = NoirProofScheme::from_file(circuit_dir.join("target/ownership_proof.json"))
-            .map_err(|e| eyre::eyre!(e.to_string()))?;
+        let scheme = NoirProofScheme::from_file(
+            circuit_dir
+                .join("target")
+                .join(format!("{artifact_name}.json")),
+        )
+        .map_err(|e| eyre::eyre!(e.to_string()))?;
 
         provekit_common::file::write(
             &Prover::from_noir_proof_scheme(scheme.clone()),
-            &out_dir.join("ownership_proof.pkp"),
+            &out_dir.join(format!("{artifact_name}.pkp")),
         )
         .map_err(|e| eyre::eyre!(e.to_string()))?;
 
         provekit_common::file::write(
             &Verifier::from_noir_proof_scheme(scheme),
-            &out_dir.join("ownership_proof.pkv"),
+            &out_dir.join(format!("{artifact_name}.pkv")),
         )
         .map_err(|e| eyre::eyre!(e.to_string()))?;
 

--- a/crates/proof/noir/claims-proof/Nargo.toml
+++ b/crates/proof/noir/claims-proof/Nargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "claims_proof"
+type = "bin"
+description = "PROTOTYPE: selectively disclose issuer-attested credential claims"
+authors = ["@dzejkop"]
+backend = "provekit"
+
+[dependencies]
+poseidon2 = { tag = "v0.5.0-beta.0", git = "https://github.com/TaceoLabs/noir-poseidon", directory = "poseidon2" }
+eddsa_poseidon2 = { tag = "taceo-oprf-v0.12.0", git = "https://github.com/TaceoLabs/oprf-service.git", directory = "noir/eddsa_poseidon2" }

--- a/crates/proof/noir/claims-proof/README.md
+++ b/crates/proof/noir/claims-proof/README.md
@@ -1,0 +1,32 @@
+# Claims proof prototype
+
+This is a proof-of-concept companion to the Circom `OPRFNullifier` proof. It
+shows that public predicates hold over private credential claims without
+revealing the credential's stable `claims_hash`.
+
+The circuit proves that:
+
+1. the private claims produce the `claims_hash` embedded in a valid issuer
+   signature;
+2. the public `salted_claims_hash` commits to that private `claims_hash`;
+3. the public statements hold over the private claims; and
+4. the issuer-attested credential subject and the public nullifier are derived
+   from the same private World ID leaf index.
+
+The RP verifies the Circom nullifier proof and this proof with the same public
+`nullifier`, `issuer_schema_id`, `cred_pk`, `rp_id`, `action`, and time policy.
+This circuit intentionally does not duplicate the Circom proof's authenticator
+signature, Merkle inclusion, DLog equality, or OPRF unblinding constraints.
+
+The salt must be fresh and unpredictable for each presentation. Freshness is a
+protocol requirement and cannot be enforced by this circuit.
+
+Run the POC with the repository-pinned Noir toolchain:
+
+```sh
+nix develop --command sh -c \
+  'cd crates/proof/noir/claims-proof && nargo fmt --check && nargo test && nargo compile'
+```
+
+This directory is intentionally marked as a prototype and is not wired into
+the Rust proof-generation interface or release artifacts.

--- a/crates/proof/noir/claims-proof/README.md
+++ b/crates/proof/noir/claims-proof/README.md
@@ -8,18 +8,15 @@ The circuit proves that:
 
 1. the private claims produce the `claims_hash` embedded in a valid issuer
    signature;
-2. the public `salted_claims_hash` commits to that private `claims_hash`;
-3. the public statements hold over the private claims; and
-4. the issuer-attested credential subject and the public nullifier are derived
+2. the public statements hold over the private claims; and
+3. the issuer-attested credential subject and the public nullifier are derived
    from the same private World ID leaf index.
 
 The RP verifies the Circom nullifier proof and this proof with the same public
 `nullifier`, `issuer_schema_id`, `cred_pk`, `rp_id`, `action`, and time policy.
-This circuit intentionally does not duplicate the Circom proof's authenticator
-signature, Merkle inclusion, DLog equality, or OPRF unblinding constraints.
-
-The salt must be fresh and unpredictable for each presentation. Freshness is a
-protocol requirement and cannot be enforced by this circuit.
+This circuit intentionally does not duplicate the
+Circom proof's authenticator signature, Merkle inclusion, DLog equality, or OPRF
+unblinding constraints.
 
 Run the POC with the repository-pinned Noir toolchain:
 
@@ -28,5 +25,6 @@ nix develop --command sh -c \
   'cd crates/proof/noir/claims-proof && nargo fmt --check && nargo test && nargo compile'
 ```
 
-This directory is intentionally marked as a prototype and is not wired into
-the Rust proof-generation interface or release artifacts.
+The native Rust proof interface compiles this circuit into ProveKit artifacts when
+`embed-claims-prover` or `embed-claims-verifier` is enabled. Filesystem artifact sources can
+instead provide `claims_proof.pkp` and `claims_proof.pkv` at runtime.

--- a/crates/proof/noir/claims-proof/src/main.nr
+++ b/crates/proof/noir/claims-proof/src/main.nr
@@ -5,7 +5,7 @@ use std::field::bn254::assert_lt;
 global NUM_CLAIMS: u32 = 15;
 global MAX_U64_PLUS_ONE: Field = 18446744073709551616;
 
-// These values match the capacity elements in `oprf_nullifier.circom`.
+// Protocol domain separators, represented as capacity field elements.
 global DS_CREDENTIAL_SUB: Field = 87492525752134038588518953; // b"H_CS(id, r)"
 global DS_CREDENTIAL: Field = 1790969822004668215611014194230797064349043274; // b"POSEIDON2+EDDSA-BJJ"
 global DS_OPRF_QUERY: Field = 1773399373884719043551600379785849; // b"World ID Query"
@@ -21,9 +21,7 @@ pub struct ClaimsStatement {
     pub range_check_max: Field,
 }
 
-pub struct ClaimsDisclosureInputs {
-    pub salt: Field,
-    pub salted_claims_hash: Field,
+pub struct ClaimsStatementInputs {
     pub statements: [ClaimsStatement; NUM_CLAIMS],
 }
 
@@ -41,7 +39,7 @@ pub struct NullifierPublicInputs {
 }
 
 pub struct ClaimsProofPublicInputs {
-    pub disclosure: ClaimsDisclosureInputs,
+    pub claims: ClaimsStatementInputs,
     pub credential: CredentialPublicInputs,
     pub nullifier: NullifierPublicInputs,
 }
@@ -75,10 +73,6 @@ fn calculate_claims_hash(claims: [Field; NUM_CLAIMS]) -> Field {
         state[i] = claims[i];
     }
     perm::x5_16(state)[1]
-}
-
-fn calculate_salted_claims_hash(salt: Field, claims_hash: Field) -> Field {
-    perm::x5_4([salt, claims_hash, 0, 0])[1]
 }
 
 fn calculate_credential_subject(leaf_index: Field, blinder: Field) -> Field {
@@ -142,14 +136,7 @@ fn check_claim_statements(claims: [Field; NUM_CLAIMS], statements: [ClaimsStatem
 /// proofs against the same `nullifier`, `issuer_schema_id`, `cred_pk`, `rp_id`,
 /// `action`, and time policy.
 fn main(public_inputs: pub ClaimsProofPublicInputs, private_inputs: ClaimsProofPrivateInputs) {
-    assert(public_inputs.disclosure.salt != 0, "salt must not be zero");
-
     let claims_hash = calculate_claims_hash(private_inputs.claims);
-    assert(
-        calculate_salted_claims_hash(public_inputs.disclosure.salt, claims_hash)
-            == public_inputs.disclosure.salted_claims_hash,
-        "salted claims hash mismatch",
-    );
 
     let subject = calculate_credential_subject(
         private_inputs.nullifier.leaf_index,
@@ -195,7 +182,7 @@ fn main(public_inputs: pub ClaimsProofPublicInputs, private_inputs: ClaimsProofP
         private_inputs.credential.cred_genesis_issued_at + 1,
     );
 
-    check_claim_statements(private_inputs.claims, public_inputs.disclosure.statements);
+    check_claim_statements(private_inputs.claims, public_inputs.claims.statements);
 
     assert(
         calculate_nullifier(
@@ -211,13 +198,12 @@ fn main(public_inputs: pub ClaimsProofPublicInputs, private_inputs: ClaimsProofP
 
 mod tests {
     use super::{
-        calculate_claims_hash, calculate_nullifier, calculate_salted_claims_hash,
-        check_claim_statements, ClaimsDisclosureInputs, ClaimsProofPrivateInputs,
-        ClaimsProofPublicInputs, ClaimsStatement, CredentialPrivateInputs, CredentialPublicInputs,
-        main, NullifierPrivateInputs, NullifierPublicInputs, NUM_CLAIMS,
+        calculate_claims_hash, calculate_nullifier, check_claim_statements,
+        ClaimsProofPrivateInputs, ClaimsProofPublicInputs, ClaimsStatement, ClaimsStatementInputs,
+        CredentialPrivateInputs, CredentialPublicInputs, main, NullifierPrivateInputs,
+        NullifierPublicInputs, NUM_CLAIMS,
     };
 
-    global SALT: Field = 340282366920938463463374607431768211507;
     global ISSUER_SCHEMA_ID: Field = 1;
     global CRED_PK: [Field; 2] = [
         21825204959029483311433036009853709113262520481918849765727459753607131160346,
@@ -262,13 +248,9 @@ mod tests {
         }
     }
 
-    fn fixture_public_inputs(salted_claims_hash: Field) -> ClaimsProofPublicInputs {
+    fn fixture_public_inputs() -> ClaimsProofPublicInputs {
         ClaimsProofPublicInputs {
-            disclosure: ClaimsDisclosureInputs {
-                salt: SALT,
-                salted_claims_hash,
-                statements: no_statements(),
-            },
+            claims: ClaimsStatementInputs { statements: no_statements() },
             credential: CredentialPublicInputs {
                 issuer_schema_id: ISSUER_SCHEMA_ID,
                 cred_pk: CRED_PK,
@@ -305,8 +287,7 @@ mod tests {
     #[test]
     fn test_full_attested_claims_flow() {
         let inputs = fixture_inputs();
-        let salted_claims_hash = calculate_salted_claims_hash(SALT, EXPECTED_CLAIMS_HASH);
-        main(fixture_public_inputs(salted_claims_hash), inputs);
+        main(fixture_public_inputs(), inputs);
     }
 
     #[test]
@@ -323,9 +304,7 @@ mod tests {
     fn test_tampered_claim_is_not_attested() {
         let mut inputs = fixture_inputs();
         inputs.claims[0] = 1;
-        let salted_claims_hash =
-            calculate_salted_claims_hash(SALT, calculate_claims_hash(inputs.claims));
-        main(fixture_public_inputs(salted_claims_hash), inputs);
+        main(fixture_public_inputs(), inputs);
     }
 
     #[test(should_fail_with = "minimum check must be boolean")]

--- a/crates/proof/noir/claims-proof/src/main.nr
+++ b/crates/proof/noir/claims-proof/src/main.nr
@@ -1,0 +1,338 @@
+use eddsa_poseidon2::verify_eddsa_poseidon2;
+use poseidon2::bn254::perm;
+use std::field::bn254::assert_lt;
+
+global NUM_CLAIMS: u32 = 15;
+global MAX_U64_PLUS_ONE: Field = 18446744073709551616;
+
+// These values match the capacity elements in `oprf_nullifier.circom`.
+global DS_CREDENTIAL_SUB: Field = 87492525752134038588518953; // b"H_CS(id, r)"
+global DS_CREDENTIAL: Field = 1790969822004668215611014194230797064349043274; // b"POSEIDON2+EDDSA-BJJ"
+global DS_OPRF_QUERY: Field = 1773399373884719043551600379785849; // b"World ID Query"
+global DS_NULLIFIER: Field = 1773399373884719043551596035141478; // b"World ID Proof"
+
+/// A public predicate over the claim in the corresponding fixed credential slot.
+///
+/// `checks[0]` enables the strict lower bound and `checks[1]` enables the strict
+/// upper bound. The claim itself remains private.
+pub struct ClaimsStatement {
+    pub checks: [Field; 2],
+    pub range_check_min: Field,
+    pub range_check_max: Field,
+}
+
+pub struct ClaimsDisclosureInputs {
+    pub salt: Field,
+    pub salted_claims_hash: Field,
+    pub statements: [ClaimsStatement; NUM_CLAIMS],
+}
+
+pub struct CredentialPublicInputs {
+    pub issuer_schema_id: Field,
+    pub cred_pk: [Field; 2],
+    pub current_timestamp: Field,
+    pub cred_genesis_issued_at_min: Field,
+}
+
+pub struct NullifierPublicInputs {
+    pub value: Field,
+    pub rp_id: Field,
+    pub action: Field,
+}
+
+pub struct ClaimsProofPublicInputs {
+    pub disclosure: ClaimsDisclosureInputs,
+    pub credential: CredentialPublicInputs,
+    pub nullifier: NullifierPublicInputs,
+}
+
+pub struct CredentialPrivateInputs {
+    pub cred_genesis_issued_at: Field,
+    pub cred_expires_at: Field,
+    pub associated_data_hash: Field,
+    pub cred_id: Field,
+    pub cred_user_id_r: Field,
+    pub cred_s: Field,
+    pub cred_r: [Field; 2],
+}
+
+pub struct NullifierPrivateInputs {
+    pub leaf_index: Field,
+    pub oprf_response: [Field; 2],
+}
+
+/// Private values which connect the issuer-attested claims to the nullifier.
+pub struct ClaimsProofPrivateInputs {
+    pub claims: [Field; NUM_CLAIMS],
+    pub credential: CredentialPrivateInputs,
+    pub nullifier: NullifierPrivateInputs,
+}
+
+fn calculate_claims_hash(claims: [Field; NUM_CLAIMS]) -> Field {
+    // Credential V1 puts the 15 claims in the rate and zero in the capacity.
+    let mut state: [Field; 16] = [0; 16];
+    for i in 0..NUM_CLAIMS {
+        state[i] = claims[i];
+    }
+    perm::x5_16(state)[1]
+}
+
+fn calculate_salted_claims_hash(salt: Field, claims_hash: Field) -> Field {
+    perm::x5_4([salt, claims_hash, 0, 0])[1]
+}
+
+fn calculate_credential_subject(leaf_index: Field, blinder: Field) -> Field {
+    perm::x5_3([DS_CREDENTIAL_SUB, leaf_index, blinder])[1]
+}
+
+fn calculate_credential_message(
+    issuer_schema_id: Field,
+    subject: Field,
+    genesis_issued_at: Field,
+    expires_at: Field,
+    claims_hash: Field,
+    associated_data_hash: Field,
+    cred_id: Field,
+) -> Field {
+    perm::x5_8([
+        DS_CREDENTIAL,
+        issuer_schema_id,
+        subject,
+        genesis_issued_at,
+        expires_at,
+        claims_hash,
+        associated_data_hash,
+        cred_id,
+    ])[1]
+}
+
+fn calculate_nullifier(
+    leaf_index: Field,
+    rp_id: Field,
+    action: Field,
+    oprf_response: [Field; 2],
+) -> Field {
+    let query = perm::x5_4([DS_OPRF_QUERY, leaf_index, rp_id, action])[1];
+    perm::x5_4([DS_NULLIFIER, query, oprf_response[0], oprf_response[1]])[1]
+}
+
+fn check_claim_statements(claims: [Field; NUM_CLAIMS], statements: [ClaimsStatement; NUM_CLAIMS]) {
+    for i in 0..NUM_CLAIMS {
+        let check_min = statements[i].checks[0];
+        let check_max = statements[i].checks[1];
+
+        // Do not allow an arbitrary field value to silently disable a check.
+        assert(check_min * (check_min - 1) == 0, "minimum check must be boolean");
+        assert(check_max * (check_max - 1) == 0, "maximum check must be boolean");
+
+        if check_min == 1 {
+            assert_lt(statements[i].range_check_min, claims[i]);
+        }
+        if check_max == 1 {
+            assert_lt(claims[i], statements[i].range_check_max);
+        }
+    }
+}
+
+/// PROTOTYPE: proves public predicates about private issuer-attested claims and
+/// binds them to the same hidden leaf index used to derive `nullifier`.
+///
+/// This deliberately does not re-prove the authenticator/Merkle/DLog/unblinding
+/// parts of the companion Circom nullifier proof. The verifier must verify both
+/// proofs against the same `nullifier`, `issuer_schema_id`, `cred_pk`, `rp_id`,
+/// `action`, and time policy.
+fn main(public_inputs: pub ClaimsProofPublicInputs, private_inputs: ClaimsProofPrivateInputs) {
+    assert(public_inputs.disclosure.salt != 0, "salt must not be zero");
+
+    let claims_hash = calculate_claims_hash(private_inputs.claims);
+    assert(
+        calculate_salted_claims_hash(public_inputs.disclosure.salt, claims_hash)
+            == public_inputs.disclosure.salted_claims_hash,
+        "salted claims hash mismatch",
+    );
+
+    let subject = calculate_credential_subject(
+        private_inputs.nullifier.leaf_index,
+        private_inputs.credential.cred_user_id_r,
+    );
+    let credential_message = calculate_credential_message(
+        public_inputs.credential.issuer_schema_id,
+        subject,
+        private_inputs.credential.cred_genesis_issued_at,
+        private_inputs.credential.cred_expires_at,
+        claims_hash,
+        private_inputs.credential.associated_data_hash,
+        private_inputs.credential.cred_id,
+    );
+    assert(
+        verify_eddsa_poseidon2(
+            public_inputs.credential.cred_pk[0],
+            public_inputs.credential.cred_pk[1],
+            private_inputs.credential.cred_s,
+            private_inputs.credential.cred_r,
+            credential_message,
+        ),
+        "invalid credential signature",
+    );
+
+    // Mirror the credential timestamp semantics from `CheckCredentialSignature`.
+    assert_lt(
+        private_inputs.credential.cred_genesis_issued_at,
+        MAX_U64_PLUS_ONE,
+    );
+    assert_lt(private_inputs.credential.cred_expires_at, MAX_U64_PLUS_ONE);
+    assert_lt(public_inputs.credential.current_timestamp, MAX_U64_PLUS_ONE);
+    assert_lt(
+        public_inputs.credential.cred_genesis_issued_at_min,
+        MAX_U64_PLUS_ONE,
+    );
+    assert_lt(
+        public_inputs.credential.current_timestamp,
+        private_inputs.credential.cred_expires_at,
+    );
+    assert_lt(
+        public_inputs.credential.cred_genesis_issued_at_min,
+        private_inputs.credential.cred_genesis_issued_at + 1,
+    );
+
+    check_claim_statements(private_inputs.claims, public_inputs.disclosure.statements);
+
+    assert(
+        calculate_nullifier(
+            private_inputs.nullifier.leaf_index,
+            public_inputs.nullifier.rp_id,
+            public_inputs.nullifier.action,
+            private_inputs.nullifier.oprf_response,
+        )
+            == public_inputs.nullifier.value,
+        "nullifier mismatch",
+    );
+}
+
+mod tests {
+    use super::{
+        calculate_claims_hash, calculate_nullifier, calculate_salted_claims_hash,
+        check_claim_statements, ClaimsDisclosureInputs, ClaimsProofPrivateInputs,
+        ClaimsProofPublicInputs, ClaimsStatement, CredentialPrivateInputs, CredentialPublicInputs,
+        main, NullifierPrivateInputs, NullifierPublicInputs, NUM_CLAIMS,
+    };
+
+    global SALT: Field = 340282366920938463463374607431768211507;
+    global ISSUER_SCHEMA_ID: Field = 1;
+    global CRED_PK: [Field; 2] = [
+        21825204959029483311433036009853709113262520481918849765727459753607131160346,
+        8339486770249821464793634710648189540136988043780169655155172519121840615364,
+    ];
+    global RP_ID: Field = 950325648507560155068233096743093215539447660945;
+    global ACTION: Field =
+        84721944028150696728472418813119358007006361082259892623669024918011698311;
+    global CURRENT_TIMESTAMP: Field = 1767868101;
+    global GENESIS_ISSUED_AT_MIN: Field = 0;
+    global EXPECTED_NULLIFIER: Field =
+        21342856517406476000190785734870568200315738457615815351702849709270076362125;
+    global EXPECTED_CLAIMS_HASH: Field =
+        14272087287699568472569351444185311392108883722570788958733484799744115401870;
+
+    fn no_statements() -> [ClaimsStatement; NUM_CLAIMS] {
+        [ClaimsStatement { checks: [0, 0], range_check_min: 0, range_check_max: 0 }; NUM_CLAIMS]
+    }
+
+    fn fixture_inputs() -> ClaimsProofPrivateInputs {
+        ClaimsProofPrivateInputs {
+            claims: [0; NUM_CLAIMS],
+            credential: CredentialPrivateInputs {
+                cred_genesis_issued_at: 1767868120,
+                cred_expires_at: 1767868180,
+                associated_data_hash: 0,
+                cred_id: 12176925761186149284,
+                cred_user_id_r: 19016519542686775328775746932795543103858066763212549618980890183285781521458,
+                cred_s: 1785197794318390548654263507521729446174585997835004080357493002880021427752,
+                cred_r: [
+                    9716162517813998269973089361571651784159199085806289463178774674474552458864,
+                    6858161934880479087336794169055762635352680692798466775715085760374212641424,
+                ],
+            },
+            nullifier: NullifierPrivateInputs {
+                leaf_index: 1,
+                oprf_response: [
+                    11771927497930831763844779626723106344742708040976110136703486119568919340013,
+                    19299702061490581533153169629464406607119112637706400365988657399831357218309,
+                ],
+            },
+        }
+    }
+
+    fn fixture_public_inputs(salted_claims_hash: Field) -> ClaimsProofPublicInputs {
+        ClaimsProofPublicInputs {
+            disclosure: ClaimsDisclosureInputs {
+                salt: SALT,
+                salted_claims_hash,
+                statements: no_statements(),
+            },
+            credential: CredentialPublicInputs {
+                issuer_schema_id: ISSUER_SCHEMA_ID,
+                cred_pk: CRED_PK,
+                current_timestamp: CURRENT_TIMESTAMP,
+                cred_genesis_issued_at_min: GENESIS_ISSUED_AT_MIN,
+            },
+            nullifier: NullifierPublicInputs {
+                value: EXPECTED_NULLIFIER,
+                rp_id: RP_ID,
+                action: ACTION,
+            },
+        }
+    }
+
+    #[test]
+    fn test_circom_fixture_claims_hash() {
+        assert_eq(calculate_claims_hash([0; NUM_CLAIMS]), EXPECTED_CLAIMS_HASH);
+    }
+
+    #[test]
+    fn test_circom_fixture_nullifier() {
+        let inputs = fixture_inputs();
+        assert_eq(
+            calculate_nullifier(
+                inputs.nullifier.leaf_index,
+                RP_ID,
+                ACTION,
+                inputs.nullifier.oprf_response,
+            ),
+            EXPECTED_NULLIFIER,
+        );
+    }
+
+    #[test]
+    fn test_full_attested_claims_flow() {
+        let inputs = fixture_inputs();
+        let salted_claims_hash = calculate_salted_claims_hash(SALT, EXPECTED_CLAIMS_HASH);
+        main(fixture_public_inputs(salted_claims_hash), inputs);
+    }
+
+    #[test]
+    fn test_numeric_claim_statement() {
+        let mut claims = [0; NUM_CLAIMS];
+        claims[3] = 21;
+        let mut statements = no_statements();
+        statements[3] =
+            ClaimsStatement { checks: [1, 1], range_check_min: 18, range_check_max: 65 };
+        check_claim_statements(claims, statements);
+    }
+
+    #[test(should_fail_with = "invalid credential signature")]
+    fn test_tampered_claim_is_not_attested() {
+        let mut inputs = fixture_inputs();
+        inputs.claims[0] = 1;
+        let salted_claims_hash =
+            calculate_salted_claims_hash(SALT, calculate_claims_hash(inputs.claims));
+        main(fixture_public_inputs(salted_claims_hash), inputs);
+    }
+
+    #[test(should_fail_with = "minimum check must be boolean")]
+    fn test_statement_flags_must_be_boolean() {
+        let claims = [0; NUM_CLAIMS];
+        let mut statements = no_statements();
+        statements[0].checks[0] = 2;
+        check_claim_statements(claims, statements);
+    }
+}

--- a/crates/proof/src/artifacts/cached.rs
+++ b/crates/proof/src/artifacts/cached.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use once_cell::sync::OnceCell;
 
 use crate::{
-    OwnershipProver, OwnershipVerifier,
+    ClaimsProver, ClaimsVerifier, OwnershipProver, OwnershipVerifier,
     artifacts::{ZkArtifactError, ZkArtifactSource},
     nullifier_proof::CircomGroth16Material,
 };
@@ -15,6 +15,8 @@ pub struct CachedZkArtifactSource {
     nullifier: OnceCell<Arc<CircomGroth16Material>>,
     ownership_prover: OnceCell<OwnershipProver>,
     ownership_verifier: OnceCell<OwnershipVerifier>,
+    claims_prover: OnceCell<ClaimsProver>,
+    claims_verifier: OnceCell<ClaimsVerifier>,
 }
 
 impl CachedZkArtifactSource {
@@ -33,6 +35,8 @@ impl CachedZkArtifactSource {
             nullifier: OnceCell::new(),
             ownership_prover: OnceCell::new(),
             ownership_verifier: OnceCell::new(),
+            claims_prover: OnceCell::new(),
+            claims_verifier: OnceCell::new(),
         }
     }
 }
@@ -59,6 +63,18 @@ impl ZkArtifactSource for CachedZkArtifactSource {
     fn ownership_verifier(&self) -> Result<OwnershipVerifier, ZkArtifactError> {
         self.ownership_verifier
             .get_or_try_init(|| self.inner.ownership_verifier())
+            .cloned()
+    }
+
+    fn claims_prover(&self) -> Result<ClaimsProver, ZkArtifactError> {
+        self.claims_prover
+            .get_or_try_init(|| self.inner.claims_prover())
+            .cloned()
+    }
+
+    fn claims_verifier(&self) -> Result<ClaimsVerifier, ZkArtifactError> {
+        self.claims_verifier
+            .get_or_try_init(|| self.inner.claims_verifier())
             .cloned()
     }
 }

--- a/crates/proof/src/artifacts/dummy.rs
+++ b/crates/proof/src/artifacts/dummy.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use crate::{
-    OwnershipProver, OwnershipVerifier,
+    ClaimsProver, ClaimsVerifier, OwnershipProver, OwnershipVerifier,
     artifacts::{ZkArtifactError, ZkArtifactKind, ZkArtifactSource},
     nullifier_proof::CircomGroth16Material,
 };
@@ -34,5 +34,13 @@ impl ZkArtifactSource for DummyZkArtifactSource {
 
     fn ownership_verifier(&self) -> Result<OwnershipVerifier, ZkArtifactError> {
         Err(not_provided(ZkArtifactKind::OwnershipVerifier))
+    }
+
+    fn claims_prover(&self) -> Result<ClaimsProver, ZkArtifactError> {
+        Err(not_provided(ZkArtifactKind::ClaimsProver))
+    }
+
+    fn claims_verifier(&self) -> Result<ClaimsVerifier, ZkArtifactError> {
+        Err(not_provided(ZkArtifactKind::ClaimsVerifier))
     }
 }

--- a/crates/proof/src/artifacts/embedded.rs
+++ b/crates/proof/src/artifacts/embedded.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use crate::{
-    OwnershipProver, OwnershipVerifier,
+    ClaimsProver, ClaimsVerifier, OwnershipProver, OwnershipVerifier,
     artifacts::{ZkArtifactError, ZkArtifactKind, ZkArtifactSource},
     nullifier_proof::CircomGroth16Material,
 };
@@ -85,6 +85,38 @@ impl ZkArtifactSource for EmbeddedZkArtifacts {
             Err(ZkArtifactError::Unavailable {
                 kind: ZkArtifactKind::OwnershipVerifier,
                 reason: "enable `embed-ownership-verifier` on a native target",
+            })
+        }
+    }
+
+    fn claims_prover(&self) -> Result<ClaimsProver, ZkArtifactError> {
+        #[cfg(all(not(target_arch = "wasm32"), feature = "embed-claims-prover"))]
+        {
+            noir::load_embedded_claims_prover()
+                .map_err(|e| ZkArtifactError::load(ZkArtifactKind::ClaimsProver, e))
+        }
+
+        #[cfg(any(target_arch = "wasm32", not(feature = "embed-claims-prover")))]
+        {
+            Err(ZkArtifactError::Unavailable {
+                kind: ZkArtifactKind::ClaimsProver,
+                reason: "enable `embed-claims-prover` on a native target",
+            })
+        }
+    }
+
+    fn claims_verifier(&self) -> Result<ClaimsVerifier, ZkArtifactError> {
+        #[cfg(all(not(target_arch = "wasm32"), feature = "embed-claims-verifier"))]
+        {
+            noir::load_embedded_claims_verifier()
+                .map_err(|e| ZkArtifactError::load(ZkArtifactKind::ClaimsVerifier, e))
+        }
+
+        #[cfg(any(target_arch = "wasm32", not(feature = "embed-claims-verifier")))]
+        {
+            Err(ZkArtifactError::Unavailable {
+                kind: ZkArtifactKind::ClaimsVerifier,
+                reason: "enable `embed-claims-verifier` on a native target",
             })
         }
     }
@@ -253,7 +285,9 @@ pub mod zkeys {
     not(target_arch = "wasm32"),
     any(
         feature = "embed-ownership-prover",
-        feature = "embed-ownership-verifier"
+        feature = "embed-ownership-verifier",
+        feature = "embed-claims-prover",
+        feature = "embed-claims-verifier"
     )
 ))]
 pub mod noir {
@@ -285,6 +319,36 @@ pub mod noir {
     #[cfg(feature = "embed-ownership-verifier")]
     pub fn load_embedded_ownership_verifier() -> eyre::Result<crate::OwnershipVerifier> {
         crate::ownership_proof::load_ownership_verifier_from_reader(PKV_BYTES)
+    }
+
+    #[cfg(all(feature = "embed-claims-prover", not(docsrs)))]
+    const CLAIMS_PKP_BYTES: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/claims_proof.pkp"));
+
+    #[cfg(all(feature = "embed-claims-prover", docsrs))]
+    const CLAIMS_PKP_BYTES: &[u8] = &[];
+
+    /// Loads the embedded claims proof prover.
+    ///
+    /// # Errors
+    /// Returns an error if embedded Noir artifacts are missing or invalid.
+    #[cfg(feature = "embed-claims-prover")]
+    pub fn load_embedded_claims_prover() -> eyre::Result<crate::ClaimsProver> {
+        crate::claims_proof::load_claims_prover_from_reader(CLAIMS_PKP_BYTES)
+    }
+
+    #[cfg(all(feature = "embed-claims-verifier", not(docsrs)))]
+    const CLAIMS_PKV_BYTES: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/claims_proof.pkv"));
+
+    #[cfg(all(feature = "embed-claims-verifier", docsrs))]
+    const CLAIMS_PKV_BYTES: &[u8] = &[];
+
+    /// Loads the embedded claims proof verifier.
+    ///
+    /// # Errors
+    /// Returns an error if embedded Noir artifacts are missing or invalid.
+    #[cfg(feature = "embed-claims-verifier")]
+    pub fn load_embedded_claims_verifier() -> eyre::Result<crate::ClaimsVerifier> {
+        crate::claims_proof::load_claims_verifier_from_reader(CLAIMS_PKV_BYTES)
     }
 }
 

--- a/crates/proof/src/artifacts/error.rs
+++ b/crates/proof/src/artifacts/error.rs
@@ -5,6 +5,8 @@ pub enum ZkArtifactKind {
     NullifierMaterial,
     OwnershipProver,
     OwnershipVerifier,
+    ClaimsProver,
+    ClaimsVerifier,
 }
 
 impl std::fmt::Display for ZkArtifactKind {
@@ -14,6 +16,8 @@ impl std::fmt::Display for ZkArtifactKind {
             Self::NullifierMaterial => "nullifier proof material",
             Self::OwnershipProver => "ownership prover",
             Self::OwnershipVerifier => "ownership verifier",
+            Self::ClaimsProver => "claims prover",
+            Self::ClaimsVerifier => "claims verifier",
         };
         f.write_str(name)
     }

--- a/crates/proof/src/artifacts/filesystem.rs
+++ b/crates/proof/src/artifacts/filesystem.rs
@@ -4,13 +4,16 @@ use std::{
 };
 
 use crate::{
-    OwnershipProver, OwnershipVerifier,
+    ClaimsProver, ClaimsVerifier, OwnershipProver, OwnershipVerifier,
     artifacts::{ZkArtifactError, ZkArtifactKind, ZkArtifactSource},
     nullifier_proof::{CircomGroth16Material, load_nullifier_material_from_paths},
     oprf_query::load_query_material_from_paths,
 };
 
-use crate::ownership_proof::{load_ownership_prover_from_path, load_ownership_verifier_from_path};
+use crate::{
+    claims_proof::{load_claims_prover_from_path, load_claims_verifier_from_path},
+    ownership_proof::{load_ownership_prover_from_path, load_ownership_verifier_from_path},
+};
 
 /// ZK artifacts loaded from files on disk.
 #[derive(Debug, Default, Clone)]
@@ -21,6 +24,8 @@ pub struct FileSystemZkArtifacts {
     nullifier_graph_path: Option<PathBuf>,
     ownership_prover_path: Option<PathBuf>,
     ownership_verifier_path: Option<PathBuf>,
+    claims_prover_path: Option<PathBuf>,
+    claims_verifier_path: Option<PathBuf>,
 }
 
 impl FileSystemZkArtifacts {
@@ -68,6 +73,18 @@ impl FileSystemZkArtifacts {
         self
     }
 
+    /// Sets the claims proof prover and verifier paths.
+    #[must_use]
+    pub fn with_claims_paths(
+        mut self,
+        prover_path: impl Into<PathBuf>,
+        verifier_path: impl Into<PathBuf>,
+    ) -> Self {
+        self.claims_prover_path = Some(prover_path.into());
+        self.claims_verifier_path = Some(verifier_path.into());
+        self
+    }
+
     /// Sets the query proof zkey path.
     #[must_use]
     pub fn with_query_zkey_path(mut self, path: impl Into<PathBuf>) -> Self {
@@ -107,6 +124,20 @@ impl FileSystemZkArtifacts {
     #[must_use]
     pub fn with_ownership_verifier_path(mut self, path: impl Into<PathBuf>) -> Self {
         self.ownership_verifier_path = Some(path.into());
+        self
+    }
+
+    /// Sets the claims proof prover path.
+    #[must_use]
+    pub fn with_claims_prover_path(mut self, path: impl Into<PathBuf>) -> Self {
+        self.claims_prover_path = Some(path.into());
+        self
+    }
+
+    /// Sets the claims proof verifier path.
+    #[must_use]
+    pub fn with_claims_verifier_path(mut self, path: impl Into<PathBuf>) -> Self {
+        self.claims_verifier_path = Some(path.into());
         self
     }
 }
@@ -160,6 +191,26 @@ impl ZkArtifactSource for FileSystemZkArtifacts {
             &self.ownership_verifier_path,
             kind,
             "ownership verifier path not set",
+        )?)
+        .map_err(|e| ZkArtifactError::load(kind, e))
+    }
+
+    fn claims_prover(&self) -> Result<ClaimsProver, ZkArtifactError> {
+        let kind = ZkArtifactKind::ClaimsProver;
+        load_claims_prover_from_path(required_path(
+            &self.claims_prover_path,
+            kind,
+            "claims prover path not set",
+        )?)
+        .map_err(|e| ZkArtifactError::load(kind, e))
+    }
+
+    fn claims_verifier(&self) -> Result<ClaimsVerifier, ZkArtifactError> {
+        let kind = ZkArtifactKind::ClaimsVerifier;
+        load_claims_verifier_from_path(required_path(
+            &self.claims_verifier_path,
+            kind,
+            "claims verifier path not set",
         )?)
         .map_err(|e| ZkArtifactError::load(kind, e))
     }

--- a/crates/proof/src/artifacts/mod.rs
+++ b/crates/proof/src/artifacts/mod.rs
@@ -2,7 +2,10 @@
 
 use std::sync::Arc;
 
-use crate::{OwnershipProver, OwnershipVerifier, nullifier_proof::CircomGroth16Material};
+use crate::{
+    ClaimsProver, ClaimsVerifier, OwnershipProver, OwnershipVerifier,
+    nullifier_proof::CircomGroth16Material,
+};
 
 /// Source of ZK artifacts required by World ID proof generation.
 pub trait ZkArtifactSource: Send + Sync {
@@ -29,6 +32,30 @@ pub trait ZkArtifactSource: Send + Sync {
     /// # Errors
     /// Returns an error if the material cannot be loaded or is unavailable on the target platform.
     fn ownership_verifier(&self) -> Result<OwnershipVerifier, error::ZkArtifactError>;
+
+    /// Loads claims proof prover material.
+    ///
+    /// # Errors
+    /// Returns an error if the material cannot be loaded or is unavailable on the target platform.
+    fn claims_prover(&self) -> Result<ClaimsProver, error::ZkArtifactError> {
+        Err(error::ZkArtifactError::NotProvided {
+            kind: error::ZkArtifactKind::ClaimsProver,
+            detail: Some("claims prover is not implemented by this ZK artifact source".to_owned()),
+        })
+    }
+
+    /// Loads claims proof verifier material.
+    ///
+    /// # Errors
+    /// Returns an error if the material cannot be loaded or is unavailable on the target platform.
+    fn claims_verifier(&self) -> Result<ClaimsVerifier, error::ZkArtifactError> {
+        Err(error::ZkArtifactError::NotProvided {
+            kind: error::ZkArtifactKind::ClaimsVerifier,
+            detail: Some(
+                "claims verifier is not implemented by this ZK artifact source".to_owned(),
+            ),
+        })
+    }
 }
 
 pub mod cached;
@@ -36,7 +63,9 @@ pub mod dummy;
 #[cfg(any(
     feature = "embed-zkeys",
     feature = "embed-ownership-prover",
-    feature = "embed-ownership-verifier"
+    feature = "embed-ownership-verifier",
+    feature = "embed-claims-prover",
+    feature = "embed-claims-verifier"
 ))]
 pub mod embedded;
 pub mod error;

--- a/crates/proof/src/claims_proof.rs
+++ b/crates/proof/src/claims_proof.rs
@@ -1,0 +1,639 @@
+//! Presentation-specific proofs over private issuer-attested credential claims.
+
+use std::{collections::BTreeMap, io::Read, path::Path};
+
+use ark_ff::{BigInt, BigInteger as _, PrimeField as _};
+use eddsa_babyjubjub::EdDSAPublicKey;
+use provekit_common::{InputMap, InputValue, NoirElement, NoirProof, PublicInputs};
+use provekit_prover::Prove as _;
+use provekit_verifier::Verify as _;
+use world_id_primitives::{
+    ClaimStatement, ClaimsProof, ClaimsProofRequest, Credential, FieldElement, ProofRequest,
+    ResponseItem,
+};
+
+use crate::{
+    ClaimsProver, ClaimsVerifier, NoirRepresentable as _, ProofError, artifacts::ZkArtifactSource,
+    errors::ProofInputError,
+};
+
+/// Public values shared with the companion Circom nullifier proof.
+#[derive(Debug, Clone)]
+pub struct ClaimsProofContext {
+    /// Issuer/schema identifier of the credential.
+    pub issuer_schema_id: FieldElement,
+    /// Issuer key that signed the credential.
+    pub credential_public_key: EdDSAPublicKey,
+    /// Timestamp input used by the nullifier proof's credential expiry policy.
+    pub current_timestamp: FieldElement,
+    /// Minimum accepted credential genesis timestamp.
+    pub cred_genesis_issued_at_min: FieldElement,
+    /// Nullifier output shared by both proofs.
+    pub nullifier: FieldElement,
+    /// Registered relying-party identifier.
+    pub rp_id: FieldElement,
+    /// Nullifier action shared by both proofs.
+    pub action: FieldElement,
+}
+
+/// Private witness and public request data needed to generate a claims proof.
+pub struct ClaimsProofInput<'a> {
+    /// Signed credential whose claims are proven.
+    pub credential: &'a Credential,
+    /// Blinder used in the credential subject commitment.
+    pub credential_sub_blinding_factor: FieldElement,
+    /// Holder's private World ID leaf index.
+    pub leaf_index: u64,
+    /// Unblinded OPRF response shared with the nullifier proof.
+    pub oprf_response: ark_babyjubjub::EdwardsAffine,
+    /// Public values shared with the nullifier proof.
+    pub context: ClaimsProofContext,
+    /// RP-requested claims predicates.
+    pub request: &'a ClaimsProofRequest,
+}
+
+/// Loads a claims proof prover from a reader containing PKP bytes.
+///
+/// # Errors
+/// Returns an error if the reader cannot be read or the prover cannot be deserialized.
+pub fn load_claims_prover_from_reader(mut reader: impl Read) -> eyre::Result<ClaimsProver> {
+    provekit_common::register_ntt();
+    let mut bytes = Vec::new();
+    reader.read_to_end(&mut bytes)?;
+    provekit_common::file::deserialize(&bytes).map_err(|e| eyre::eyre!(e.to_string()))
+}
+
+/// Loads a claims proof prover from a PKP file path.
+///
+/// # Errors
+/// Returns an error if the file cannot be read or the prover cannot be deserialized.
+pub fn load_claims_prover_from_path(path: impl AsRef<Path>) -> eyre::Result<ClaimsProver> {
+    provekit_common::register_ntt();
+    provekit_common::file::read(path.as_ref()).map_err(|e| eyre::eyre!(e.to_string()))
+}
+
+/// Loads a claims proof verifier from a reader containing PKV bytes.
+///
+/// # Errors
+/// Returns an error if the reader cannot be read or the verifier cannot be deserialized.
+pub fn load_claims_verifier_from_reader(mut reader: impl Read) -> eyre::Result<ClaimsVerifier> {
+    provekit_common::register_ntt();
+    let mut bytes = Vec::new();
+    reader.read_to_end(&mut bytes)?;
+    provekit_common::file::deserialize(&bytes).map_err(|e| eyre::eyre!(e.to_string()))
+}
+
+/// Loads a claims proof verifier from a PKV file path.
+///
+/// # Errors
+/// Returns an error if the file cannot be read or the verifier cannot be deserialized.
+pub fn load_claims_verifier_from_path(path: impl AsRef<Path>) -> eyre::Result<ClaimsVerifier> {
+    provekit_common::register_ntt();
+    provekit_common::file::read(path.as_ref()).map_err(|e| eyre::eyre!(e.to_string()))
+}
+
+/// Generates a claims proof using artifacts from the provided source.
+///
+/// # Errors
+/// Returns an error if inputs are invalid, artifacts cannot be loaded, or proving fails.
+pub fn generate_claims_proof(
+    input: ClaimsProofInput<'_>,
+    artifacts: &dyn ZkArtifactSource,
+) -> Result<ClaimsProof, ProofError> {
+    let prover = artifacts.claims_prover()?;
+    generate_claims_proof_with_prover(input, prover)
+}
+
+/// Generates a claims proof using the provided prover.
+///
+/// # Errors
+/// Returns an error if inputs are invalid, witness generation fails, or proving fails.
+pub fn generate_claims_proof_with_prover(
+    input: ClaimsProofInput<'_>,
+    prover: ClaimsProver,
+) -> Result<ClaimsProof, ProofError> {
+    validate_input(&input)?;
+    provekit_common::register_ntt();
+
+    let witness = into_witness(&input)?;
+    let noir_proof = prover
+        .prove(witness)
+        .map_err(|e| ProofError::GenerationError(e.to_string()))?;
+
+    Ok(ClaimsProof {
+        proof: noir_proof.whir_r1cs_proof,
+        statements: input.request.statements.clone(),
+    })
+}
+
+/// Verifies a claims proof using artifacts from the provided source.
+///
+/// The caller must obtain `context` from the same RP request, issuer registry lookup, and
+/// nullifier-proof response that it independently verifies.
+///
+/// # Errors
+/// Returns an error if artifacts cannot be loaded, inputs are invalid, or verification fails.
+pub fn verify_claims_proof(
+    proof: &ClaimsProof,
+    context: &ClaimsProofContext,
+    artifacts: &dyn ZkArtifactSource,
+) -> Result<(), ProofError> {
+    let mut verifier = artifacts.claims_verifier()?;
+    verify_claims_proof_with_verifier(proof, context, &mut verifier)
+}
+
+/// Verifies the claims co-proof attached to a nullifier-proof response item.
+///
+/// This is the RP-facing seam: it reconstructs every public input shared with the companion
+/// nullifier proof from the original request and response. The caller must independently verify
+/// `response.proof` as the Circom nullifier proof and resolve `credential_public_key` from the
+/// issuer/schema registry.
+///
+/// # Errors
+/// Returns an error if the request and response do not match, no claims proof is attached, or the
+/// claims proof fails verification. The RP must still validate the complete response and verify its
+/// companion Circom proof independently.
+pub fn verify_claims_proof_for_response(
+    request: &ProofRequest,
+    response: &ResponseItem,
+    credential_public_key: EdDSAPublicKey,
+    artifacts: &dyn ZkArtifactSource,
+) -> Result<(), ProofError> {
+    let request_item = request
+        .requests
+        .iter()
+        .find(|item| item.identifier == response.identifier)
+        .ok_or_else(|| ProofError::InternalError(eyre::eyre!("response item was not requested")))?;
+    if request_item.issuer_schema_id != response.issuer_schema_id {
+        return Err(ProofError::InternalError(eyre::eyre!(
+            "response issuer schema does not match request"
+        )));
+    }
+    if request.proof_type.is_session() != response.is_session() {
+        return Err(ProofError::InternalError(eyre::eyre!(
+            "response proof type does not match request"
+        )));
+    }
+    let expected_expires_at_min = request_item.effective_expires_at_min(request.created_at);
+    if response.expires_at_min != expected_expires_at_min {
+        return Err(ProofError::InternalError(eyre::eyre!(
+            "response credential time policy does not match request"
+        )));
+    }
+    let proof = response.claims_proof.as_ref().ok_or_else(|| {
+        ProofError::InternalError(eyre::eyre!("response item has no claims proof"))
+    })?;
+    let requested_statements = &request_item
+        .claims
+        .as_ref()
+        .ok_or_else(|| {
+            ProofError::InternalError(eyre::eyre!("request item did not ask for a claims proof"))
+        })?
+        .statements;
+    if requested_statements != &proof.statements {
+        return Err(ProofError::InternalError(eyre::eyre!(
+            "claims proof statements do not match request"
+        )));
+    }
+
+    let (nullifier, action) = match (&response.nullifier, &response.session_nullifier) {
+        (Some(nullifier), None) => (
+            nullifier.inner,
+            request.action.ok_or_else(|| {
+                ProofError::InternalError(eyre::eyre!("uniqueness request has no nullifier action"))
+            })?,
+        ),
+        (None, Some(session_nullifier)) => {
+            (session_nullifier.nullifier(), session_nullifier.action())
+        }
+        _ => {
+            return Err(ProofError::InternalError(eyre::eyre!(
+                "response must contain exactly one nullifier type"
+            )));
+        }
+    };
+
+    verify_claims_proof(
+        proof,
+        &ClaimsProofContext {
+            issuer_schema_id: request_item.issuer_schema_id.into(),
+            credential_public_key,
+            current_timestamp: response.expires_at_min.into(),
+            cred_genesis_issued_at_min: request_item.genesis_issued_at_min.unwrap_or(0).into(),
+            nullifier,
+            rp_id: request.rp_id.into(),
+            action,
+        },
+        artifacts,
+    )
+}
+
+/// Verifies a claims proof using the provided verifier.
+///
+/// # Errors
+/// Returns an error if public inputs are invalid or verification fails.
+pub fn verify_claims_proof_with_verifier(
+    proof: &ClaimsProof,
+    context: &ClaimsProofContext,
+    verifier: &mut ClaimsVerifier,
+) -> Result<(), ProofError> {
+    validate_statements(&proof.statements)?;
+
+    provekit_common::register_ntt();
+    let public_inputs = PublicInputs::from_vec(public_inputs(proof, context));
+    verifier
+        .verify(&NoirProof {
+            public_inputs,
+            whir_r1cs_proof: proof.proof.clone(),
+        })
+        .map_err(|e| ProofError::Verification(e.to_string()))
+}
+
+fn validate_input(input: &ClaimsProofInput<'_>) -> Result<(), ProofError> {
+    validate_statements(&input.request.statements)?;
+    if input.credential.signature.is_none() {
+        return Err(ProofError::InternalError(eyre::eyre!(
+            "credential not signed"
+        )));
+    }
+    if input.credential.issuer_schema_id != u64::try_from(input.context.issuer_schema_id)? {
+        return Err(ProofError::InternalError(eyre::eyre!(
+            "claims proof issuer schema does not match credential"
+        )));
+    }
+    if input.credential.issuer != input.context.credential_public_key {
+        return Err(ProofError::InternalError(eyre::eyre!(
+            "claims proof issuer key does not match credential"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_statements(statements: &[ClaimStatement]) -> Result<(), ProofInputError> {
+    let mut seen = [false; Credential::MAX_CLAIMS];
+    for statement in statements {
+        let index = usize::from(statement.claim_index);
+        if index >= Credential::MAX_CLAIMS {
+            return Err(ProofInputError::InvalidClaimIndex {
+                index: statement.claim_index,
+            });
+        }
+        if std::mem::replace(&mut seen[index], true) {
+            return Err(ProofInputError::DuplicateClaimIndex {
+                index: statement.claim_index,
+            });
+        }
+        if statement.min_exclusive.is_none() && statement.max_exclusive.is_none() {
+            return Err(ProofInputError::EmptyClaimStatement {
+                index: statement.claim_index,
+            });
+        }
+    }
+    Ok(())
+}
+
+fn expanded_statements(
+    statements: &[ClaimStatement],
+) -> [(bool, bool, FieldElement, FieldElement); Credential::MAX_CLAIMS] {
+    let mut expanded =
+        [(false, false, FieldElement::ZERO, FieldElement::ZERO); Credential::MAX_CLAIMS];
+    for statement in statements {
+        let index = usize::from(statement.claim_index);
+        expanded[index] = (
+            statement.min_exclusive.is_some(),
+            statement.max_exclusive.is_some(),
+            statement.min_exclusive.unwrap_or(FieldElement::ZERO),
+            statement.max_exclusive.unwrap_or(FieldElement::ZERO),
+        );
+    }
+    expanded
+}
+
+fn statement_values(statements: &[ClaimStatement]) -> Vec<InputValue> {
+    expanded_statements(statements)
+        .into_iter()
+        .map(|(check_min, check_max, min, max)| {
+            let mut statement = BTreeMap::new();
+            statement.insert(
+                "checks".into(),
+                InputValue::Vec(vec![
+                    InputValue::Field(NoirElement::from(check_min)),
+                    InputValue::Field(NoirElement::from(check_max)),
+                ]),
+            );
+            statement.insert("range_check_min".into(), min.into_noir_value());
+            statement.insert("range_check_max".into(), max.into_noir_value());
+            InputValue::Struct(statement)
+        })
+        .collect()
+}
+
+fn into_witness(input: &ClaimsProofInput<'_>) -> Result<InputMap, ProofError> {
+    let mut claims_public = BTreeMap::new();
+    claims_public.insert(
+        "statements".into(),
+        InputValue::Vec(statement_values(&input.request.statements)),
+    );
+
+    let mut credential_public = BTreeMap::new();
+    credential_public.insert(
+        "issuer_schema_id".into(),
+        input.context.issuer_schema_id.into_noir_value(),
+    );
+    credential_public.insert(
+        "cred_pk".into(),
+        InputValue::Vec(vec![
+            InputValue::Field(NoirElement::from_repr(
+                input.context.credential_public_key.pk.x,
+            )),
+            InputValue::Field(NoirElement::from_repr(
+                input.context.credential_public_key.pk.y,
+            )),
+        ]),
+    );
+    credential_public.insert(
+        "current_timestamp".into(),
+        input.context.current_timestamp.into_noir_value(),
+    );
+    credential_public.insert(
+        "cred_genesis_issued_at_min".into(),
+        input.context.cred_genesis_issued_at_min.into_noir_value(),
+    );
+
+    let mut nullifier_public = BTreeMap::new();
+    nullifier_public.insert("value".into(), input.context.nullifier.into_noir_value());
+    nullifier_public.insert("rp_id".into(), input.context.rp_id.into_noir_value());
+    nullifier_public.insert("action".into(), input.context.action.into_noir_value());
+
+    let mut public = BTreeMap::new();
+    public.insert("claims".into(), InputValue::Struct(claims_public));
+    public.insert("credential".into(), InputValue::Struct(credential_public));
+    public.insert("nullifier".into(), InputValue::Struct(nullifier_public));
+
+    let mut claims = vec![FieldElement::ZERO; Credential::MAX_CLAIMS];
+    claims[..input.credential.claims.len()].copy_from_slice(&input.credential.claims);
+
+    let signature = input
+        .credential
+        .signature
+        .as_ref()
+        .ok_or_else(|| ProofError::InternalError(eyre::eyre!("credential not signed")))?;
+    let signature_s =
+        ark_bn254::Fr::from_be_bytes_mod_order(&signature.s.into_bigint().to_bytes_be());
+    let cred_id = ark_babyjubjub::Fq::from(BigInt([
+        input.credential.id,
+        u64::from(input.credential.issuer_version),
+        0,
+        0,
+    ]));
+
+    let mut credential_private = BTreeMap::new();
+    credential_private.insert(
+        "cred_genesis_issued_at".into(),
+        FieldElement::from(input.credential.genesis_issued_at).into_noir_value(),
+    );
+    credential_private.insert(
+        "cred_expires_at".into(),
+        FieldElement::from(input.credential.expires_at).into_noir_value(),
+    );
+    credential_private.insert(
+        "associated_data_hash".into(),
+        input
+            .credential
+            .associated_data_commitment
+            .into_noir_value(),
+    );
+    credential_private.insert(
+        "cred_id".into(),
+        FieldElement::from(cred_id).into_noir_value(),
+    );
+    credential_private.insert(
+        "cred_user_id_r".into(),
+        input.credential_sub_blinding_factor.into_noir_value(),
+    );
+    credential_private.insert(
+        "cred_s".into(),
+        InputValue::Field(NoirElement::from_repr(signature_s)),
+    );
+    credential_private.insert(
+        "cred_r".into(),
+        InputValue::Vec(vec![
+            InputValue::Field(NoirElement::from_repr(signature.r.x)),
+            InputValue::Field(NoirElement::from_repr(signature.r.y)),
+        ]),
+    );
+
+    let mut nullifier_private = BTreeMap::new();
+    nullifier_private.insert(
+        "leaf_index".into(),
+        FieldElement::from(input.leaf_index).into_noir_value(),
+    );
+    nullifier_private.insert(
+        "oprf_response".into(),
+        InputValue::Vec(vec![
+            InputValue::Field(NoirElement::from_repr(input.oprf_response.x)),
+            InputValue::Field(NoirElement::from_repr(input.oprf_response.y)),
+        ]),
+    );
+
+    let mut private = BTreeMap::new();
+    private.insert(
+        "claims".into(),
+        InputValue::Vec(
+            claims
+                .into_iter()
+                .map(|claim| claim.into_noir_value())
+                .collect(),
+        ),
+    );
+    private.insert("credential".into(), InputValue::Struct(credential_private));
+    private.insert("nullifier".into(), InputValue::Struct(nullifier_private));
+
+    let mut witness = InputMap::new();
+    witness.insert("public_inputs".into(), InputValue::Struct(public));
+    witness.insert("private_inputs".into(), InputValue::Struct(private));
+    Ok(witness)
+}
+
+fn public_inputs(proof: &ClaimsProof, context: &ClaimsProofContext) -> Vec<ark_babyjubjub::Fq> {
+    let mut values = Vec::with_capacity(68);
+    for (check_min, check_max, min, max) in expanded_statements(&proof.statements) {
+        values.push(ark_babyjubjub::Fq::from(check_min));
+        values.push(ark_babyjubjub::Fq::from(check_max));
+        values.push(*min);
+        values.push(*max);
+    }
+    values.extend([
+        *context.issuer_schema_id,
+        context.credential_public_key.pk.x,
+        context.credential_public_key.pk.y,
+        *context.current_timestamp,
+        *context.cred_genesis_issued_at_min,
+        *context.nullifier,
+        *context.rp_id,
+        *context.action,
+    ]);
+    values
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(all(feature = "embed-claims-prover", feature = "embed-claims-verifier"))]
+    use std::str::FromStr as _;
+
+    #[cfg(all(feature = "embed-claims-prover", feature = "embed-claims-verifier"))]
+    use ark_babyjubjub::{EdwardsAffine, Fq, Fr};
+    #[cfg(all(feature = "embed-claims-prover", feature = "embed-claims-verifier"))]
+    use eddsa_babyjubjub::EdDSASignature;
+    #[cfg(all(feature = "embed-claims-prover", feature = "embed-claims-verifier"))]
+    use world_id_primitives::CredentialVersion;
+
+    use super::*;
+
+    #[test]
+    fn rejects_duplicate_claim_indices() {
+        let statement = ClaimStatement {
+            claim_index: 2,
+            min_exclusive: Some(FieldElement::from(18u64)),
+            max_exclusive: None,
+        };
+        let error = validate_statements(&[statement.clone(), statement]).unwrap_err();
+        assert!(matches!(
+            error,
+            ProofInputError::DuplicateClaimIndex { index: 2 }
+        ));
+    }
+
+    #[test]
+    fn expands_sparse_statements_into_fixed_claim_slots() {
+        let statements = [ClaimStatement {
+            claim_index: 3,
+            min_exclusive: Some(FieldElement::from(17u64)),
+            max_exclusive: Some(FieldElement::from(66u64)),
+        }];
+        let expanded = expanded_statements(&statements);
+        assert_eq!(
+            expanded[2],
+            (false, false, FieldElement::ZERO, FieldElement::ZERO)
+        );
+        assert_eq!(
+            expanded[3],
+            (
+                true,
+                true,
+                FieldElement::from(17u64),
+                FieldElement::from(66u64)
+            )
+        );
+    }
+
+    #[cfg(all(feature = "embed-claims-prover", feature = "embed-claims-verifier"))]
+    fn field(value: &str) -> FieldElement {
+        FieldElement::from(Fq::from_str(value).unwrap())
+    }
+
+    #[cfg(all(feature = "embed-claims-prover", feature = "embed-claims-verifier"))]
+    fn fixture() -> (Credential, FieldElement, EdwardsAffine, ClaimsProofContext) {
+        let blinder =
+            field("19016519542686775328775746932795543103858066763212549618980890183285781521458");
+        let issuer_pk = EdDSAPublicKey {
+            pk: EdwardsAffine::new_unchecked(
+                Fq::from_str(
+                    "21825204959029483311433036009853709113262520481918849765727459753607131160346",
+                )
+                .unwrap(),
+                Fq::from_str(
+                    "8339486770249821464793634710648189540136988043780169655155172519121840615364",
+                )
+                .unwrap(),
+            ),
+        };
+        let credential = Credential {
+            id: 12_176_925_761_186_149_284,
+            version: CredentialVersion::V1,
+            issuer_version: 0,
+            issuer_schema_id: 1,
+            sub: Credential::compute_sub(1, blinder),
+            genesis_issued_at: 1_767_868_120,
+            expires_at: 1_767_868_180,
+            claims: vec![FieldElement::ZERO; Credential::MAX_CLAIMS],
+            associated_data_commitment: FieldElement::ZERO,
+            signature: Some(EdDSASignature {
+                s: Fr::from_str(
+                    "1785197794318390548654263507521729446174585997835004080357493002880021427752",
+                )
+                .unwrap(),
+                r: EdwardsAffine::new_unchecked(
+                    Fq::from_str(
+                        "9716162517813998269973089361571651784159199085806289463178774674474552458864",
+                    )
+                    .unwrap(),
+                    Fq::from_str(
+                        "6858161934880479087336794169055762635352680692798466775715085760374212641424",
+                    )
+                    .unwrap(),
+                ),
+            }),
+            issuer: issuer_pk.clone(),
+        };
+        let oprf_response = EdwardsAffine::new_unchecked(
+            Fq::from_str(
+                "11771927497930831763844779626723106344742708040976110136703486119568919340013",
+            )
+            .unwrap(),
+            Fq::from_str(
+                "19299702061490581533153169629464406607119112637706400365988657399831357218309",
+            )
+            .unwrap(),
+        );
+        let context = ClaimsProofContext {
+            issuer_schema_id: FieldElement::from(1u64),
+            credential_public_key: issuer_pk,
+            current_timestamp: FieldElement::from(1_767_868_101u64),
+            cred_genesis_issued_at_min: FieldElement::ZERO,
+            nullifier: field(
+                "21342856517406476000190785734870568200315738457615815351702849709270076362125",
+            ),
+            rp_id: field("950325648507560155068233096743093215539447660945"),
+            action: field(
+                "84721944028150696728472418813119358007006361082259892623669024918011698311",
+            ),
+        };
+        (credential, blinder, oprf_response, context)
+    }
+
+    #[cfg(all(feature = "embed-claims-prover", feature = "embed-claims-verifier"))]
+    #[test]
+    fn generates_verifies_and_binds_nullifier() {
+        use crate::artifacts::embedded::EmbeddedZkArtifacts;
+
+        let (credential, blinder, oprf_response, context) = fixture();
+        let request = ClaimsProofRequest {
+            statements: vec![ClaimStatement {
+                claim_index: 0,
+                min_exclusive: None,
+                max_exclusive: Some(FieldElement::from(1u64)),
+            }],
+        };
+        let artifacts = EmbeddedZkArtifacts;
+        let proof = generate_claims_proof(
+            ClaimsProofInput {
+                credential: &credential,
+                credential_sub_blinding_factor: blinder,
+                leaf_index: 1,
+                oprf_response,
+                context: context.clone(),
+                request: &request,
+            },
+            &artifacts,
+        )
+        .unwrap();
+
+        verify_claims_proof(&proof, &context, &artifacts).unwrap();
+
+        let mut wrong_context = context;
+        wrong_context.nullifier = FieldElement::from(1u64);
+        let error = verify_claims_proof(&proof, &wrong_context, &artifacts).unwrap_err();
+        assert!(matches!(error, ProofError::Verification(_)));
+    }
+}

--- a/crates/proof/src/lib.rs
+++ b/crates/proof/src/lib.rs
@@ -12,7 +12,7 @@ use zeroize::{Zeroize, ZeroizeOnDrop};
 /// ZK artifact source abstractions.
 pub mod artifacts;
 
-/// Circuit input types for Circom/Groth16 circuits (query, nullifier, ownership proofs).
+/// Circuit input types for Circom/Groth16 circuits (query and nullifier proofs).
 pub mod circuit_inputs;
 
 /// Static circuit input fixtures shared by the tests and the generated circuit examples.
@@ -30,6 +30,10 @@ pub use oprf_query::{
 pub mod nullifier_proof;
 pub use nullifier_proof::*;
 
+/// Proofs over private issuer-attested credential claims.
+#[cfg(not(target_arch = "wasm32"))]
+pub mod claims_proof;
+
 /// Authenticator Attestations (WIP-106): Root of Trust Token generation.
 pub mod authenticator_attestation;
 
@@ -44,6 +48,11 @@ pub mod ownership_proof;
 pub use provekit_common::{
     NoirProof, Prover as OwnershipProver, Verifier as OwnershipVerifier, WhirR1CSProof,
 };
+
+/// ProveKit prover material for the claims circuit.
+pub type ClaimsProver = provekit_common::Prover;
+/// ProveKit verifier material for the claims circuit.
+pub type ClaimsVerifier = provekit_common::Verifier;
 
 /// Error type for OPRF operations and proof generation.
 #[derive(Debug, thiserror::Error)]

--- a/crates/proof/src/nullifier_proof/errors.rs
+++ b/crates/proof/src/nullifier_proof/errors.rs
@@ -114,6 +114,15 @@ pub enum ProofInputError {
     /// The provided commitment does not match the one derived from the leaf index and blinder.
     #[error("The provided expected commitment does not match the derived commitment")]
     InvalidExpectedCommitment,
+    /// A claims statement addresses a slot outside the credential's claim vector.
+    #[error("Claim index {index} is outside the credential claim vector.")]
+    InvalidClaimIndex { index: u8 },
+    /// More than one claims statement addresses the same credential claim slot.
+    #[error("Claim index {index} occurs more than once in the claims proof request.")]
+    DuplicateClaimIndex { index: u8 },
+    /// A claims statement enables neither a lower nor an upper bound.
+    #[error("Claim index {index} has no predicate to prove.")]
+    EmptyClaimStatement { index: u8 },
 }
 
 /// This method checks the validity of the input parameters by emulating the operations that are proved in ZK and raising Errors that would result in an invalid proof.


### PR DESCRIPTION
## Summary

- add a Noir companion circuit for proving sparse strict-range predicates over private credential claims
- recalculate the private `claims_hash` and verify that it is covered by the issuer credential signature
- bind the issuer-attested credential to the companion Circom proof through the shared nullifier, issuer, RP/action, and credential time policy
- add optional claims-proof request/response primitives, native Authenticator generation, and an RP-facing verification helper
- add embedded, filesystem, cached, and custom artifact-source plumbing for the claims prover and verifier

## Privacy model

The raw 15 claim slots and the recalculated `claims_hash` are private circuit inputs. There is no public claims hash, salt, or claims commitment. Only the RP-requested predicates and the public context needed to pair and verify the two proofs are exposed.

The RP must independently verify both the Circom nullifier proof and the Noir claims proof using matching public context. The claims verifier also requires the issuer public key resolved for the requested issuer/schema.

## Claims-proof public inputs

The Noir ABI contains 68 public field elements grouped into three structs:

1. `claims` — 60 fields: 15 fixed claim slots, each containing `check_min`, `check_max`, `range_check_min`, and `range_check_max`. The sparse indexed Rust statements are expanded into these slots internally. The two check flags are constrained to boolean values.
2. `credential` — 5 fields: `issuer_schema_id`, issuer public key coordinates `cred_pk[2]`, `current_timestamp`, and `cred_genesis_issued_at_min`.
3. `nullifier` — 3 fields: the shared nullifier `value`, `rp_id`, and `action`.

The credential and nullifier fields must match the public context used to verify the companion Circom proof. In the Authenticator integration, `current_timestamp` is the request item's effective `expires_at_min` policy value.

## POC limitations

- claims proving and verification are native-only; claims requests return an explicit unsupported error on `wasm32`
- this is a draft protocol/API shape and has not received a security audit
- the fixed 15-slot Noir predicate representation is intentionally hidden behind sparse indexed Rust request types

## Validation

- `nix develop --command sh -c 'cd crates/proof/noir/claims-proof && nargo fmt --check && nargo test && nargo compile'` — 6 tests passed
- `cargo test -p world-id-primitives` — 167 unit tests, regression tests, and doctests passed
- `cargo test -p world-id-proof --lib` — 28 tests passed
- `cargo test -p world-id-authenticator --lib` — 19 tests passed
- `cargo clippy -p world-id-primitives -p world-id-proof -p world-id-authenticator -p world-id-core --all-targets -- -D warnings`
- real embedded ProveKit generation/verification passed, including rejection when the paired nullifier is changed
