### PR TITLE
fix: pin forge utils to 1.7.1 in ci

### DIFF
--- a/.github/workflows/contracts-ci.yml
+++ b/.github/workflows/contracts-ci.yml
@@ -35,6 +35,8 @@ jobs:
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@908c540300062bd5a7e473851cdb4282204cee09 # v1.9.1 https://github.com/foundry-rs/foundry-toolchain/releases/tag/v1.9.1
+        with:
+          version: 1.7.1
 
       - name: Cache Forge dependencies
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0 https://github.com/actions/cache/releases/tag/v4.3.0
@@ -64,6 +66,8 @@ jobs:
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@908c540300062bd5a7e473851cdb4282204cee09 # v1.9.1 https://github.com/foundry-rs/foundry-toolchain/releases/tag/v1.9.1
+        with:
+          version: 1.7.1
 
       - name: Cache Forge dependencies
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0 https://github.com/actions/cache/releases/tag/v4.3.0

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -47,6 +47,8 @@ jobs:
       - name: Install Foundry
         if: steps.cache-contracts.outputs.cache-hit != 'true'
         uses: foundry-rs/foundry-toolchain@908c540300062bd5a7e473851cdb4282204cee09 # v1.9.1 https://github.com/foundry-rs/foundry-toolchain/releases/tag/v1.9.1
+        with:
+          version: 1.7.1
 
       - name: Build contracts and extract ABIs
         if: steps.cache-contracts.outputs.cache-hit != 'true'
@@ -239,6 +241,8 @@ jobs:
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@908c540300062bd5a7e473851cdb4282204cee09 # v1.9.1 https://github.com/foundry-rs/foundry-toolchain/releases/tag/v1.9.1
+        with:
+          version: 1.7.1
         # Anvil is used for integration tests
 
       - uses: noir-lang/noirup@7dbe69ccc78877f0200ffa5a40836c953d2cfd8f # v0.1.4 https://github.com/noir-lang/noirup/releases/tag/v0.1.4
@@ -303,6 +307,8 @@ jobs:
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@908c540300062bd5a7e473851cdb4282204cee09 # v1.9.1 https://github.com/foundry-rs/foundry-toolchain/releases/tag/v1.9.1
+        with:
+          version: 1.7.1
 
       - uses: noir-lang/noirup@7dbe69ccc78877f0200ffa5a40836c953d2cfd8f # v0.1.4 https://github.com/noir-lang/noirup/releases/tag/v0.1.4
         with:


### PR DESCRIPTION
Pins foundry tooling to 1.7.1 in CI

Necessary until https://github.com/foundry-rs/foundry/issues/16413 resolves


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow change with no application or contract logic changes; main effect is consistent Foundry behavior in pipelines.
> 
> **Overview**
> **Pins the Foundry binaries installed in CI to version `1.7.1`** on every `foundry-rs/foundry-toolchain` step in **Contracts CI** (`test`, `check-abis`) and **Rust CI** (`build-contracts`, `test`, `setup-test`).
> 
> Previously those steps used the action’s default Foundry version; adding `with: version: 1.7.1` keeps `forge`/`anvil` (and contract builds) on a known release until an upstream Foundry issue is fixed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe185c052877528535d53f1ac5a765c8cc0c9aa6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->