### PR TITLE
chore: bump rust to 1.98

### DIFF
--- a/crates/core/tests/authenticator_registration.rs
+++ b/crates/core/tests/authenticator_registration.rs
@@ -1,4 +1,5 @@
 #![cfg(feature = "authenticator")]
+#![recursion_limit = "256"]
 
 use alloy::primitives::U256;
 use backon::{ExponentialBuilder, Retryable};

--- a/crates/core/tests/e2e_authenticator_insert_update_remove.rs
+++ b/crates/core/tests/e2e_authenticator_insert_update_remove.rs
@@ -1,4 +1,5 @@
 #![cfg(feature = "authenticator")]
+#![recursion_limit = "256"]
 
 use std::{sync::Arc, time::Duration};
 

--- a/crates/core/tests/generate_proof.rs
+++ b/crates/core/tests/generate_proof.rs
@@ -1,4 +1,5 @@
 #![cfg(feature = "authenticator")]
+#![recursion_limit = "256"]
 
 use std::{
     path::PathBuf,

--- a/crates/primitives/src/request/constraints.rs
+++ b/crates/primitives/src/request/constraints.rs
@@ -112,7 +112,6 @@ impl ConstraintExpr<'_> {
                             return false;
                         }
                     }
-                    true
                 }
                 ConstraintExpr::Any { any } => {
                     for n in any {
@@ -120,7 +119,6 @@ impl ConstraintExpr<'_> {
                             return false;
                         }
                     }
-                    true
                 }
                 ConstraintExpr::Enumerate { enumerate } => {
                     for n in enumerate {
@@ -128,9 +126,9 @@ impl ConstraintExpr<'_> {
                             return false;
                         }
                     }
-                    true
                 }
             }
+            true
         }
 
         fn count_node(node: &ConstraintNode<'_>, count: &mut usize, max_nodes: usize) -> bool {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.93.0"
+channel = "1.98.0"
 profile = "minimal"
 components = ["clippy", "rustfmt", "rust-src", "rust-analyzer"]

--- a/services/common/src/lib.rs
+++ b/services/common/src/lib.rs
@@ -1,5 +1,4 @@
 //! Common utilities and types shared across multiple services.
-
 pub mod alloy;
 pub mod axum;
 

--- a/services/gateway/tests/common.rs
+++ b/services/gateway/tests/common.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "256"]
+
 use alloy::primitives::Address;
 use reqwest::{Client, StatusCode};
 use std::time::Duration;

--- a/services/gateway/tests/gateway_integration.rs
+++ b/services/gateway/tests/gateway_integration.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "256"]
+
 use std::time::Duration;
 
 use alloy::{

--- a/services/gateway/tests/test_inflight.rs
+++ b/services/gateway/tests/test_inflight.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "256"]
+
 use alloy::{
     primitives::{Address, U256},
     signers::local::PrivateKeySigner,

--- a/services/gateway/tests/test_recovery_agent_update.rs
+++ b/services/gateway/tests/test_recovery_agent_update.rs
@@ -6,6 +6,8 @@
 //! the new V2-native `update-recovery-agent` / `revert-recovery-agent-update`
 //! URLs.
 
+#![recursion_limit = "256"]
+
 use std::{future::Future, time::Duration};
 
 use alloy::{


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Toolchain bump plus mechanical test attributes and a no-op control-flow cleanup in constraint validation; no runtime behavior change intended.
> 
> **Overview**
> **Upgrades the repo from Rust 1.93.0 to 1.98.0** via `rust-toolchain.toml`.
> 
> To keep the tree green on the new compiler, integration and e2e test crates get `#![recursion_limit = "256"]` (core authenticator tests and gateway test modules) so deeply nested macro/type expansion still compiles.
> 
> In `validate_max_nodes` (`constraints.rs`), the `All` / `Any` / `Enumerate` arms no longer each end with `true`; control falls through to a single `true` after the `match`, with the same short-circuit behavior when `count_node` fails.
> 
> A stray blank line after the crate doc in `services/common/src/lib.rs` is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0fb6c659425e1bad685142c2ed5b1203a5cfd89. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->