### PR TITLE
fix: properly validate revoked authenticator after recovery

### DIFF
--- a/contracts/src/core/UnreleasedWorldIDVerifierV3.sol
+++ b/contracts/src/core/UnreleasedWorldIDVerifierV3.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.13;
 import {WorldIDVerifierV2} from "./WorldIDVerifierV2.sol";
 import {IWorldIDVerifier} from "./interfaces/IWorldIDVerifier.sol";
 import {IWorldIDVerifierV3} from "./interfaces/UnreleasedIWorldIDVerifierV3.sol";
+import {PackedAccountData} from "./libraries/PackedAccountData.sol";
 
 /**
  * @title WorldIDVerifierV3
@@ -14,6 +15,39 @@ import {IWorldIDVerifierV3} from "./interfaces/UnreleasedIWorldIDVerifierV3.sol"
  * @custom:repo https://github.com/world-id/world-id-protocol
  */
 contract WorldIDVerifierV3 is IWorldIDVerifierV3, WorldIDVerifierV2 {
+    /// @inheritdoc IWorldIDVerifierV3
+    /// @dev Returns 0 for an unknown authenticator, matching `WorldIDRegistry.getPackedAccountData`.
+    function getPackedAccountData(address authenticatorAddress)
+        external
+        view
+        virtual
+        onlyProxy
+        onlyInitialized
+        returns (uint256)
+    {
+        uint256 packedAccountData = _worldIDRegistry.getPackedAccountData(authenticatorAddress);
+        uint64 leafIndex = PackedAccountData.leafIndex(packedAccountData);
+
+        // `recoverAccount` bumps the account's counter but leaves the old authenticator mapped
+        if (PackedAccountData.recoveryCounter(packedAccountData) < _worldIDRegistry.getRecoveryCounter(leafIndex)) {
+            revert AuthenticatorRevoked();
+        }
+
+        return packedAccountData;
+    }
+
+    /// @inheritdoc IWorldIDVerifierV3
+    function getUnverifiedPackedAccountData(address authenticatorAddress)
+        external
+        view
+        virtual
+        onlyProxy
+        onlyInitialized
+        returns (uint256)
+    {
+        return _worldIDRegistry.getPackedAccountData(authenticatorAddress);
+    }
+
     /// @inheritdoc IWorldIDVerifierV3
     function verifyWithSession(
         uint256 nullifier,

--- a/contracts/src/core/interfaces/UnreleasedIWorldIDVerifierV3.sol
+++ b/contracts/src/core/interfaces/UnreleasedIWorldIDVerifierV3.sol
@@ -21,9 +21,29 @@ interface IWorldIDVerifierV3 is IWorldIDVerifier {
      */
     error InvalidSessionId();
 
+    /**
+    * @dev Thrown when querying for an authenticator that is now revoked because of an account recovery. This
+    * will not be raised if the authenticator is removed normally (i.e. by another authenticator).
+    */
+    error AuthenticatorRevoked();
+
     ////////////////////////////////////////////////////////////
     //                    VIEW FUNCTIONS                      //
     ////////////////////////////////////////////////////////////
+
+    /**
+     * @dev Returns the packed account data for an authenticator address. Will throw if the
+     * queried authenticator has been revoked after an account recovery.
+     * @param authenticatorAddress The authenticator address to query.
+     */
+    function getPackedAccountData(address authenticatorAddress) external view returns (uint256);
+
+    /**
+     * @dev Returns the packed account data for an authenticator address WITHOUT checking if the
+     * authenticator is not revoked by account recovery.
+     * @param authenticatorAddress The authenticator address to query.
+     */
+    function getUnverifiedPackedAccountData(address authenticatorAddress) external view returns (uint256);
 
     /**
      * @notice Verifies a Uniqueness Proof that is bound to an existing session.

--- a/contracts/src/core/interfaces/UnreleasedIWorldIDVerifierV3.sol
+++ b/contracts/src/core/interfaces/UnreleasedIWorldIDVerifierV3.sol
@@ -22,9 +22,9 @@ interface IWorldIDVerifierV3 is IWorldIDVerifier {
     error InvalidSessionId();
 
     /**
-    * @dev Thrown when querying for an authenticator that is now revoked because of an account recovery. This
-    * will not be raised if the authenticator is removed normally (i.e. by another authenticator).
-    */
+     * @dev Thrown when querying for an authenticator that is now revoked because of an account recovery. This
+     * will not be raised if the authenticator is removed normally (i.e. by another authenticator).
+     */
     error AuthenticatorRevoked();
 
     ////////////////////////////////////////////////////////////

--- a/contracts/test/core/WorldIDVerifierV3Test.t.sol
+++ b/contracts/test/core/WorldIDVerifierV3Test.t.sol
@@ -7,6 +7,7 @@ import {IWorldIDVerifierV2} from "../../src/core/interfaces/IWorldIDVerifierV2.s
 import {WorldIDVerifier} from "../../src/core/WorldIDVerifier.sol";
 import {IWorldIDVerifierV3} from "../../src/core/interfaces/UnreleasedIWorldIDVerifierV3.sol";
 import {Verifier} from "../../src/core/Verifier.sol";
+import {PackedAccountData} from "../../src/core/libraries/PackedAccountData.sol";
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 
 import {
@@ -18,8 +19,32 @@ import {
     rootCorrect
 } from "./WorldIDVerifierTest.t.sol";
 
+/// Adds the account state `getPackedAccountData` reads: a packed value per authenticator and a
+/// recovery counter per leaf, both settable so tests can stage pre- and post-recovery states.
+contract WorldIDRegistryRecoveryMock is WorldIDRegistryMock {
+    mapping(address => uint256) internal packedAccountData;
+    mapping(uint64 => uint256) internal recoveryCounters;
+
+    function setPackedAccountData(address authenticatorAddress, uint256 packed) external {
+        packedAccountData[authenticatorAddress] = packed;
+    }
+
+    function setRecoveryCounter(uint64 leafIndex, uint256 counter) external {
+        recoveryCounters[leafIndex] = counter;
+    }
+
+    function getPackedAccountData(address authenticatorAddress) external view returns (uint256) {
+        return packedAccountData[authenticatorAddress];
+    }
+
+    function getRecoveryCounter(uint64 leafIndex) external view returns (uint256) {
+        return recoveryCounters[leafIndex];
+    }
+}
+
 contract WorldIDVerifierV3Test is Test {
     WorldIDVerifierV3 public verifier;
+    WorldIDRegistryRecoveryMock public registry;
 
     uint256 nullifier = 0x5968cd4d3c50bfd2305671d1092bee10ccb679b93db3ca779b6477e4885e476;
     uint64 expiresAtMin = 0x6a54cd68;
@@ -48,7 +73,8 @@ contract WorldIDVerifierV3Test is Test {
 
     function setUp() public {
         address oprfKeyRegistry = address(new OprfKeyRegistryMock());
-        address worldIDRegistryMock = address(new WorldIDRegistryMock());
+        registry = new WorldIDRegistryRecoveryMock();
+        address worldIDRegistryMock = address(registry);
         address credentialSchemaIssuerRegistryMock = address(new CredentialSchemaIssuerRegistryMock());
         address groth16Verifier = address(new Verifier());
         uint256 minExpirationThreshold = 5 hours;
@@ -219,5 +245,92 @@ contract WorldIDVerifierV3Test is Test {
         verifier.verify(
             nullifier, action, rpIdCorrect, nonce, signalHash, expiresAtMin, credentialIssuerIdCorrect, 0, proof
         );
+    }
+
+    ////////////////////////////////////////////////////////////
+    //            getPackedAccountData                        //
+    ////////////////////////////////////////////////////////////
+
+    address constant AUTHENTICATOR = address(0x11);
+    address constant RECOVERED_AUTHENTICATOR = address(0x22);
+    uint64 constant LEAF_INDEX = 7;
+
+    /// Stages an account at `LEAF_INDEX` whose authenticator is current (counters agree).
+    function _stageAccount(uint32 recoveryCounter) internal returns (uint256 packed) {
+        packed = PackedAccountData.pack(LEAF_INDEX, recoveryCounter, 0);
+        registry.setPackedAccountData(AUTHENTICATOR, packed);
+        registry.setRecoveryCounter(LEAF_INDEX, recoveryCounter);
+    }
+
+    function test_GetPackedAccountDataReturnsCurrentAuthenticator() public {
+        uint256 packed = _stageAccount(0);
+        assertEq(verifier.getPackedAccountData(AUTHENTICATOR), packed);
+    }
+
+    function test_GetPackedAccountDataRevertsForAuthenticatorRevokedByRecovery() public {
+        _stageAccount(0);
+        // `recoverAccount` bumps the account counter and leaves the old authenticator mapped.
+        registry.setRecoveryCounter(LEAF_INDEX, 1);
+        registry.setPackedAccountData(RECOVERED_AUTHENTICATOR, PackedAccountData.pack(LEAF_INDEX, 1, 0));
+
+        vm.expectRevert(abi.encodeWithSelector(IWorldIDVerifierV3.AuthenticatorRevoked.selector));
+        verifier.getPackedAccountData(AUTHENTICATOR);
+    }
+
+    function test_GetPackedAccountDataReturnsAuthenticatorInstalledByRecovery() public {
+        _stageAccount(0);
+        registry.setRecoveryCounter(LEAF_INDEX, 1);
+        uint256 packed = PackedAccountData.pack(LEAF_INDEX, 1, 0);
+        registry.setPackedAccountData(RECOVERED_AUTHENTICATOR, packed);
+
+        assertEq(verifier.getPackedAccountData(RECOVERED_AUTHENTICATOR), packed);
+    }
+
+    function test_GetPackedAccountDataRevertsForEveryAuthenticatorPredatingLatestRecovery() public {
+        // A second recovery must revoke the authenticator the first recovery installed.
+        registry.setPackedAccountData(AUTHENTICATOR, PackedAccountData.pack(LEAF_INDEX, 0, 0));
+        registry.setPackedAccountData(RECOVERED_AUTHENTICATOR, PackedAccountData.pack(LEAF_INDEX, 1, 0));
+        registry.setRecoveryCounter(LEAF_INDEX, 2);
+
+        vm.expectRevert(abi.encodeWithSelector(IWorldIDVerifierV3.AuthenticatorRevoked.selector));
+        verifier.getPackedAccountData(AUTHENTICATOR);
+
+        vm.expectRevert(abi.encodeWithSelector(IWorldIDVerifierV3.AuthenticatorRevoked.selector));
+        verifier.getPackedAccountData(RECOVERED_AUTHENTICATOR);
+    }
+
+    function test_GetPackedAccountDataReadsCounterOfItsOwnLeaf() public {
+        uint256 packed = _stageAccount(2);
+        registry.setRecoveryCounter(2, 9);
+
+        assertEq(verifier.getPackedAccountData(AUTHENTICATOR), packed);
+    }
+
+    function test_GetPackedAccountDataReturnsZeroForUnknownAuthenticator() public view {
+        // Parity with `WorldIDRegistry.getPackedAccountData`, which returns 0 rather than reverting.
+        assertEq(verifier.getPackedAccountData(address(0xdead)), 0);
+    }
+
+    function test_GetUnverifiedPackedAccountDataReturnsRevokedAuthenticator() public {
+        uint256 packed = _stageAccount(0);
+        registry.setRecoveryCounter(LEAF_INDEX, 1);
+
+        assertEq(verifier.getUnverifiedPackedAccountData(AUTHENTICATOR), packed);
+    }
+
+    function testFuzz_GetPackedAccountDataRevertsExactlyWhenCounterIsStale(
+        uint32 authenticatorCounter,
+        uint32 accountCounter
+    ) public {
+        uint256 packed = PackedAccountData.pack(LEAF_INDEX, authenticatorCounter, 0);
+        registry.setPackedAccountData(AUTHENTICATOR, packed);
+        registry.setRecoveryCounter(LEAF_INDEX, accountCounter);
+
+        if (authenticatorCounter < accountCounter) {
+            vm.expectRevert(abi.encodeWithSelector(IWorldIDVerifierV3.AuthenticatorRevoked.selector));
+            verifier.getPackedAccountData(AUTHENTICATOR);
+        } else {
+            assertEq(verifier.getPackedAccountData(AUTHENTICATOR), packed);
+        }
     }
 }

--- a/crates/test-utils/Cargo.toml
+++ b/crates/test-utils/Cargo.toml
@@ -38,3 +38,6 @@ semver = { workspace = true }
 testcontainers = { workspace = true }
 tracing = { workspace = true }
 world-id-primitives = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/crates/test-utils/src/anvil.rs
+++ b/crates/test-utils/src/anvil.rs
@@ -617,6 +617,33 @@ impl TestAnvil {
         Self::deploy_contract(provider, bytecode, Bytes::new()).await
     }
 
+    /// Links `PackedAccountData` into the V3 verifier implementation bytecode and deploys it.
+    async fn deploy_linked_verifier_impl<P: Provider>(
+        provider: P,
+        packed_account_data_addr: Address,
+    ) -> Result<Address> {
+        let impl_json = include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../contracts/out/UnreleasedWorldIDVerifierV3.sol/WorldIDVerifierV3.json"
+        ));
+        let json_value: serde_json::Value = serde_json::from_str(impl_json)?;
+        let bytecode_str = json_value["bytecode"]["object"]
+            .as_str()
+            .context("bytecode not found in JSON")?
+            .strip_prefix("0x")
+            .context("bytecode should be 0x-prefixed")?;
+
+        let bytecode_str = Self::link_bytecode_hex(
+            impl_json,
+            bytecode_str,
+            "src/core/libraries/PackedAccountData.sol:PackedAccountData",
+            packed_account_data_addr,
+        )?;
+
+        let bytecode = Bytes::from(hex::decode(bytecode_str)?);
+        Self::deploy_contract(provider, bytecode, Bytes::new()).await
+    }
+
     /// Deploys the `RpRegistry` contract using the supplied signer.
     #[allow(dead_code)]
     pub async fn deploy_rp_registry(
@@ -695,10 +722,14 @@ impl TestAnvil {
             .await
             .context("failed to deploy Verifier (Groth16) contract")?;
 
-        // WorldID verifier (upgradeable, delegates to Groth16 verifier)
-        let world_id_verifier = WorldIDVerifierV3::deploy(provider.clone())
+        let packed_account_data = PackedAccountData::deploy(provider.clone())
             .await
-            .context("failed to deploy WorldIDVerifierV3 contract")?;
+            .context("failed to deploy PackedAccountData library")?;
+
+        // WorldID verifier (upgradeable, delegates to Groth16 verifier)
+        let world_id_verifier =
+            Self::deploy_linked_verifier_impl(provider.clone(), *packed_account_data.address())
+                .await?;
 
         let init_data = Bytes::from(
             WorldIDVerifierV3::initializeCall {
@@ -711,7 +742,7 @@ impl TestAnvil {
             .abi_encode(),
         );
 
-        let proxy = ERC1967Proxy::deploy(provider, *world_id_verifier.address(), init_data)
+        let proxy = ERC1967Proxy::deploy(provider, world_id_verifier, init_data)
             .await
             .context("failed to deploy WorldIDVerifier proxy")?;
 

--- a/crates/test-utils/tests/verifier_deploy.rs
+++ b/crates/test-utils/tests/verifier_deploy.rs
@@ -1,0 +1,29 @@
+use alloy::{
+    primitives::{Address, U256},
+    providers::ProviderBuilder,
+};
+use world_id_test_utils::{anvil::WorldIDVerifierV3, fixtures::RegistryTestContext};
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn deployed_verifier_has_packed_account_data_library_linked() {
+    let ctx = RegistryTestContext::new()
+        .await
+        .expect("failed to build registry test context");
+
+    let provider = ProviderBuilder::new().connect_http(
+        ctx.anvil
+            .endpoint()
+            .parse()
+            .expect("invalid anvil endpoint"),
+    );
+    let verifier = WorldIDVerifierV3::new(ctx.world_id_verifier, provider);
+
+    // Unpacking runs through the library, so this reverts if the deploy left it unlinked.
+    let packed = verifier
+        .getPackedAccountData(Address::from([0x11; 20]))
+        .call()
+        .await
+        .expect("getPackedAccountData reverted; PackedAccountData is likely unlinked");
+
+    assert_eq!(packed, U256::ZERO, "unknown authenticator should return 0");
+}

--- a/services/indexer/migrations/0003_account_recovery_counter.sql
+++ b/services/indexer/migrations/0003_account_recovery_counter.sql
@@ -1,0 +1,5 @@
+alter table accounts
+    add column if not exists recovery_counter bigint not null default 0;
+
+comment on column accounts.recovery_counter is
+    'number of `AccountRecovered` events observed.compared against the recovery counter in packed data to detect revoked authenticators.';

--- a/services/indexer/src/db/accounts.rs
+++ b/services/indexer/src/db/accounts.rs
@@ -27,6 +27,7 @@ pub struct Account {
     pub authenticator_addresses: Vec<Option<Address>>,
     pub authenticator_pubkeys: Vec<Option<U256>>,
     pub offchain_signer_commitment: U256,
+    pub recovery_counter: u64,
     pub latest_event_id: AccountLatestEventId,
 }
 
@@ -110,6 +111,7 @@ where
                     authenticator_addresses,
                     authenticator_pubkeys,
                     offchain_signer_commitment,
+                    recovery_counter,
                     latest_block_number,
                     latest_log_index
                 FROM accounts
@@ -122,6 +124,28 @@ where
         .await?;
 
         result.map(|row| Self::map_account(&row)).transpose()
+    }
+
+    /// Returns the number of recoveries observed for `leaf_index`, or `None` if the account is
+    /// not indexed yet.
+    #[instrument(level = "info", skip(self))]
+    pub async fn get_recovery_counter(self, leaf_index: u64) -> DBResult<Option<u64>> {
+        let result = sqlx::query(
+            r#"
+                SELECT
+                    recovery_counter
+                FROM accounts
+                WHERE
+                    leaf_index = $1
+            "#,
+        )
+        .bind(leaf_index as i64)
+        .fetch_optional(self.executor)
+        .await?;
+
+        result
+            .map(|row| Self::map_recovery_counter(&row))
+            .transpose()
     }
 
     #[instrument(level = "info", skip(self))]
@@ -244,6 +268,7 @@ where
                     authenticator_addresses = $2,
                     authenticator_pubkeys = $3,
                     offchain_signer_commitment = $4,
+                    recovery_counter = recovery_counter + 1,
                     latest_block_number = $5,
                     latest_log_index = $6
                 WHERE
@@ -394,12 +419,17 @@ where
             authenticator_addresses: Self::map_authenticator_addresses(row)?,
             authenticator_pubkeys: Self::map_authenticator_pub_keys(row)?,
             offchain_signer_commitment: Self::map_offchain_signer_commitment(row)?,
+            recovery_counter: Self::map_recovery_counter(row)?,
             latest_event_id: Self::map_latest_event_id(row)?,
         })
     }
 
     fn map_leaf_index(row: &PgRow) -> DBResult<u64> {
         Ok(row.get::<i64, _>("leaf_index") as u64)
+    }
+
+    fn map_recovery_counter(row: &PgRow) -> DBResult<u64> {
+        Ok(row.get::<i64, _>("recovery_counter") as u64)
     }
 
     fn map_recovery_address(row: &PgRow) -> DBResult<Address> {

--- a/services/indexer/src/routes/get_packed_account.rs
+++ b/services/indexer/src/routes/get_packed_account.rs
@@ -7,6 +7,11 @@ use world_id_primitives::api_types::{
 
 use crate::config::AppState;
 
+/// Packed account data layout: `[32 bits recoveryCounter][32 bits pubkeyId][128 reserved][64 bits leafIndex]`.
+/// See `contracts/src/core/libraries/PackedAccountData.sol`.
+const RECOVERY_COUNTER_SHIFT: usize = 224;
+const LEAF_INDEX_MASK: U256 = U256::from_limbs([u64::MAX, 0, 0, 0]);
+
 /// Get Packed Account Data
 ///
 /// Returns the packed account data for a given authenticator address from the `WorldIDRegistry` contract.
@@ -17,7 +22,7 @@ use crate::config::AppState;
     request_body = IndexerPackedAccountRequest,
     responses(
         (status = 200, body = IndexerPackedAccountResponse),
-        (status = 400, description = "Account does not exist for the given authenticator address", body = IndexerErrorBody),
+        (status = 400, description = "Account does not exist for the given authenticator address, or the authenticator was revoked by recovery", body = IndexerErrorBody),
     ),
     tag = "indexer"
 )]
@@ -39,6 +44,27 @@ pub(crate) async fn handler(
         return Err(IndexerErrorResponse::bad_request(
             IndexerErrorCode::AccountDoesNotExist,
             "There is no account for this authenticator address".to_string(),
+        ));
+    }
+
+    let leaf_index = (packed_account_data & LEAF_INDEX_MASK).to::<u64>();
+    let packed_recovery_counter = (packed_account_data >> RECOVERY_COUNTER_SHIFT).to::<u64>();
+
+    let indexed_recovery_counter = state
+        .db
+        .accounts()
+        .get_recovery_counter(leaf_index)
+        .await
+        .map_err(|err| {
+            tracing::error!(leaf_index, "DB error fetching recovery counter: {err}");
+            IndexerErrorResponse::internal_server_error()
+        })?;
+
+    // Fails open: rejects only if the authenticator is confirmed revoked
+    if indexed_recovery_counter.is_some_and(|indexed| indexed > packed_recovery_counter) {
+        return Err(IndexerErrorResponse::bad_request(
+            IndexerErrorCode::AccountDoesNotExist,
+            "This authenticator was revoked by an account recovery".to_string(),
         ));
     }
 

--- a/services/indexer/tests/db_tests.rs
+++ b/services/indexer/tests/db_tests.rs
@@ -429,6 +429,35 @@ async fn test_reset_authenticator() {
     assert_eq!(account.authenticator_addresses[0], Some(new_address));
     assert_eq!(account.authenticator_pubkeys[0], Some(new_pubkey));
     assert_eq!(account.offchain_signer_commitment, new_commitment);
+
+    // Recovery bumps the counter so /packed-account can spot authenticators revoked by it.
+    assert_eq!(account.recovery_counter, 1);
+    assert_eq!(
+        db.accounts()
+            .get_recovery_counter(leaf_index)
+            .await
+            .unwrap(),
+        Some(1)
+    );
+
+    db.accounts()
+        .reset_authenticator(
+            leaf_index,
+            &new_address,
+            &new_pubkey,
+            &new_commitment,
+            101,
+            0,
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        db.accounts()
+            .get_recovery_counter(leaf_index)
+            .await
+            .unwrap(),
+        Some(2)
+    );
 }
 
 /// Test inserting world tree event

--- a/services/indexer/tests/helpers/common.rs
+++ b/services/indexer/tests/helpers/common.rs
@@ -6,11 +6,12 @@ use super::db_helpers::{TestDatabase, create_unique_test_db};
 use alloy::{
     network::EthereumWallet,
     primitives::{Address, U256, address},
-    providers::ProviderBuilder,
+    providers::{DynProvider, Provider, ProviderBuilder},
+    signers::local::PrivateKeySigner,
 };
 use sqlx::PgPool;
 use world_id_primitives::TREE_DEPTH;
-use world_id_registries::world_id::WorldIdRegistry;
+use world_id_registries::world_id::{WorldIdRegistry, domain, sign_recover_account};
 use world_id_test_utils::anvil::TestAnvil;
 
 pub const RECOVERY_ADDRESS: Address = address!("0x0000000000000000000000000000000000000001");
@@ -61,17 +62,33 @@ impl TestSetup {
         self._anvil.ws_endpoint().to_string()
     }
 
-    pub async fn create_account(&self, auth_addr: Address, pubkey: U256, commitment: u64) {
+    /// Provider that signs as the anvil deployer account.
+    fn provider(&self) -> DynProvider {
         let deployer = self._anvil.signer(0).unwrap();
-        let registry = WorldIdRegistry::new(
-            self.registry_address,
-            ProviderBuilder::new()
-                .wallet(EthereumWallet::from(deployer))
-                .connect_http(self._anvil.endpoint().parse().unwrap()),
-        );
+        ProviderBuilder::new()
+            .wallet(EthereumWallet::from(deployer))
+            .connect_http(self._anvil.endpoint().parse().unwrap())
+            .erased()
+    }
+
+    pub async fn create_account(&self, auth_addr: Address, pubkey: U256, commitment: u64) {
+        self.create_account_with_recovery_agent(auth_addr, pubkey, commitment, RECOVERY_ADDRESS)
+            .await;
+    }
+
+    /// Like [`Self::create_account`], but the caller picks the recovery agent so the account can
+    /// later be recovered with a signature via [`Self::recover_account`].
+    pub async fn create_account_with_recovery_agent(
+        &self,
+        auth_addr: Address,
+        pubkey: U256,
+        commitment: u64,
+        recovery_agent: Address,
+    ) {
+        let registry = WorldIdRegistry::new(self.registry_address, self.provider());
         registry
             .createAccount(
-                RECOVERY_ADDRESS,
+                recovery_agent,
                 vec![auth_addr],
                 vec![pubkey],
                 U256::from(commitment),
@@ -84,14 +101,54 @@ impl TestSetup {
             .expect("createAccount transaction failed");
     }
 
+    /// Recovers `leaf_index` onto `new_auth_addr`, bumping the on-chain recovery counter and
+    /// revoking every authenticator the account had before.
+    pub async fn recover_account(
+        &self,
+        leaf_index: u64,
+        new_auth_addr: Address,
+        new_pubkey: U256,
+        old_commitment: U256,
+        new_commitment: U256,
+        recovery_agent: &PrivateKeySigner,
+    ) {
+        let provider = self.provider();
+        let chain_id = provider.get_chain_id().await.unwrap();
+        let registry = WorldIdRegistry::new(self.registry_address, provider);
+        let nonce = registry.getSignatureNonce(leaf_index).call().await.unwrap();
+
+        let signature = sign_recover_account(
+            recovery_agent,
+            leaf_index,
+            new_auth_addr,
+            new_pubkey,
+            new_commitment,
+            nonce,
+            &domain(chain_id, self.registry_address),
+        )
+        .await
+        .expect("failed to sign recoverAccount payload");
+
+        registry
+            .recoverAccount(
+                leaf_index,
+                new_auth_addr,
+                new_pubkey,
+                old_commitment,
+                new_commitment,
+                signature.as_bytes().to_vec().into(),
+                nonce,
+            )
+            .send()
+            .await
+            .expect("failed to submit recoverAccount transaction")
+            .get_receipt()
+            .await
+            .expect("recoverAccount transaction failed");
+    }
+
     pub async fn get_root(&self) -> U256 {
-        let deployer = self._anvil.signer(0).unwrap();
-        let registry = WorldIdRegistry::new(
-            self.registry_address,
-            ProviderBuilder::new()
-                .wallet(EthereumWallet::from(deployer))
-                .connect_http(self._anvil.endpoint().parse().unwrap()),
-        );
+        let registry = WorldIdRegistry::new(self.registry_address, self.provider());
         registry.currentRoot().call().await.unwrap()
     }
 

--- a/services/indexer/tests/rollback_tests.rs
+++ b/services/indexer/tests/rollback_tests.rs
@@ -354,6 +354,7 @@ async fn test_rollback_with_mixed_event_types() {
         account.authenticator_addresses[1],
         Some(Address::from([2u8; 20]))
     );
+    assert_eq!(account.recovery_counter, 0); // replays AccountCreated, so the recovery counter must reset
 }
 
 /// Test that rollback to current state has no effect

--- a/services/indexer/tests/test_get_packed_account.rs
+++ b/services/indexer/tests/test_get_packed_account.rs
@@ -5,30 +5,24 @@ use helpers::common::{TestSetup, query_count};
 
 use std::time::Duration;
 
-use alloy::primitives::{U256, address};
+use alloy::primitives::{Address, U256, address};
 use eddsa_babyjubjub::EdDSAPrivateKey;
 use http::StatusCode;
+use sqlx::PgPool;
 use world_id_indexer::config::{
     Environment, GlobalConfig, HttpConfig, IndexerConfig, RunMode, TreeCacheConfig,
 };
 use world_id_services_common::ProviderArgs;
 
-/// Tests the packed_account endpoint that maps authenticator addresses to account indices
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_packed_account_endpoint() {
-    let setup = TestSetup::new().await;
+fn random_pubkey() -> U256 {
     let sk = EdDSAPrivateKey::random(&mut rand::thread_rng());
-    let pk = sk.public().to_compressed_bytes().unwrap();
-    let pk = U256::from_le_slice(&pk);
+    U256::from_le_slice(&sk.public().to_compressed_bytes().unwrap())
+}
 
-    let auth_addr = address!("0x0000000000000000000000000000000000000011");
-
-    // Create an account with a specific authenticator address
-    setup.create_account(auth_addr, pk, 1).await;
-
+fn indexer_config(setup: &TestSetup, http_addr: &str) -> GlobalConfig {
     let temp_cache_path =
         std::env::temp_dir().join(format!("test_cache_{}.mmap", uuid::Uuid::new_v4()));
-    let global_config = GlobalConfig {
+    GlobalConfig {
         environment: Environment::Development,
         run_mode: RunMode::Both {
             indexer_config: IndexerConfig {
@@ -39,7 +33,7 @@ async fn test_packed_account_endpoint() {
                 max_concurrent_log_requests: 1,
             },
             http_config: HttpConfig {
-                http_addr: "0.0.0.0:8083".parse().unwrap(),
+                http_addr: http_addr.parse().unwrap(),
                 db_poll_interval_secs: 1,
                 request_timeout_secs: 10,
                 sanity_check_interval_secs: None,
@@ -53,69 +47,155 @@ async fn test_packed_account_endpoint() {
             tree_depth: 30,
             http_cache_refresh_interval_secs: 30,
         },
-    };
+    }
+}
 
-    let indexer_task = tokio::spawn(async move {
-        unsafe { world_id_indexer::run_indexer(global_config).await }.unwrap();
-    });
-
-    // Add a small delay to let initialization start
-    tokio::time::sleep(Duration::from_millis(500)).await;
-    tracing::info!("Indexer task spawned, waiting for backfill...");
-
-    // Wait for account to be indexed
+async fn wait_for_accounts(pool: &PgPool, expected: i64) {
     let deadline = std::time::Instant::now() + Duration::from_secs(15);
     loop {
-        let c = query_count(&setup.pool).await;
-        tracing::info!(
-            "Current account count: {} (elapsed: {:?})",
-            c,
-            deadline.saturating_duration_since(std::time::Instant::now())
-        );
-        if c >= 1 {
-            tracing::info!("Account found! Backfill complete.");
-            break;
+        let c = query_count(pool).await;
+        if c >= expected {
+            return;
         }
         if std::time::Instant::now() > deadline {
             panic!("timeout waiting for backfill; count {c}");
         }
         tokio::time::sleep(Duration::from_millis(200)).await;
     }
+}
 
+/// Waits until the indexer has committed the `AccountRecovered` event for `leaf_index`.
+async fn wait_for_recovery_indexed(pool: &PgPool, leaf_index: i64) {
+    let deadline = std::time::Instant::now() + Duration::from_secs(15);
+    loop {
+        let (count,): (i64,) = sqlx::query_as(
+            "select count(*) from world_id_registry_events \
+             where event_type = 'account_recovered' and leaf_index = $1",
+        )
+        .bind(leaf_index)
+        .fetch_one(pool)
+        .await
+        .unwrap();
+        if count >= 1 {
+            return;
+        }
+        if std::time::Instant::now() > deadline {
+            panic!("timeout waiting for AccountRecovered to be indexed for leaf {leaf_index}");
+        }
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+}
+
+async fn packed_account(host_url: &str, auth_addr: Address) -> (StatusCode, serde_json::Value) {
+    let resp = reqwest::Client::new()
+        .post(format!("{host_url}/packed-account"))
+        .json(&serde_json::json!({ "authenticator_address": auth_addr }))
+        .send()
+        .await
+        .unwrap();
+    let status = resp.status();
+    (status, resp.json().await.unwrap())
+}
+
+fn packed_data(json: &serde_json::Value) -> U256 {
+    json["packed_account_data"]
+        .as_str()
+        .unwrap()
+        .parse()
+        .unwrap()
+}
+
+/// Tests the packed_account endpoint that maps authenticator addresses to account indices
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_packed_account_endpoint() {
+    let setup = TestSetup::new().await;
+    let auth_addr = address!("0x0000000000000000000000000000000000000011");
+
+    // Create an account with a specific authenticator address
+    setup.create_account(auth_addr, random_pubkey(), 1).await;
+
+    let global_config = indexer_config(&setup, "0.0.0.0:8083");
+    let indexer_task = tokio::spawn(async move {
+        unsafe { world_id_indexer::run_indexer(global_config).await }.unwrap();
+    });
+
+    wait_for_accounts(&setup.pool, 1).await;
     TestSetup::wait_for_health("http://127.0.0.1:8083").await;
 
-    let client = reqwest::Client::new();
-
-    // Test successful lookup
-    let resp = client
-        .post("http://127.0.0.1:8083/packed-account")
-        .json(&serde_json::json!({
-            "authenticator_address": auth_addr
-        }))
-        .send()
-        .await
-        .unwrap();
-
-    assert_eq!(resp.status(), StatusCode::OK);
-    let json: serde_json::Value = resp.json().await.unwrap();
-    let packed_account_data = json["packed_account_data"].as_str().unwrap();
-
-    // Account index 1 should map to packed account index of 1
-    assert_eq!(packed_account_data, "0x1");
+    // Test successful lookup: account index 1 maps to packed account index of 1
+    let (status, json) = packed_account("http://127.0.0.1:8083", auth_addr).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(json["packed_account_data"].as_str().unwrap(), "0x1");
 
     // Test non-existent authenticator address
-    let resp = client
-        .post("http://127.0.0.1:8083/packed-account")
-        .json(&serde_json::json!({
-            "authenticator_address": "0x0000000000000000000000000000000000000099"
-        }))
-        .send()
-        .await
-        .unwrap();
-
-    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
-    let json: serde_json::Value = resp.json().await.unwrap();
+    let (status, json) = packed_account(
+        "http://127.0.0.1:8083",
+        address!("0x0000000000000000000000000000000000000099"),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
     assert_eq!(json["code"].as_str().unwrap(), "account_does_not_exist");
+
+    indexer_task.abort();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_packed_account_rejects_authenticator_revoked_by_recovery() {
+    let setup = TestSetup::new().await;
+    let host = "http://127.0.0.1:8087";
+    let leaf_index = 1u64;
+
+    let recovery_agent = setup._anvil.signer(1).unwrap();
+    let old_auth_addr = address!("0x0000000000000000000000000000000000000011");
+    let new_auth_addr = address!("0x0000000000000000000000000000000000000022");
+    let old_commitment = U256::from(1);
+    let new_commitment = U256::from(2);
+
+    setup
+        .create_account_with_recovery_agent(
+            old_auth_addr,
+            random_pubkey(),
+            old_commitment.to::<u64>(),
+            recovery_agent.address(),
+        )
+        .await;
+
+    let global_config = indexer_config(&setup, "0.0.0.0:8087");
+    let indexer_task = tokio::spawn(async move {
+        unsafe { world_id_indexer::run_indexer(global_config).await }.unwrap();
+    });
+
+    wait_for_accounts(&setup.pool, 1).await;
+    TestSetup::wait_for_health(host).await;
+
+    // Before recovery the authenticator resolves normally.
+    let (status, json) = packed_account(host, old_auth_addr).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(packed_data(&json), U256::from(leaf_index));
+
+    setup
+        .recover_account(
+            leaf_index,
+            new_auth_addr,
+            random_pubkey(),
+            old_commitment,
+            new_commitment,
+            &recovery_agent,
+        )
+        .await;
+    wait_for_recovery_indexed(&setup.pool, leaf_index as i64).await;
+
+    let (status, json) = packed_account(host, old_auth_addr).await;
+    assert_eq!(status, StatusCode::BAD_REQUEST); // after recovery, the old authenticator is revoked
+    assert_eq!(json["code"].as_str().unwrap(), "account_does_not_exist");
+
+    // the other authenticator works
+    let (status, json) = packed_account(host, new_auth_addr).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        packed_data(&json),
+        (U256::from(1) << 224) | U256::from(leaf_index)
+    );
 
     indexer_task.abort();
 }


### PR DESCRIPTION
### Motivation

After account recovery, all existing authenticators are revoked. In the current version, when calling `/packed-account` in the indexer or `getPackedAccount` data in the `WorldIDRegistry`, this consideration is not taken into account, and a seemingly valid authenticator is returned.

### Changes
1. The indexer now tracks the `recovery_counter` and will check it before returning the packed account data in that endpoint. We use this to avoid a second RPC call or multi-call. There may be a small lag from the recovery events coming in, but this fails open.
2. Updates the V3 registry contract to do this verification on-chain and exposes a separate unverified method that will not perform this validation. This is a behavioral breaking change for when V3 is released.


### Launch
This fails open, but would be best to replay chain events to make sure the recovery counter is filled in the DB.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches post-recovery authenticator trust for API and future V3 on-chain reads; indexer rejection depends on indexed recovery events staying in sync with chain state.
> 
> **Overview**
> After account recovery, old authenticators can still appear in on-chain packed mappings; this PR **treats them as invalid** by comparing each authenticator’s embedded recovery counter to the account’s current recovery counter.
> 
> **On-chain (V3 verifier):** Adds `getPackedAccountData`, which reverts with `AuthenticatorRevoked` when the packed counter is behind the registry’s counter for that leaf, and `getUnverifiedPackedAccountData` for callers that need the raw registry value. Foundry tests and Anvil deploy helpers link the `PackedAccountData` library when deploying V3.
> 
> **Indexer:** Persists `recovery_counter` on accounts (incremented on recovery via `reset_authenticator`) and **`/packed-account`** unpacks the on-chain packed value, compares counters from the DB, and returns a client error when the authenticator is confirmed revoked—**fails open** if the account isn’t indexed yet. Integration tests cover full create → recover → lookup flows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eefa9de56eb6c8961eb53bf8c9bf4de8d1cc7f16. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->