### PR TITLE
feat: WIP-110 & WIP-111 (Embedding similarity circuit & embedding verifier)

### DIFF
--- a/docs/WIPs/wip-110.md
+++ b/docs/WIPs/wip-110.md
@@ -1,38 +1,86 @@
 ---
 wip: 110
-title: Trusted Embedding Verifier
-description: Defines a trusted execution environment-backed for embedding extraction from images and comparison against one or many.
+title: Embedding Verifier
+description: A service that extracts vector embeddings, compares them, and signs a token committing to its inputs and results.
 author: Kilian Glas (@kilianglas), Paolo D'Amico (@paolodamico)
-status: Draft
-type: Informative
+status: 🚧 Draft
+type: Informational
 created: 2026-08-03
 ---
 
+> [!NOTE]  
+> This spec outlines a draft functionality for beta testing. Changes are expected.
+
 ## Abstract
+
+This spec defines the **Embedding Verifier**: a trusted execution environment (TEE) service that receives a credential item, a live capture, and optionally a challenge item; extracts a vector embedding from any of them supplied as raw media; compares them; and signs a token committing to every input it received and every score it produced.
+
+The token is its only output. [WIP-111][wip-111] consumes it to prove the comparison to a Relying Party without revealing any item.
+
+**Embedding Verifier** is the name used across the Protocol for this component. "TEE verifier", "trusted verifier", "enclave", etc. MUST NOT be used as synonyms.
 
 ## Motivation
 
+Comparing two embeddings is cheap. Getting an embedding anyone should believe is not.
+
+Extraction runs a model over raw media, which is impractical in a ZK circuit. The checks that make an extracted embedding meaningful — image quality, Presentation Attack Detection, anti-fraud signals — are even worse. Much of these models require complex inputs and advanced signals, and may even rely on model obscurity.
+
+Running extraction and comparison in an attested Trusted Execution Environment keeps the inputs private and the execution verifiable. Committing to the raw inputs makes the result usable by a verifier who trusts neither the prover nor the prover's device.
 
 ## Specification
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).
 
+### Inputs
 
+A request MUST carry a credential item and a live capture, and MAY carry a challenge item. Absence of the challenge selects the 2-way flow. The request MUST be encrypted to the Embedding Verifier.
+
+| Item | Supplied by |
+| --- | --- |
+| `credential_image` | the Authenticator, from the user's Credential |
+| `live_image` | the Authenticator, captured at proof time |
+| `challenge_image` | the RP |
+
+### Commitments
+
+The Embedding Verifier MUST emit one commitment per item, over the bytes it received. It MUST NOT commit to an embedding it extracted from an image.
+
+Each commitment is later checked for equality against the Issuer's claim, the Authenticator's `cdh`, or the RP's public input, as specified in [WIP-111 Commitments](wip-111.md#commitments).
+
+### Extraction, Quality and Presentation Attack Detection
+
+> TODO. Needs to make clear that currently this is out of bounds for the spec and is defined by the provider of the Embedding Verifier.
+
+### Comparison
+
+> TODO. Which pairs are compared, and the metric, normalization and range for each score. [WIP-111][wip-111] compares scores against an RP threshold, so the encoding MUST be monotonic in similarity and MUST NOT wrap in the field.
+
+A request MAY carry a minimum threshold so the Embedding Verifier can decline to emit a token for a comparison that would fail [WIP-111][wip-111] anyway. This is a convenience. The threshold that matters is the public input of [WIP-111][wip-111]; one in this request carries no guarantee.
+
+### Token
+
+The output is a CWT signed with EdDSA-Poseidon2 over BabyJubJub, carrying the claims in [WIP-111 Token Claims](wip-111.md#token-claims).
+
+> TODO: claim keys and encoding, expiry, and the claims needed to identify the Verifier for key attestation.
+
+### Verifiability and reproducible builds
+
+OCI verification, reproducible builds. Models may be injected at runtime but it must be provable in the code that models have no network access or disk persistence to exfiltrate information.
 
 ## Use Cases
 
-
+> TODO
 
 ## Rationale
 
-
-
-
+**Commitments are over received bytes.** Committing to an extracted embedding would produce a value no other party ever signed, leaving [WIP-111][wip-111] nothing to bind it to.
 
 ## Security
 
-
+> TODO. At minimum: what the attestation covers, what a compromised signing key can forge, model substitution, and the fact that this spec does not improve the trust assumption for the `live` image, which still rests on Authenticator integrity.
 
 ## Backwards Compatibility
 
 This World Improvement Proposal (WIP) introduces a new interface; no existing contracts or other previously existing functionality is affected.
+
+[wip-111]: wip-111.md

--- a/docs/WIPs/wip-110.md
+++ b/docs/WIPs/wip-110.md
@@ -67,7 +67,7 @@ The output is a CWT signed with EdDSA-Poseidon2 over BabyJubJub, carrying the cl
 
 OCI verification, reproducible builds. Models may be injected at runtime but it must be provable in the code that models have no network access or disk persistence to exfiltrate information.
 
-## Use Cases
+### Key Registry
 
 > TODO
 

--- a/docs/WIPs/wip-110.md
+++ b/docs/WIPs/wip-110.md
@@ -1,0 +1,38 @@
+---
+wip: 110
+title: Trusted Embedding Verifier
+description: Defines a trusted execution environment-backed for embedding extraction from images and comparison against one or many.
+author: Kilian Glas (@kilianglas), Paolo D'Amico (@paolodamico)
+status: Draft
+type: Informative
+created: 2026-08-03
+---
+
+## Abstract
+
+## Motivation
+
+
+## Specification
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).
+
+
+
+## Use Cases
+
+
+
+## Rationale
+
+
+
+
+
+## Security
+
+
+
+## Backwards Compatibility
+
+This World Improvement Proposal (WIP) introduces a new interface; no existing contracts or other previously existing functionality is affected.

--- a/docs/WIPs/wip-110.md
+++ b/docs/WIPs/wip-110.md
@@ -1,7 +1,7 @@
 ---
 wip: 110
-title: Embedding Verifier
-description: A service that extracts vector embeddings, compares them, and signs a token committing to its inputs and results.
+title: Flamingo Verifier
+description: A TEE-backed service that extracts vector embeddings, compares them, and signs a token committing to its inputs and results.
 author: Kilian Glas (@kilianglas), Paolo D'Amico (@paolodamico)
 status: 🚧 Draft
 type: Informational
@@ -11,15 +11,13 @@ created: 2026-08-03
 > [!NOTE]  
 > This spec outlines a draft functionality for beta testing. Changes are expected.
 
-## Abstract
+## 1. Abstract
 
-This spec defines the **Embedding Verifier**: a trusted execution environment (TEE) service that receives a credential item, a live capture, and optionally a challenge item; extracts a vector embedding from any of them supplied as raw media; compares them; and signs a token committing to every input it received and every score it produced.
+This spec defines the **Flamingo Verifier** (also called **Verifier** in the context of this spec): a trusted execution environment (TEE) service that receives a credential item, a live capture, and optionally a challenge item; extracts a vector embedding from any of them supplied as raw media; compares them; and signs a token committing to every input it received and every score it produced.
 
 The token is its only output. [WIP-111][wip-111] consumes it to prove the comparison to a Relying Party without revealing any item.
 
-**Embedding Verifier** is the name used across the Protocol for this component. "TEE verifier", "trusted verifier", "enclave", etc. MUST NOT be used as synonyms.
-
-## Motivation
+## 2. Motivation
 
 Comparing two embeddings is cheap. Getting an embedding anyone should believe is not.
 
@@ -27,13 +25,13 @@ Extraction runs a model over raw media, which is impractical in a ZK circuit. Th
 
 Running extraction and comparison in an attested Trusted Execution Environment keeps the inputs private and the execution verifiable. Committing to the raw inputs makes the result usable by a verifier who trusts neither the prover nor the prover's device.
 
-## Specification
+## 3. Specification
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).
 
-### Inputs
+### 3.1 Inputs
 
-A request MUST carry a credential item and a live capture, and MAY carry a challenge item. Absence of the challenge selects the 2-way flow. The request MUST be encrypted to the Embedding Verifier.
+A request MUST carry a credential item and a live capture, and MAY carry a challenge item. Absence of the challenge selects the 2-way flow. The request MUST be encrypted to the Verifier.
 
 | Item | Supplied by |
 | --- | --- |
@@ -41,46 +39,91 @@ A request MUST carry a credential item and a live capture, and MAY carry a chall
 | `live_image` | the Authenticator, captured at proof time |
 | `challenge_image` | the RP |
 
-### Commitments
+### 3.2 Commitments
 
-The Embedding Verifier MUST emit one commitment per item, over the bytes it received. It MUST NOT commit to an embedding it extracted from an image.
+The Verifier MUST emit one commitment per item, over the bytes it received. It MUST NOT commit to an embedding it extracted from an image.
 
-Each commitment is later checked for equality against the Issuer's claim, the Authenticator's `cdh`, or the RP's public input, as specified in [WIP-111 Commitments](wip-111.md#commitments).
+Each commitment is later checked for equality against the Issuer's claim, the Authenticator's `cdh`, or the RP's public input, as specified in [WIP-111 Commitments](wip-111.md#34-commitments).
 
-### Extraction, Quality and Presentation Attack Detection
+### 3.3 Extraction, Quality and Presentation Attack Detection
 
-> TODO. Needs to make clear that currently this is out of bounds for the spec and is defined by the provider of the Embedding Verifier.
+> TODO. Needs to make clear that currently this is out of bounds for the spec and is defined by the provider of the Verifier.
 
-### Comparison
+### 3.4 Comparison
 
 > TODO. Which pairs are compared, and the metric, normalization and range for each score. [WIP-111][wip-111] compares scores against an RP threshold, so the encoding MUST be monotonic in similarity and MUST NOT wrap in the field.
+>
+> Two scores are defined in [§3.5.1](#351-token-claims), both against the credential item. If the challenge-to-live pair is gated as well, its score belongs in the token; the `t=8` digest state has exactly one free slot for it.
 
-A request MAY carry a minimum threshold so the Embedding Verifier can decline to emit a token for a comparison that would fail [WIP-111][wip-111] anyway. This is a convenience. The threshold that matters is the public input of [WIP-111][wip-111]; one in this request carries no guarantee.
+A request MAY carry a minimum threshold so the Verifier can decline to emit a token for a comparison that would fail [WIP-111][wip-111] anyway. This is a convenience. The threshold that matters is the public input of [WIP-111][wip-111]; one in this request carries no guarantee.
 
-### Token
+### 3.5 Token
 
-The output is a CWT signed with EdDSA-Poseidon2 over BabyJubJub, carrying the claims in [WIP-111 Token Claims](wip-111.md#token-claims).
+The output is a CWT `COSE_Sign1`-signed with EdDSA-Poseidon2 over BabyJubJub, encoded as deterministic CBOR, following the requirements [WIP-106][wip-106] sets for tokens of this algorithm.
 
-> TODO: claim keys and encoding, expiry, and the claims needed to identify the Verifier for key attestation.
+#### 3.5.1 Token claims
 
-### Verifiability and reproducible builds
+| Claim | Key | Encoded key | Description |
+| --- | --- | --- | --- |
+| `iat` | `6` | `06` | Time of the comparison, seconds since the Unix epoch. |
+| `eat_profile` | `265` | `19 01 09` | URI identifying the profile, as [RFC 9711](https://datatracker.ietf.org/doc/rfc9711/) §4.3.2. MUST be `https://world.org/eat/evt/v1`. |
+| `credential_commitment` | `-90000` | `3a 00 01 5f 8f` | Commitment to `credential_image`. |
+| `live_commitment` | `-90001` | `3a 00 01 5f 90` | Commitment to `live_image`. |
+| `challenge_commitment` | `-90002` | `3a 00 01 5f 91` | Commitment to `challenge_image`. `0` in the 2-way flow. |
+| `similarity_live` | `-90003` | `3a 00 01 5f 92` | Score for live against credential. |
+| `similarity_challenge` | `-90004` | `3a 00 01 5f 93` | Score for challenge against credential. `0` when `challenge_commitment` is `0`. |
+
+The claims MUST appear in the order above, which is the bytewise lexicographic order of their encoded keys required by deterministic CBOR ([RFC 8949 §4.2.1](https://datatracker.ietf.org/doc/html/rfc8949#section-4.2.1)).
+
+The private-use keys occupy a `-90000` block, distinct from the `-70000` and `-80000` blocks [WIP-106][wip-106] allocates, so no World ID claim key is reused across token types. All are below `-65536` as the [CWT Claims registry](https://www.iana.org/assignments/cwt/cwt.xhtml) requires for private use.
+
+Every claim value except `eat_profile` MUST be a single field element, encoded as a 32-byte CBOR byte string in canonical big-endian, as [WIP-106][wip-106] encodes `cdh`. `eat_profile` is a text string and is excluded from the [signed digest](#352-signed-digest); like the TAKT's, it is therefore not signature-covered and MUST be treated as an untrusted hint outside a circuit.
+
+`iat` MUST be a numeric date in seconds since the Unix epoch, as defined in [RFC 8392](https://datatracker.ietf.org/doc/html/rfc8392#section-3.1.6), encoded as a 4-byte CBOR uint (`0x1a`), representable through year 2106. It MUST be the time of the comparison this token attests. A Verifier MUST NOT reuse an `iat` from an earlier comparison, and MUST NOT set it from a value supplied in the request.
+
+`iat` rather than `exp` because an RP needs the comparison's age, which is the security-relevant quantity for proving someone is present. An expiry would only say that some lifetime chosen by the Verifier had not elapsed. Without either, a single successful comparison is replayable forever: the Authenticator can mint a fresh `aat` carrying the same `cdh` for any later request, and every other constraint in [WIP-111][wip-111] still holds.
+
+[WIP-111][wip-111] keeps `iat` private and compares it in-circuit against an RP-supplied maximum age, so the RP learns the comparison was recent enough without learning when it happened. The operative maximum age is the RP's decision, not this spec's.
+
+#### 3.5.2 Signed digest
+
+As with the TAKT of [WIP-106][wip-106], the signed message is **not** the COSE `Sig_structure`. It MUST be the Poseidon2 `t=8` permutation over the domain separator followed by the claim values in deterministic CBOR map-key order ([RFC 8949 §4.2.1](https://datatracker.ietf.org/doc/html/rfc8949#section-4.2.1)), zero-padded:
+
+```
+[DS_EVT_V1, iat, credential_commitment, live_commitment, challenge_commitment, similarity_live, similarity_challenge, 0]
+```
+
+The digest is output state element `1`.
+
+| Constant | Value | Description |
+|----------|-------|-------------|
+| `DS_EVT_V1` | `453338657364062333832270442605270577` (`b"WORLD_ID_EVT_V1"`) | Domain separator for the Verifier token digest. |
+
+Because the digest is taken over field elements, a verifying circuit neither parses nor reconstructs CBOR; the CBOR encoding is the wire format only. Claims therefore need no fixed-width encoding, unlike the AAT.
+
+The `t=8` state holds the domain separator and seven claims. Six are defined, leaving one spare. An eighth claim would require a wider permutation and would change every digest.
+
+> TODO: the claims needed to identify the Verifier for key attestation.
+
+### 3.6 Verifiability and reproducible builds
 
 OCI verification, reproducible builds. Models may be injected at runtime but it must be provable in the code that models have no network access or disk persistence to exfiltrate information.
 
-### Key Registry
+### 3.7 Key Registry
 
 > TODO
 
-## Rationale
+## 4. Rationale
 
 **Commitments are over received bytes.** Committing to an extracted embedding would produce a value no other party ever signed, leaving [WIP-111][wip-111] nothing to bind it to.
 
-## Security
+## 5. Security
 
 > TODO. At minimum: what the attestation covers, what a compromised signing key can forge, model substitution, and the fact that this spec does not improve the trust assumption for the `live` image, which still rests on Authenticator integrity.
 
-## Backwards Compatibility
+## 6. Backwards Compatibility
 
 This World Improvement Proposal (WIP) introduces a new interface; no existing contracts or other previously existing functionality is affected.
 
+[wip-106]: https://github.com/worldcoin/world-id-protocol/pull/676
 [wip-111]: wip-111.md

--- a/docs/WIPs/wip-111.md
+++ b/docs/WIPs/wip-111.md
@@ -1,0 +1,122 @@
+---
+wip: 110
+title: Proof of Embedding Similarity
+description: Mechanism to prove similarity between vector embeddings based on a World ID credential.
+author: Paolo D'Amico (@paolodamico), Kilian Glas (@kilianglas)
+status: Draft
+type: Informative
+created: 2026-08-03
+---
+
+## Abstract
+
+## Motivation
+
+Being able to prove you are a particular person online is becoming increasingly important, such as combating deepfakes. Through the World ID Protocol, issuers can emit credentials to users committing to a particular vector embedding (e.g. representing a user's face). This spec introduces a mechanism by which an RP can challenge a user to prove they have a [Credential](https://docs.rs/world-id-primitives/latest/world_id_primitives/credential/struct.Credential.html) with an embedding which matches a challenged or expected embedding. One particular use case is proving you are the expected person behind a digital call using for example a Credential where an Issuer attests to how your face looks. 
+
+
+## Specification
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).
+
+
+### Circuit constants
+
+The Field ($F$), the Curve, and the Hashing ($H_t$) definitions MUST follow the requirements of [WIP-100][wip-100].
+
+This circuit does not introduce new constants.
+
+
+### Circuit Inputs
+
+`Pub` defines a public input to the circuit. Any inputs not defined as **Pub** MUST remain private. The purpose listed below is for reference, but is non-normative. Please see the [Circuit Constraints](#circuit-constraints) for details.
+
+| **Group** | Input | Purpose (Non-normative) |
+| --- | --- | --- |
+| Authenticator Assertion (WIP-106) | `aat` (Authenticator Assertion Token) | Provides (basic) integrity to the live image used for comparison based on Authenticator trust.<br />Ensures the image that was asserted in the AAT matches the image that was compared by the verifier TEE |
+| Authenticator Assertion (WIP-106) | **Pub.** `trust_anchor_key` (x, y) | Allows the RP to determine which Authenticator Providers they trust and that the AAT comes from a valid provider. |
+| Authenticator Assertion (WIP-106) | **Pub.** `sec_flags` | Allows the RP to review security metadata to make decisions on whether to accept the request or not. |
+| RP Inputs | **Pub.** `nonce` | Prevents replays. |
+| RP Inputs | **Pub.** `session_id` (**may be _nil_**) | Allows the RP to verify the same World ID is performing this proof. |
+| RP Inputs | **Pub.** `genesis_issued_at_min` | Allows the RP to specify a minimum timestamp when the type of credential was first issued. |
+| RP Inputs | **Pub**. `expires_at_min` | Allows the RP to verify that a non-expired credential was used. |
+| Embedding Verifier Inputs (WIP-110) | `cwt` | Provides verification that the embedding extraction and comparison process occurred in a trusted environment. |
+| Embedding Verifier Inputs (WIP-110) | **Pub.** `cwt_verifier_key` | Allows the RP to verify the environment which performed the embedding extraction and comparison. |
+| Embedding Verifier Inputs (WIP-110) | **Pub.** `challenge_image_hash` | Allows the RP to verify that the challenge image is the image to which the comparison is expected. |
+| Embedding Verifier Inputs (WIP-110) | **Pub.** `match_min_threshold` | Allows the RP to verify that the comparison result matched their minimum match threshold. |
+| Credential Validity | Merkle tree inclusion proof (`leaf_index`, `siblings`, `depth`) | Used to prove the World ID is validly registered in the `WorldIDRegistry`. |
+| Credential Validity | **Pub.** `merkle_root` | RP can verify the correct `WorldIDRegistry` was used. |
+| Credential Validity | Authenticator authorization (`sig_s`, `sig_r`, `pk_index`, `pk_set[]`) | To prove an authorized authenticator is executing the operation. |
+| Credential Validity | Credential inputs (`cred_associated_data_hash`, `cred_genesis_issued_at`, `cred_expires_at`, `cred_s`, `cred_r`, `cred_sub_blinding_factor`, `cred_id`) | Ensures a valid credential is used for the verification process |
+| Credential Validity | `claims[]` set from the credential as an array of 16 `FieldElement` | Ensures the image used in the verification environment is committed in the credential being used. |
+| Credential Validity | **Pub**. `cred_pk` (signer of the user’s credential) | To verify the correct issuer of the Credential. |
+
+
+### Circuit Constraints
+
+The Embedding Similarity Proof circuit MUST implement the following constraints (order is not relevant):
+
+
+## Trust Assumptions
+
+It is imperative for RPs to understand the trust assumptions behind this proof. Similar to how using any Credential requires taking certain assumptions from the Issuer. This section is **non-normative**, but it clearly outlines all the trust assumptions.
+
+```mermaid
+flowchart TB
+  %% Trust Assumptions
+  TAK(["🔑 trust_anchor_key"]):::anchor
+  ISS(["🔑 cred_pk"]):::anchor
+  VK(["🔑 cwt_verifier_key"]):::anchor
+  CH(["📌 Challenge image hash<br/>RP-computed from captured bytes"]):::anchor
+  MIN(["📌 match_min_threshold<br/>RP-supplied"]):::anchor
+
+  %% Input sources
+  AAT["AAT<br/>signal = H(live_image)"]
+  CRED["Credential<br/>claim[11] = image_hash"]
+  CWT["Verifier TEE CWT<br/>live_image_hash · credential_claim<br/>challenger_image_hash · match_coefficient"]
+
+  CIRCUIT{{"WIP-111 Circuit<br/>binds all + checks they match"}}
+  RP(["Relying Party"])
+
+  TAK -->|attests| AAT
+  ISS -->|signs| CRED
+  VK -->|signs| CWT
+
+  AAT -->|"signal == live_image_hash"| CIRCUIT
+  CRED -->|"claims == credential_claim"| CIRCUIT
+  CH -->|"== challenger_image_hash"| CIRCUIT
+  MIN -->|"match_coefficient ≥ min"| CIRCUIT
+  CWT -->|"comparison + committed hashes"| CIRCUIT
+
+  CIRCUIT -->|proof| RP
+
+  classDef anchor fill:#e8ecff,stroke:#3355bb,color:#111,stroke-width:2px;
+```
+
+## Use Cases
+
+
+
+## Rationale
+
+
+## Alternatives Considered
+
+
+
+
+
+## Security
+
+
+
+## Backwards Compatibility
+
+This World Improvement Proposal (WIP) introduces a new interface; no existing contracts or other previously existing functionality is affected.
+
+
+## Appendix: Test Vectors
+
+
+
+[wip-100]: https://github.com/worldcoin/world-id-protocol/pull/888

--- a/docs/WIPs/wip-111.md
+++ b/docs/WIPs/wip-111.md
@@ -25,7 +25,7 @@ Being able to prove you are a particular person online is becoming increasingly 
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).
 
-The terms [Authenticator](https://docs.rs/world-id-core/latest/world_id_core/struct.Authenticator.html), Issuer and [Credential](https://docs.rs/world-id-primitives/latest/world_id_primitives/credential/struct.Credential.html) are as defined in the World ID Protocol. **Verifier**, **WIP-110 Verifier** or **Flamingo Verifier** is as defined in [WIP-110][wip-110]. [WIP-106][wip-106] is not yet published in full; where this spec cites it for the AAT and TAKT structure, the authoritative reference until then is the `authenticator-assertion` library under `crates/proof/noir/`.
+The terms [Authenticator](https://docs.rs/world-id-core/latest/world_id_core/struct.Authenticator.html), Issuer and [Credential](https://docs.rs/world-id-primitives/latest/world_id_primitives/credential/struct.Credential.html) are as defined in the World ID Protocol. **Verifier**, **WIP-110 Verifier** or **Flamingo Verifier** is as defined in [WIP-110][wip-110].
 
 This circuit compares three items: the **credential** item, the **live** capture, and the RP's **challenge**. It never sees any of them. It sees a commitment to each (as a `FieldElement`), and a similarity score per compared pair. Whether an item was an image or a vector is decided in [WIP-110][wip-110] and is invisible here.
 
@@ -55,7 +55,7 @@ The following are defined elsewhere, included for reference:
 
 ### 3.2 Circuit Inputs
 
-`Pub` defines a public input to the circuit. Any inputs not defined as **Pub** MUST remain private. The purpose listed below is for reference, but is non-normative. See [Circuit Constraints](#35-circuit-constraints) for what is enforced.
+**`Pub`** defines a public input to the circuit. Any inputs not defined as **Pub** MUST remain private. The purpose listed below is for reference, but is non-normative. See [Circuit Constraints](#35-circuit-constraints) for what is enforced.
 
 | **Group** | Input | Type | Purpose (Non-normative) |
 | --- | --- | --- | --- |
@@ -67,10 +67,10 @@ The following are defined elsewhere, included for reference:
 | RP Inputs | **Pub.** `nonce` | Field element | Prevents replays. Also the `aat` `nonce`. |
 | RP Inputs | **Pub.** `rp_id` | Field element | The `aat` audience. A `u64`, so `< 2^64`; `0` is a valid value. |
 | RP Inputs | **Pub.** `now` | Field element | Current time in Unix **seconds**, to check expiries. Milliseconds fail every proof. |
-| RP Inputs | **Pub.** `session_id` (**may be _nil_**) | Field element | Lets the RP verify the same World ID is performing this proof. |
+| RP Inputs | **Pub.** `session_id` (may be _nil_) | Field element | Lets the RP verify the same World ID is performing this proof. |
 | RP Inputs | **Pub.** `genesis_issued_at_min` | Field element | Minimum timestamp for when the credential type was first issued. |
-| RP Inputs | `session_id_r` | Field element | Blinding factor for the session commitment. MUST be sampled per session from a CSPRNG uniformly over $F$ and MUST NOT be reused: `leaf_index < 2^30`, so a low-entropy or reused value lets anyone holding `session_id` brute-force it. |
-| [WIP-110][wip-110] Verifier | `cwt` | claims + EdDSA signature | Carries every commitment and score. See [Token Claims](#33-token-claims). |
+| RP Inputs | `session_id_r` | Field element | Blinding factor for the session commitment. |
+| [WIP-110][wip-110] Verifier | `cwt` | claims + EdDSA signature | To prove the output from the Verifier. See [Token Claims](#33-token-claims). |
 | [WIP-110][wip-110] Verifier | **Pub.** `verifier_key` | `PublicKey` | Lets the RP identify which Verifier ran. Signed the `cwt`. |
 | [WIP-110][wip-110] Verifier | **Pub.** `challenge_commitment` (**may be _nil_**) | Field element | Lets the RP verify its own challenge item was the one compared. Nil (`0`) in the 2-way flow. |
 | [WIP-110][wip-110] Verifier | **Pub.** `comparison_age_max` | Field element | Oldest comparison, in seconds, the RP will accept. |
@@ -121,7 +121,7 @@ The Embedding Similarity Proof circuit MUST implement the following constraints 
 
 Every ordering comparison below (`<`, `<=`, `>=`) is over the canonical integer representative of a value range-checked to a stated width, never over $F$, which has no ordering. Timestamps, ages and `rp_id` are 64-bit; scores and thresholds are 64-bit.
 
-Hashing ($H_t$), EdDSA and Merkle inclusion are as defined in [WIP-100][wip-100]. The Uniqueness Proof and the Query Proof do not yet have their own WIPs; where referenced they mean those circuits as currently implemented.
+Hashing ($H_t$), EdDSA and Merkle inclusion are as defined in [WIP-100][wip-100]. The Uniqueness Proof and the Query Proof do not yet have their own WIPs, but they follow the introductory [World ID 4.0 Specs](https://github.com/worldcoin/world-id-protocol/tree/main/docs/world-id-4-specs).
 
 **Credential Validity**
 
@@ -142,7 +142,7 @@ Hashing ($H_t$), EdDSA and Merkle inclusion are as defined in [WIP-100][wip-100]
 12. **Assertion metadata exposure.** Unpack `sec_flags` from the `takt` with a range check on every sub-field, including that all reserved bits are `0`. Expose as public inputs only the sub-fields the RP's policy requires; the packed `sec_flags` MUST NOT itself be a public input, because its 32-bit `build_version` is constant per authenticator build and identical at every RP, making it a cross-RP correlator. The `authenticator_meta` public input MUST equal the `aat` claim.
 13. **AAT request binding.** Constrain `aat.nonce == nonce` and `aat.aud == rp_id`.
 
-**WIP-110 Embedding**
+**Verifier**
 
 14. **Token verification.** The `cwt` claims are private inputs, one field element each. Compute the digest as defined in [WIP-110 Signed digest](wip-110.md#352-signed-digest) and verify it as a `BabyJubJub-EdDSA-Poseidon2` signature by `verifier_key`, following all the verification requirements of [WIP-100][wip-100]. The circuit MUST NOT parse or reconstruct CBOR.
 15. **Comparison age.** Range-check `iat`, `now` and `comparison_age_max` as 64-bit values. Constrain `iat <= now`, then `now - iat <= comparison_age_max`. The first check is required both because a future-dated token would otherwise satisfy any age bound, and because the second underflows in $F$ without it. Also constrain `comparison_age_max <= MAX_COMPARISON_AGE_SECS`, a backstop against an RP that sets no meaningful bound. `iat` stays private: the RP fixes the bound and the circuit applies it, so the exact time of the comparison need not be revealed.
@@ -160,11 +160,11 @@ Hashing ($H_t$), EdDSA and Merkle inclusion are as defined in [WIP-100][wip-100]
 20. **Session commitment.** Compute `computed = H_3(DS_SESSION_COMMITMENT; leaf_index, session_id_r)` and constrain `session_id * (session_id - computed) === 0`, so `session_id` is either nil or the correct commitment.
 21. **Verifier-supplied input validation.** `nonce`, `now`, `similarity_min` and `comparison_age_max` MUST NOT equal `0`. These are usually intended as sentinel values and could surface an incorrect use of them. `rp_id` MAY be `0`, which is a valid `RpId`.
 
-### 3.6 Verification
+### 3.6 Proof Verification
 
 The circuit proves its constraints hold. It cannot decide whether the parties involved are ones the RP trusts, or whether the comparison is recent enough for the RP's purpose. Verifiers (i.e. RPs) MUST perform the following checks outside the proof:
 
-1. **Proof verification.** The proof MUST verify under the verification key the RP has pinned for this circuit.
+1. **ZKP verification.** The proof MUST verify under the verification key the RP has pinned for this circuit.
 2. **Registry and Issuer.** `merkle_root` MUST be a current root of the canonical `WorldIDRegistry`. `cred_pk` MUST be a key the RP allowlists as an Issuer for `issuer_schema_id`, and `issuer_schema_id` and `issuer_version` MUST be the credential type and version the RP expects. Without these three, a prover mints its own credential over an item of its choosing and builds its own single-leaf registry, and every constraint still passes.
 3. **Claim index.** `claim_index` MUST be the index at which the expected credential schema places the embedding commitment. A prover is free to name any index, so an RP that does not pin this may have constraint 16 bind to an unrelated claim.
 4. **Comparison age.** `comparison_age_max` MUST be the value your policy requires; the circuit has already enforced it against the comparison time. It is RECOMMENDED to use a very short window, in the realm of a few minutes. The circuit's `MAX_COMPARISON_AGE_SECS` ceiling is only a backstop.

--- a/docs/WIPs/wip-111.md
+++ b/docs/WIPs/wip-111.md
@@ -11,25 +11,25 @@ created: 2026-08-03
 > [!NOTE]  
 > This spec outlines a draft functionality for beta testing. Changes are expected.
 
-## Abstract
+## 1. Abstract
 
 This spec introduces a new ZK circuit ("Embedding Similarity Proof") which proves that an embedding committed in a user's [Credential](https://docs.rs/world-id-primitives/latest/world_id_primitives/credential/struct.Credential.html) is similar to one or two other embeddings, without revealing any of them to the verifying party (an RP).
 
-The circuit neither extracts embeddings nor computes similarity. An Embedding Verifier ([WIP-110][wip-110]) does both, and signs a token committing to each input it consumed and each score it produced. This circuit verifies that token and checks three things: each commitment matches the party that vouches for it, the scores clear the RP's threshold, and the credential is valid.
+The circuit neither extracts embeddings nor computes similarity. A WIP-110 Verifier ([WIP-110][wip-110]) does both, and signs a token committing to each input it consumed and each score it produced. This circuit verifies that token and checks three things: each commitment matches the party that vouches for it, the scores clear the RP's threshold, and the credential is valid.
 
-## Motivation
+## 2. Motivation
 
 Being able to prove you are a particular person online is becoming increasingly important, such as combating deepfakes. Through the World ID Protocol, issuers can emit credentials to users committing to a particular vector embedding (e.g. representing a user's face). This spec introduces a mechanism by which an RP can challenge a user to prove they have a [Credential](https://docs.rs/world-id-primitives/latest/world_id_primitives/credential/struct.Credential.html) with an embedding which matches a challenged or expected embedding. One particular use case is proving you are the expected person behind a digital call using for example a Credential where an Issuer attests to how your face looks.
 
-## Specification
+## 3. Specification
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).
 
-The terms [Authenticator](https://docs.rs/world-id-core/latest/world_id_core/struct.Authenticator.html), Issuer and [Credential](https://docs.rs/world-id-primitives/latest/world_id_primitives/credential/struct.Credential.html) are as defined in the World ID Protocol. **Embedding Verifier** is as defined in [WIP-110][wip-110].
+The terms [Authenticator](https://docs.rs/world-id-core/latest/world_id_core/struct.Authenticator.html), Issuer and [Credential](https://docs.rs/world-id-primitives/latest/world_id_primitives/credential/struct.Credential.html) are as defined in the World ID Protocol. **Verifier**, **WIP-110 Verifier** or **Flamingo Verifier** is as defined in [WIP-110][wip-110]. [WIP-106][wip-106] is not yet published in full; where this spec cites it for the AAT and TAKT structure, the authoritative reference until then is the `authenticator-assertion` library under `crates/proof/noir/`.
 
-This circuit compares three items: the **credential** item, the **live** capture, and the RP's **challenge**. It never sees any of them. It sees a commitment to each (asa a `FieldElement`), and a similarity score per compared pair. Whether an item was an image or a vector is decided in [WIP-110][wip-110] and is invisible here.
+This circuit compares three items: the **credential** item, the **live** capture, and the RP's **challenge**. It never sees any of them. It sees a commitment to each (as a `FieldElement`), and a similarity score per compared pair. Whether an item was an image or a vector is decided in [WIP-110][wip-110] and is invisible here.
 
-### Circuit constants
+### 3.1 Circuit constants
 
 The Field ($F$), the Curve (`BabyJubJub`), and the Hashing ($H_t$) definitions MUST follow the requirements of [WIP-100][wip-100]. `H_t` refers to the hash built from a Poseidon2 permutation of `t` elements.
 
@@ -37,34 +37,44 @@ This circuit introduces the following constants:
 
 | Constant | Value | Description |
 |----------|-------|-------------|
-| `CLAIM_INDEX` | `11` | Index in `claims` holding the credential commitment. Determined by the Issuer's claim schema. |
 | `MAX_COMPARISON_AGE_SECS` | `86400` | Ceiling on the RP-supplied `comparison_age_max`, in seconds (24h). |
 | `DS_WIP_111` | `127603488023523044162070750169730678246161835968334` (`b"WORLD-ID/WIP-111/SIGN"`) | Domain separator for the authenticator authorization message. MUST NOT be reused outside it. |
 
-`NUM_KEYS`, `MERKLE_LEAF_DS`, `DS_CREDENTIAL_V1`, `DS_CREDENTIAL_SUB` and `DS_SESSION_COMMITMENT` are defined in the Query and Uniqueness Proofs, `MAX_CLAIMS` from the Credential, `AAT_MAX_LIFETIME` and `DS_TAKT` from [WIP-106][wip-106], and `DS_EDDSA` from [WIP-100][wip-100].
+The following are defined elsewhere, included for reference:
 
-### Circuit Inputs
+| Name | Label | Source |
+|------|-------|--------|
+| `NUM_KEYS` = `7`, `MAX_CLAIMS` = `15` | — | the Query Proof and the Credential |
+| `MERKLE_LEAF_DS` | `b"World ID PK"` | the Query Proof (`ds::AUTHENTICATOR_KEY_SET`) |
+| `DS_CREDENTIAL_V1` | `b"POSEIDON2+EDDSA-BJJ"` | the Credential (`ds::CREDENTIAL_V1`) |
+| `DS_CREDENTIAL_SUB` | `b"H_CS(id, r)"` | the Uniqueness Proof (`ds::CREDENTIAL_SUB`; `DS_C_CS` in [WIP-103](wip-103.md)) |
+| `DS_SESSION_COMMITMENT` | `b"H(id, r)"` | the Uniqueness Proof (`ds::SESSION_COMMITMENT`) |
+| `CLAIMS_HASH_V1` | `b"CLAIMS_HASH_V1"` | the Credential (`ds::CLAIMS_HASH_V1`) |
+| `DS_TAKT`, `MAX_AAT_LIFETIME_SECS` = `43200` | `b"WORLD_ID_TAKT_V1"` | [WIP-106][wip-106] |
+| `DS_EDDSA` | `b"EdDSA Signature"` | [WIP-100][wip-100] |
 
-`Pub` defines a public input to the circuit. Any inputs not defined as **Pub** MUST remain private. The purpose listed below is for reference, but is non-normative. See [Circuit Constraints](#circuit-constraints) for what is enforced.
+### 3.2 Circuit Inputs
+
+`Pub` defines a public input to the circuit. Any inputs not defined as **Pub** MUST remain private. The purpose listed below is for reference, but is non-normative. See [Circuit Constraints](#35-circuit-constraints) for what is enforced.
 
 | **Group** | Input | Type | Purpose (Non-normative) |
 | --- | --- | --- | --- |
-| Authenticator Assertion (WIP-106) | `aat` | claims + `ES256` signature | Vouches for the live capture. Its `cdh` claim commits to the live item. |
-| Authenticator Assertion (WIP-106) | `takt` | claims + EdDSA signature | Attests the `assertion_key` that signed the `aat`. |
-| Authenticator Assertion (WIP-106) | **Pub.** `trust_anchor_key` | `PublicKey` | Lets the RP decide which Authenticator Providers it trusts. |
-| Authenticator Assertion (WIP-106) | **Pub.** `sec_flags` | Field element | TAKT security metadata about the `assertion_key`. |
-| Authenticator Assertion (WIP-106) | **Pub.** `authenticator_meta` | Field element | AAT metadata, e.g. user presence. |
+| Authenticator Assertion ([WIP-106][wip-106]) | `aat` | claims + `ES256` signature | Vouches for the live capture. Its `cdh` claim commits to the live item. |
+| Authenticator Assertion ([WIP-106][wip-106]) | `takt` | claims + EdDSA signature | Attests the `assertion_key` that signed the `aat`. |
+| Authenticator Assertion ([WIP-106][wip-106]) | **Pub.** `trust_anchor_key` | `PublicKey` | Lets the RP decide which Authenticator Providers it trusts. |
+| Authenticator Assertion ([WIP-106][wip-106]) | `sec_flags` | Field element | Packed TAKT security metadata about the `assertion_key`. Private; only the sub-fields the RP needs are exposed, see constraint 12. |
+| Authenticator Assertion ([WIP-106][wip-106]) | **Pub.** `authenticator_meta` | Field element | AAT metadata, e.g. user presence. |
 | RP Inputs | **Pub.** `nonce` | Field element | Prevents replays. Also the `aat` `nonce`. |
-| RP Inputs | **Pub.** `rp_id` | Field element | The `aat` audience. |
-| RP Inputs | **Pub.** `now` | Field element | Current Unix timestamp, to check expiries. |
+| RP Inputs | **Pub.** `rp_id` | Field element | The `aat` audience. A `u64`, so `< 2^64`; `0` is a valid value. |
+| RP Inputs | **Pub.** `now` | Field element | Current time in Unix **seconds**, to check expiries. Milliseconds fail every proof. |
 | RP Inputs | **Pub.** `session_id` (**may be _nil_**) | Field element | Lets the RP verify the same World ID is performing this proof. |
 | RP Inputs | **Pub.** `genesis_issued_at_min` | Field element | Minimum timestamp for when the credential type was first issued. |
-| RP Inputs | `session_id_r` | Field element | Blinding factor for the session commitment. |
-| Embedding Verifier (WIP-110) | `cwt` | claims + EdDSA signature | Carries every commitment and score. See [Token Claims](#token-claims). |
-| Embedding Verifier (WIP-110) | **Pub.** `verifier_key` | `PublicKey` | Lets the RP identify which Embedding Verifier ran. Signed the `cwt`. |
-| Embedding Verifier (WIP-110) | **Pub.** `challenge_commitment` (**may be _nil_**) | Field element | Lets the RP verify its own challenge item was the one compared. Nil (`0`) in the 2-way flow. |
-| Embedding Verifier (WIP-110) | **Pub.** `comparison_age_max` | Field element | Oldest comparison, in seconds, the RP will accept. |
-| Embedding Verifier (WIP-110) | **Pub.** `similarity_min` | Field element | Lets the RP verify every score cleared its threshold. |
+| RP Inputs | `session_id_r` | Field element | Blinding factor for the session commitment. MUST be sampled per session from a CSPRNG uniformly over $F$ and MUST NOT be reused: `leaf_index < 2^30`, so a low-entropy or reused value lets anyone holding `session_id` brute-force it. |
+| [WIP-110][wip-110] Verifier | `cwt` | claims + EdDSA signature | Carries every commitment and score. See [Token Claims](#33-token-claims). |
+| [WIP-110][wip-110] Verifier | **Pub.** `verifier_key` | `PublicKey` | Lets the RP identify which Verifier ran. Signed the `cwt`. |
+| [WIP-110][wip-110] Verifier | **Pub.** `challenge_commitment` (**may be _nil_**) | Field element | Lets the RP verify its own challenge item was the one compared. Nil (`0`) in the 2-way flow. |
+| [WIP-110][wip-110] Verifier | **Pub.** `comparison_age_max` | Field element | Oldest comparison, in seconds, the RP will accept. |
+| [WIP-110][wip-110] Verifier | **Pub.** `similarity_min` | Field element | Lets the RP verify every score cleared its threshold. |
 | Credential Validity | **Pub.** `merkle_root` | Field element | Lets the RP verify the correct `WorldIDRegistry` was used. |
 | Credential Validity | **Pub.** `issuer_schema_id` | Field element | Lets the RP verify which credential type was used. |
 | Credential Validity | **Pub.** `cred_pk` | `PublicKey` | Lets the RP verify the Issuer of the Credential. |
@@ -73,86 +83,101 @@ This circuit introduces the following constants:
 | Credential Validity | `sig_s`, `sig_r` | Field element, [Field element; 2] | EdDSA signature by the selected authenticator key. |
 | Credential Validity | `leaf_index` | Field element | Index of the user's World ID in the `WorldIDRegistry`. |
 | Credential Validity | `siblings` | [Field element; 30] | Sibling nodes from `leaf_index` upwards. |
-| Credential Validity | `claims` | [Field element; `MAX_CLAIMS`] | Credential claims. `claims[CLAIM_INDEX]` holds the credential commitment. |
+| Credential Validity | **Pub.** `issuer_version` | Field element | Credential schema version, `< 2^8`. Decides the meaning of each claim, so the RP pins it with `issuer_schema_id`. |
+| Credential Validity | **Pub.** `claim_index` | Field element | Index in `claims` holding the credential commitment. Fixed by the Issuer's claim schema, so the RP pins it per schema. |
+| Credential Validity | `claims` | [Field element; `MAX_CLAIMS`] | Credential claims. `claims[claim_index]` holds the credential commitment. |
 | Credential Validity | `cred_s`, `cred_r` | Field element, [Field element; 2] | EdDSA signature by the Issuer over the Credential. |
 | Credential Validity | `cred_associated_data_hash`, `cred_genesis_issued_at`, `cred_expires_at`, `cred_sub_blinding_factor`, `cred_id` | Field element | Remaining Credential fields covered by the Issuer signature. |
 
 A `PublicKey` is as defined in [WIP-100][wip-100]: an EdDSA public key as its coordinates $(x,y)$, each a Field element.
 
-### Token Claims
+### 3.3 Token Claims
 
-Defined in [WIP-110 Token claims](wip-110.md#token-claims). The circuit reads `iat`, `credential_commitment`, `live_commitment`, `challenge_commitment`, `similarity_live` and `similarity_challenge`. All are private.
+Defined in [WIP-110 Token claims](wip-110.md#351-token-claims). The circuit reads `iat`, `credential_commitment`, `live_commitment`, `challenge_commitment`, `similarity_live` and `similarity_challenge`. All are private.
 
-### Commitments
+### 3.4 Commitments
 
-The equality between commitments is what anchors the proof to ecah input.
+The equality between commitments is what anchors the proof to each input.
 
 | Commitment | Equals | Vouched for by |
 | --- | --- | --- |
-| `credential_commitment` | `claims[i]` of the Credential | the Issuer |
+| `credential_commitment` | `claims[claim_index]` of the Credential | the Issuer |
 | `live_commitment` | the `cdh` claim of the `aat` | the Authenticator Provider |
 | `challenge_commitment` | the `challenge_commitment` public input | the RP |
 
-The Embedding Verifier does not see the `aat`, the Credential, or the RP's public input. It only hashes the bytes it was given. Each commitment MUST be computed in the following manner:
+The Verifier does not see the `aat`, the Credential, or the RP's public input. It only hashes the bytes it was given. Each commitment MUST be computed in the following manner:
 
 - `credential_commitment` must be the Poseidon2 sponge defined in [WIP-100][wip-100] with the variable domain separator `CLAIMS_HASH_V1`.
 - `live_commitment` must be the Poseidon2 sponge defined in [WIP-100][wip-100] with the variable domain separator `WORLD-ID/WIP-111/LIVE`.
 - `challenge_commitment` must be the Poseidon2 sponge defined in [WIP-100][wip-100] with the variable domain separator `WORLD-ID/WIP-111/CHALLENGE`.
 
-Commitments MUST be over the bytes the Embedding Verifier received. The circuit hashes nothing. Every binding above is an equality in $F$.
+Commitments MUST be over the bytes the Verifier received. The circuit hashes nothing. Every binding above is an equality in $F$.
 
-### Circuit Constraints
+These functions are not the Verifier's alone to choose. Because the circuit only checks equality, the Authenticator MUST compute the `aat` `cdh` and the RP MUST compute its `challenge_commitment` public input with the same function and domain separator. [WIP-106][wip-106] leaves `cdh` as any collision-resistant digest, so this spec is what pins it for this circuit.
 
-The Embedding Similarity Proof circuit MUST implement the following constraints (order is not relevant). The circuit MUST NOT introduce public inputs beyond those in [Circuit Inputs](#circuit-inputs). Groups match those in [Circuit Inputs](#circuit-inputs).
+### 3.5 Circuit Constraints
+
+The Embedding Similarity Proof circuit MUST implement the following constraints (order is not relevant). The circuit MUST NOT introduce public inputs beyond those in [Circuit Inputs](#32-circuit-inputs).
+
+Every ordering comparison below (`<`, `<=`, `>=`) is over the canonical integer representative of a value range-checked to a stated width, never over $F$, which has no ordering. Timestamps, ages and `rp_id` are 64-bit; scores and thresholds are 64-bit.
 
 Hashing ($H_t$), EdDSA and Merkle inclusion are as defined in [WIP-100][wip-100]. The Uniqueness Proof and the Query Proof do not yet have their own WIPs; where referenced they mean those circuits as currently implemented.
 
-#### Credential Validity
+**Credential Validity**
 
 1. **Key selection.** Select `pk = user_pk[pk_index]`, constraining `pk_index < NUM_KEYS` as a comparison over the full field $F$ and not a truncating cast, for the same `pk_index` witness used to index.
 2. **Empty key slots.** `user_pk` MUST hold `NUM_KEYS` entries in `WorldIDRegistry` slot order, with inactive slots encoded as the identity $(0,1)$. No separate validity check on the selected `pk` is needed: [WIP-100][wip-100] signature verification already requires it to satisfy the curve equation, lie in the prime-order subgroup and not be the identity, which is what rejects an inactive slot in constraint 5.
 3. **Registry leaf.** Compute the `WorldIDRegistry` leaf as the authenticator key set commitment defined in the Query Proof: `key_set_commitment = H_16(MERKLE_LEAF_DS; user_pk[0].x, user_pk[0].y, …, user_pk[6].x, user_pk[6].y)`, the `NUM_KEYS` keys as $(x, y)$ pairs at state indices `1..14` with index `15` zero. All slots MUST be included in order, including inactive ones.
-4. **Merkle inclusion proof.** Recompute the root from `key_set_commitment` at position `leaf_index` using `siblings`, per [WIP-100][wip-100], and constrain it equals `merkle_root`. [WIP-100][wip-100] fixes the depth at 30 and requires $0 < \texttt{leaf\_index} < 2^{30}$, so the circuit takes no depth input.
-5. **Authenticator authorization.** Compute `message = H_4(DS_WIP_111; live_commitment, nonce, rp_id)` and verify `(sig_r, sig_s)` as a `BabyJubJub-EdDSA-Poseidon2` signature by the `pk` of constraint 1 over `message`, following all the verification requirements of [WIP-100][wip-100]. The message differs from the Query Proof, which signs the OPRF `query`.
+4. **Merkle inclusion proof.** Recompute the root from `key_set_commitment` at position `leaf_index` using `siblings`, per [WIP-100][wip-100], and constrain it equals `merkle_root`. [WIP-100][wip-100] fixes the depth at 30 and requires `0 < leaf_index < 2^30`, so the circuit takes no depth input.
+5. **Authenticator authorization.** Compute `message = H_4(DS_WIP_111; live_commitment, nonce, rp_id)` and verify `(sig_r, sig_s)` as a `BabyJubJub-EdDSA-Poseidon2` signature by the `pk` of constraint 1 over `message`, following all the verification requirements of [WIP-100][wip-100]. The `live_commitment` here MUST be the same witness as the `cwt` claim read in constraint 14 and bound in constraint 17; otherwise the authenticator authorizes an arbitrary field element rather than this capture. The message differs from the Query Proof, which signs the OPRF `query`.
 6. **Credential subject commitment.** Compute `sub = H_3(DS_CREDENTIAL_SUB; leaf_index, cred_sub_blinding_factor)`.
-7. **Claims hash.** Compute `claims_hash` as the Poseidon2 $t=16$ permutation over `[claims[0], …, claims[14], 0]`. This construction carries no domain separator; `claims[0]` occupies the capacity element. The Uniqueness Proof takes `claims_hash` as a direct input; this circuit MUST take the `claims` array and MUST use the same `claims` witness in constraint 16. FIXME: UPDATE TO CREDENTIAL V2.
-8. **Credential signature.** Compute `message = H_8(DS_CREDENTIAL_V1; issuer_schema_id, sub, cred_genesis_issued_at, cred_expires_at, claims_hash, cred_associated_data_hash, cred_id)` using the `sub` of constraint 6 and the `claims_hash` of constraint 7, and verify `(cred_r, cred_s)` as a `BabyJubJub-EdDSA-Poseidon2` signature by `cred_pk` over `message`, following all the verification requirements of [WIP-100][wip-100].
-9. **Credential validity window.** Range-check `cred_genesis_issued_at` and `cred_expires_at` as 64-bit values. Constrain `now < cred_expires_at` and `genesis_issued_at_min <= cred_genesis_issued_at`.
+7. **Claims hash.** Compute `claims_hash` as the Poseidon2 $t=16$ permutation over `[claims[0], …, claims[14], 0]`, where state index `15` is the fixed zero capacity element and `claims_hash` is output state element `1`. This construction carries no domain separator and matches neither $H_t$ (capacity at index `0`, digest at element `1`) nor $H_\text{var}$ (capacity at index `15`, squeezed from element `0`) of [WIP-100][wip-100]; it MUST be implemented exactly as stated. The Uniqueness Proof takes `claims_hash` as a direct input; this circuit MUST take the `claims` array and MUST use the same `claims` witness in constraint 16. FIXME: UPDATE TO CREDENTIAL V2, the way `claims_hash` is computed will change.
+8. **Credential signature.** Compute the packed identifier `cred_id_packed = cred_id + issuer_version * 2^64`, range-checking `cred_id < 2^64` and `issuer_version < 2^8`. Then compute `message = H_8(DS_CREDENTIAL_V1; issuer_schema_id, sub, cred_genesis_issued_at, cred_expires_at, claims_hash, cred_associated_data_hash, cred_id_packed)` using the `sub` of constraint 6 and the `claims_hash` of constraint 7, and verify `(cred_r, cred_s)` as a `BabyJubJub-EdDSA-Poseidon2` signature by `cred_pk` over `message`, following all the verification requirements of [WIP-100][wip-100]. The packing is REQUIRED: the Issuer signature covers `issuer_version`, so a circuit signing `cred_id` alone rejects every credential whose `issuer_version` is not `0`.
+9. **Credential validity window.** Range-check `cred_genesis_issued_at`, `cred_expires_at`, `now` and `genesis_issued_at_min` as 64-bit values. Constrain `now < cred_expires_at` and `genesis_issued_at_min <= cred_genesis_issued_at`.
 10. **Leaf-index binding.** The `leaf_index` blinded into `sub` in constraint 6, the position proven in constraint 4, and the one hashed in constraint 20 MUST be the same witness. The circuit MUST NOT accept independent values. This binding is **essential**, otherwise the circuit only proves the prover controls the `sk` of **some** registered leaf, not the one the Credential was issued to.
 
-#### Authenticator Assertion
+**Authenticator Assertion**
 
-11. **Attestation verification.** Verify the `takt` and the `aat` together, as defined in [WIP-106][wip-106]: the `takt` signature by `trust_anchor_key` over the TAKT digest, the `aat` `ES256` signature over its COSE `Sig_structure`, both unexpired at `now`, and `aat.exp` no more than `AAT_MAX_LIFETIME` beyond `now`. The `ES256` key verifying the `aat` MUST be the `assertion_key` the `takt` attests; this is the sole binding between the two tokens. `trust_anchor_key` and `now` MUST be public inputs, otherwise a prover signs its own `takt` or picks a time at which any token is fresh.
-12. **Assertion metadata exposure.** The `sec_flags` public input MUST equal the `takt` claim, unpacked with a range check on every sub-field including reserved bits. The `authenticator_meta` public input MUST equal the `aat` claim.
+11. **Attestation verification.** Verify the `takt` and the `aat` together, as defined in [WIP-106][wip-106] and following all the verification requirements of [WIP-100][wip-100] for the `takt` signature: the `takt` signature by `trust_anchor_key` over the TAKT digest, the `aat` `ES256` signature over its COSE `Sig_structure`, both unexpired at `now`, and `aat.exp` no more than `MAX_AAT_LIFETIME_SECS` beyond `now`. The `ES256` key verifying the `aat` MUST be the `assertion_key` the `takt` attests; this is the sole binding between the two tokens. `trust_anchor_key` and `now` MUST be public inputs, otherwise a prover signs its own `takt` or picks a time at which any token is fresh.
+12. **Assertion metadata exposure.** Unpack `sec_flags` from the `takt` with a range check on every sub-field, including that all reserved bits are `0`. Expose as public inputs only the sub-fields the RP's policy requires; the packed `sec_flags` MUST NOT itself be a public input, because its 32-bit `build_version` is constant per authenticator build and identical at every RP, making it a cross-RP correlator. The `authenticator_meta` public input MUST equal the `aat` claim.
 13. **AAT request binding.** Constrain `aat.nonce == nonce` and `aat.aud == rp_id`.
 
-#### Embedding Verifier
+**WIP-110 Embedding**
 
-14. **Token verification.** The `cwt` claims are private inputs, one field element each. Compute the digest as defined in [WIP-110 Signed digest](wip-110.md#signed-digest) and verify it as a `BabyJubJub-EdDSA-Poseidon2` signature by `verifier_key`, following all the verification requirements of [WIP-100][wip-100]. The circuit MUST NOT parse or reconstruct CBOR.
-15. **Comparison age.** Constrain `iat <= now`, then `now - iat <= comparison_age_max`. The first check is required both because a future-dated token would otherwise satisfy any age bound, and because the second underflows in $F$ without it. Also constrain `comparison_age_max <= MAX_COMPARISON_AGE_SECS`, a backstop against an RP that sets no meaningful bound. `iat` stays private: the RP fixes the bound and the circuit applies it, so the exact time of the comparison need not be revealed.
-16. **Credential commitment binding.** `credential_commitment` MUST equal `claims[CLAIM_INDEX]`, for the `claims` witness of constraint 7. This binding is **essential**, otherwise the circuit only proves the Embedding Verifier compared against **some** item, not the one this Credential commits to.
+14. **Token verification.** The `cwt` claims are private inputs, one field element each. Compute the digest as defined in [WIP-110 Signed digest](wip-110.md#352-signed-digest) and verify it as a `BabyJubJub-EdDSA-Poseidon2` signature by `verifier_key`, following all the verification requirements of [WIP-100][wip-100]. The circuit MUST NOT parse or reconstruct CBOR.
+15. **Comparison age.** Range-check `iat`, `now` and `comparison_age_max` as 64-bit values. Constrain `iat <= now`, then `now - iat <= comparison_age_max`. The first check is required both because a future-dated token would otherwise satisfy any age bound, and because the second underflows in $F$ without it. Also constrain `comparison_age_max <= MAX_COMPARISON_AGE_SECS`, a backstop against an RP that sets no meaningful bound. `iat` stays private: the RP fixes the bound and the circuit applies it, so the exact time of the comparison need not be revealed.
+16. **Credential commitment binding.** Select exactly one claim `claims[claim_index]`, constraining `claim_index < MAX_CLAIMS` as a comparison over the full field $F$ and not a truncating cast, for the same `claim_index` witness used to index, and for the `claims` witness of constraint 7. `credential_commitment` MUST equal the selected claim. This binding is **essential**, otherwise the circuit only proves the Verifier compared against **some** item, not the one this Credential commits to.
 17. **Live commitment binding.** `live_commitment` MUST equal the `cdh` claim of the `aat`.
 18. **Challenge commitment binding.** The `challenge_commitment` public input MUST equal the `challenge_commitment` claim. The equality is unconditional, so a nil public input requires the claim to be `0`, which is the 2-way flow.
-19. **Similarity floor.** Constrain `similarity_live >= similarity_min`. Let `is_absent` be `1` when `challenge_commitment` is `0` and `0` otherwise, set `effective_min = similarity_min * (1 - is_absent)`, and constrain `similarity_challenge >= effective_min`.
+19. **Similarity floor.** Range-check `similarity_live`, `similarity_challenge` and `similarity_min` as 64-bit values, and constrain `similarity_live >= similarity_min`.
+    For the challenge leg the circuit MUST constrain the witness `is_absent`; it MUST NOT be accepted as a free input:
+    1. `is_absent * (1 - is_absent) === 0`, so `is_absent` is boolean.
+    2. `is_absent * challenge_commitment === 0`, so a non-nil `challenge_commitment` forces `is_absent = 0`.
+    Then set `effective_min = similarity_min * (1 - is_absent)` and constrain `similarity_challenge >= effective_min`. Both constraints are **essential**: without them a prover witnesses `is_absent = 1` alongside a non-nil `challenge_commitment`, drives `effective_min` to `0`, and the challenge comparison is never enforced while every other constraint still passes. A non-boolean `is_absent = 1 - k` would likewise scale the threshold to `k * similarity_min`. When `challenge_commitment` is nil the circuit need not pin `is_absent` further: `is_absent = 0` only tightens the bound.
 
-#### RP Inputs
+**RP Inputs**
 
 20. **Session commitment.** Compute `computed = H_3(DS_SESSION_COMMITMENT; leaf_index, session_id_r)` and constrain `session_id * (session_id - computed) === 0`, so `session_id` is either nil or the correct commitment.
-21. **Verifier-supplied input validation.** `nonce`, `rp_id`, `now`, `similarity_min` and `comparison_age_max` MUST NOT equal `0`. These are usually intended as sentinel values and could surface an incorrect use of them.
+21. **Verifier-supplied input validation.** `nonce`, `now`, `similarity_min` and `comparison_age_max` MUST NOT equal `0`. These are usually intended as sentinel values and could surface an incorrect use of them. `rp_id` MAY be `0`, which is a valid `RpId`.
 
-### Verification
+### 3.6 Verification
 
 The circuit proves its constraints hold. It cannot decide whether the parties involved are ones the RP trusts, or whether the comparison is recent enough for the RP's purpose. Verifiers (i.e. RPs) MUST perform the following checks outside the proof:
 
-1. **Comparison age.** `comparison_age_max` MUST be the value your policy requires; the circuit has already enforced it against the comparison time. It is RECOMMENDED to use a very short window, in the realm of a few minutes. The circuit's `MAX_COMPARISON_AGE_SECS` ceiling is only a backstop.
-2. **Verifier trust.** `verifier_key` MUST be on the RP's allowlist, and its key attestation MUST be verified out of band. See [WIP-110][wip-110].
-3. **Authenticator trust.** `trust_anchor_key` MUST be on the RP's allowlist, and `sec_flags` and `authenticator_meta` MUST satisfy the RP's policy. See [WIP-106][wip-106].
-4. **Timestamp.** `now` MUST be a valid current timestamp. It is RECOMMENDED to accept values within 5 minutes of the verifier's local time, per [WIP-106][wip-106].
-5. **Threshold and challenge.** `similarity_min` MUST be the value the RP requires, and `challenge_commitment` MUST be the commitment the RP computed over the item it supplied.
+1. **Proof verification.** The proof MUST verify under the verification key the RP has pinned for this circuit.
+2. **Registry and Issuer.** `merkle_root` MUST be a current root of the canonical `WorldIDRegistry`. `cred_pk` MUST be a key the RP allowlists as an Issuer for `issuer_schema_id`, and `issuer_schema_id` and `issuer_version` MUST be the credential type and version the RP expects. Without these three, a prover mints its own credential over an item of its choosing and builds its own single-leaf registry, and every constraint still passes.
+3. **Claim index.** `claim_index` MUST be the index at which the expected credential schema places the embedding commitment. A prover is free to name any index, so an RP that does not pin this may have constraint 16 bind to an unrelated claim.
+4. **Comparison age.** `comparison_age_max` MUST be the value your policy requires; the circuit has already enforced it against the comparison time. It is RECOMMENDED to use a very short window, in the realm of a few minutes. The circuit's `MAX_COMPARISON_AGE_SECS` ceiling is only a backstop.
+5. **Verifier trust.** `verifier_key` MUST be on the RP's allowlist, and its key attestation MUST be verified out of band. See [WIP-110][wip-110].
+6. **Authenticator trust.** `trust_anchor_key` MUST be on the RP's allowlist, and the exposed `sec_flags` sub-fields and `authenticator_meta` MUST satisfy the RP's policy. See [WIP-106][wip-106].
+7. **Request.** `rp_id` MUST be the RP's own id. The `nonce` MUST be one the RP generated from a CSPRNG over $F$, has not expired, and has not been seen before; it MUST be invalidated on use.
+8. **Timestamp.** `now` MUST be a valid current timestamp in Unix seconds. It is RECOMMENDED to accept values within 5 minutes of the verifier's local time, per [WIP-106][wip-106].
+9. **Policy values.** `similarity_min` and `genesis_issued_at_min` MUST be the values the RP requires, and `challenge_commitment` MUST be the commitment the RP computed over the item it supplied.
+10. **Session binding.** An RP that requires the proof to be bound to a specific World ID, in particular when composing with a Uniqueness Proof, MUST reject `session_id == 0` and MUST compare it for equality with the session commitment of the other proof. Nil is the prover's choice, not the RP's: constraint 20 is satisfied by the nil branch, so a prover may otherwise present two proofs belonging to different World IDs.
 
-Faling to verify the public inputs from the circuit breaks security and trust assumptions. Such verifications MUST NOT be skipped.
+Failing to verify the public inputs from the circuit breaks security and trust assumptions. Such verifications MUST NOT be skipped.
 
-## Trust Assumptions
+## 4. Trust Assumptions
 
 RPs need to understand what they are trusting. This section is **non-normative**.
 
@@ -165,8 +190,8 @@ flowchart TB
   MIN(["📌 similarity_min<br/>RP-supplied"]):::anchor
 
   AAT["AAT<br/>cdh = live_commitment"]
-  CRED["Credential<br/>claims[i] = credential_commitment"]
-  CWT["Embedding Verifier token<br/>3 commitments + scores"]
+  CRED["Credential<br/>claims[claim_index] = credential_commitment"]
+  CWT["WIP-110 Verifier token<br/>3 commitments + scores"]
 
   CIRCUIT{{"WIP-111 Circuit"}}
   RP(["Relying Party"])
@@ -186,25 +211,35 @@ flowchart TB
   classDef anchor fill:#e8ecff,stroke:#3355bb,color:#111,stroke-width:2px;
 ```
 
-The RP trusts the Issuer to have committed an item that describes the subject, the Authenticator Provider to have captured the live item (including having performed relevant checks to prevent/mitigate tampering with the input sensor), and the Embedding Verifier to have extracted and compared honestly. The circuit adds no trust of its own. It only proves the three attestations concern the same items.
+The RP trusts the Issuer to have committed an item that describes the subject, the Authenticator Provider to have captured the live item (including having performed relevant checks to prevent/mitigate tampering with the input sensor), and the Verifier to have extracted and compared honestly. The circuit adds no trust of its own. It only proves the three attestations concern the same items.
 
-## Use Cases
+## 5. Use Cases
 
-> TODO
+1. **RP-supplied challenge (3-way).** The RP captures a frame of the party it is interacting with and requests a proof against it. A valid proof establishes that the live capture and the RP's own frame are each similar to the credential item; the two are never compared to each other. That is enough for the RP to learn that the party it can observe is the credential subject.
+2. **Presence challenge (2-way).** `challenge_commitment` is nil. A valid proof establishes that the holder produced a live capture matching their own credential. It evidences presence (trusting the Authenticator Provider) without revealing who the person is.
 
-## Rationale
+## 6. Rationale
 
-> TODO
+- **Why an Authenticator Assertion when the Verifier receives the live image directly.** The Verifier cannot tell a camera capture from a file, and will extract an embedding from an image. Nothing else establishes provenance. The `aat` is the only statement that the bytes came from a device sensor under the Authenticator Provider's conditions, which is why `live_commitment` is bound to `cdh` rather than trusted from the token.
+- **Why the Credential is the reference for every comparison.** Comparing the live capture directly against the RP's challenge would prove that the person on the RP's screen is really there, but not who they are; any prover passes with their own face. The Credential is the only item a party has committed to ahead of time.
+- **Why there is no nullifier.** Similarity is not uniqueness, they serve different purposes. If a use case requires uniqueness, a second Uniqueness Proof can be requested.
 
-## Alternatives Considered
+## 7. Alternatives Considered
 
-> TODO
+**Comparing the embeddings in the circuit.** The circuit could take both embeddings as private inputs and compute the similarity itself, which would make its name describe its statement. Rejected because it removes no trust. Extraction cannot run in a circuit, so a Verifier is required either way; it would then have to attest that a given embedding was extracted from a given item, and forging that attestation is exactly as powerful as forging a score. The cost is real: fixed-point arithmetic, the embedding dimension fixed in the circuit and therefore in the verification key, and a hash over each embedding vector to bind it to its commitment.
 
-## Security
+## 8. Security
 
-> TODO
+Three trust assumptions anchor this proof: `trust_anchor_key`, `verifier_key` and `cred_pk`. Neither is a cryptographic assumption. Each is a judgement about the entity behind it.
 
-## Backwards Compatibility
+1. **Trust in the Authenticator Provider is required for the `live_image`.** The circuit proves that `live_commitment` equals the `cdh` of an `aat` signed by an `assertion_key` that `trust_anchor_key` attests. It cannot prove those bytes came from a camera at the correct point in time. Only the Authenticator Provider asserts that. An RP needs to understand the guarantees that each Authenticator Provider gives and decide which are trusted.
+2. **Trust in the Verifier is foundational.** The circuit checks a signature and a threshold. It never checks that a comparison happened, that the models were the intended ones, or that quality and presentation-attack checks ran. A Verifier willing to sign freely can assert any commitments and any scores while every other constraint still passes, so this trust is not partial: it is the whole of the similarity claim. It rests on the key attestation and reproducible measurements of [WIP-110][wip-110], verified out of band.
+3. **Trust in the Issuer is what makes the proof about a person.** The Credential commitment anchors the comparison to a particular image or embedding, so the proof inherits whatever the Issuer's enrollment process guarantees.
+4. **A comparison may be shown to more than one RP.** The token from the Verifier is bound to the Credential and to a time, but not to a request. This is deliberate as there's no security gain from binding it to an RP request.
+5. **Replay within a window is the RP's responsibility.** The `nonce` is bound into the `aat` and into the authenticator's signature, but the circuit cannot distinguish a fresh `nonce` from a reused one. RPs MUST generate it and MUST reject any `nonce` seen before.
+6. **This is not a uniqueness proof.** It carries no nullifier and proves similarity against a single Credential. An RP that needs one World ID per person MUST additionally request a Uniqueness Proof.
+
+## 9. Backwards Compatibility
 
 This World Improvement Proposal (WIP) introduces a new interface; no existing contracts or other previously existing functionality is affected.
 

--- a/docs/WIPs/wip-111.md
+++ b/docs/WIPs/wip-111.md
@@ -31,49 +31,57 @@ This circuit compares three items: the **credential** item, the **live** capture
 
 ### Circuit constants
 
-The Field ($F$), the Curve, and the Hashing ($H_t$) definitions MUST follow the requirements of [WIP-100][wip-100].
+The Field ($F$), the Curve (`BabyJubJub`), and the Hashing ($H_t$) definitions MUST follow the requirements of [WIP-100][wip-100]. `H_t` refers to the hash built from a Poseidon2 permutation of `t` elements.
 
-This circuit does not introduce new constants.
+This circuit introduces the following constants:
+
+| Constant | Value | Description |
+|----------|-------|-------------|
+| `CLAIM_INDEX` | `11` | Index in `claims` holding the credential commitment. Determined by the Issuer's claim schema. |
+| `MAX_COMPARISON_AGE_SECS` | `86400` | Ceiling on the RP-supplied `comparison_age_max`, in seconds (24h). |
+| `DS_WIP_111` | `127603488023523044162070750169730678246161835968334` (`b"WORLD-ID/WIP-111/SIGN"`) | Domain separator for the authenticator authorization message. MUST NOT be reused outside it. |
+
+`NUM_KEYS`, `MERKLE_LEAF_DS`, `DS_CREDENTIAL_V1`, `DS_CREDENTIAL_SUB` and `DS_SESSION_COMMITMENT` are defined in the Query and Uniqueness Proofs, `MAX_CLAIMS` from the Credential, `AAT_MAX_LIFETIME` and `DS_TAKT` from [WIP-106][wip-106], and `DS_EDDSA` from [WIP-100][wip-100].
 
 ### Circuit Inputs
 
-`Pub` defines a public input to the circuit. Any inputs not defined as **Pub** MUST remain private. The purpose listed below is for reference, but is non-normative.
+`Pub` defines a public input to the circuit. Any inputs not defined as **Pub** MUST remain private. The purpose listed below is for reference, but is non-normative. See [Circuit Constraints](#circuit-constraints) for what is enforced.
 
-| **Group** | Input | Purpose (Non-normative) |
-| --- | --- | --- |
-| Authenticator Assertion (WIP-106) | `aat` (Authenticator Assertion Token) | Vouches for the live capture. Its `cdh` claim commits to the live item. |
-| Authenticator Assertion (WIP-106) | `takt` (Trust Anchor Key Token) | Attests the `assertion_key` that signed the `aat`. |
-| Authenticator Assertion (WIP-106) | **Pub.** `trust_anchor_key` (x, y) | Lets the RP decide which Authenticator Providers it trusts. |
-| Authenticator Assertion (WIP-106) | **Pub.** `sec_flags` | TAKT security metadata about the `assertion_key`. |
-| Authenticator Assertion (WIP-106) | **Pub.** `authenticator_meta` | AAT metadata, e.g. user presence. |
-| RP Inputs | **Pub.** `nonce` | Prevents replays. Also the `aat` `nonce`. |
-| RP Inputs | **Pub.** `rp_id` | The `aat` audience. |
-| RP Inputs | **Pub.** `now` | Current timestamp, to check expiries. |
-| RP Inputs | **Pub.** `session_id` (**may be _nil_**) | Lets the RP verify the same World ID is performing this proof. |
-| RP Inputs | **Pub.** `genesis_issued_at_min` | Minimum timestamp for when the credential type was first issued. |
-| RP Inputs | **Pub**. `expires_at_min` | Lets the RP verify a non-expired credential was used. |
-| Embedding Verifier (WIP-110) | `cwt` | Carries every commitment and score. See [Token Claims](#token-claims). |
-| Embedding Verifier (WIP-110) | **Pub.** `verifier_key` | Lets the RP identify which Embedding Verifier ran. Signed the `cwt`. |
-| Embedding Verifier (WIP-110) | **Pub.** `challenge_commitment` (**may be _nil_**) | Lets the RP verify its own challenge item was the one compared. Nil (`0`) in the 2-way flow. |
-| Embedding Verifier (WIP-110) | **Pub.** `similarity_min` | Lets the RP verify every score cleared its threshold. |
-| Credential Validity | Merkle tree inclusion proof (`leaf_index`, `siblings`, `depth`) | Proves the World ID is registered in the `WorldIDRegistry`. |
-| Credential Validity | **Pub.** `merkle_root` | Lets the RP verify the correct `WorldIDRegistry` was used. |
-| Credential Validity | Authenticator authorization (`sig_s`, `sig_r`, `pk_index`, `pk_set[]`) | Proves an authorized authenticator is executing the operation. |
-| Credential Validity | Credential inputs (`cred_associated_data_hash`, `cred_genesis_issued_at`, `cred_expires_at`, `cred_s`, `cred_r`, `cred_sub_blinding_factor`, `cred_id`) | Ensures a valid credential is used. |
-| Credential Validity | `claims[]` from the credential, an array of 16 `FieldElement` | Holds the credential commitment (among other claims). |
-| Credential Validity | **Pub**. `cred_pk` (signer of the user's credential) | Lets the RP verify the Issuer of the Credential. |
+| **Group** | Input | Type | Purpose (Non-normative) |
+| --- | --- | --- | --- |
+| Authenticator Assertion (WIP-106) | `aat` | claims + `ES256` signature | Vouches for the live capture. Its `cdh` claim commits to the live item. |
+| Authenticator Assertion (WIP-106) | `takt` | claims + EdDSA signature | Attests the `assertion_key` that signed the `aat`. |
+| Authenticator Assertion (WIP-106) | **Pub.** `trust_anchor_key` | `PublicKey` | Lets the RP decide which Authenticator Providers it trusts. |
+| Authenticator Assertion (WIP-106) | **Pub.** `sec_flags` | Field element | TAKT security metadata about the `assertion_key`. |
+| Authenticator Assertion (WIP-106) | **Pub.** `authenticator_meta` | Field element | AAT metadata, e.g. user presence. |
+| RP Inputs | **Pub.** `nonce` | Field element | Prevents replays. Also the `aat` `nonce`. |
+| RP Inputs | **Pub.** `rp_id` | Field element | The `aat` audience. |
+| RP Inputs | **Pub.** `now` | Field element | Current Unix timestamp, to check expiries. |
+| RP Inputs | **Pub.** `session_id` (**may be _nil_**) | Field element | Lets the RP verify the same World ID is performing this proof. |
+| RP Inputs | **Pub.** `genesis_issued_at_min` | Field element | Minimum timestamp for when the credential type was first issued. |
+| RP Inputs | `session_id_r` | Field element | Blinding factor for the session commitment. |
+| Embedding Verifier (WIP-110) | `cwt` | claims + EdDSA signature | Carries every commitment and score. See [Token Claims](#token-claims). |
+| Embedding Verifier (WIP-110) | **Pub.** `verifier_key` | `PublicKey` | Lets the RP identify which Embedding Verifier ran. Signed the `cwt`. |
+| Embedding Verifier (WIP-110) | **Pub.** `challenge_commitment` (**may be _nil_**) | Field element | Lets the RP verify its own challenge item was the one compared. Nil (`0`) in the 2-way flow. |
+| Embedding Verifier (WIP-110) | **Pub.** `comparison_age_max` | Field element | Oldest comparison, in seconds, the RP will accept. |
+| Embedding Verifier (WIP-110) | **Pub.** `similarity_min` | Field element | Lets the RP verify every score cleared its threshold. |
+| Credential Validity | **Pub.** `merkle_root` | Field element | Lets the RP verify the correct `WorldIDRegistry` was used. |
+| Credential Validity | **Pub.** `issuer_schema_id` | Field element | Lets the RP verify which credential type was used. |
+| Credential Validity | **Pub.** `cred_pk` | `PublicKey` | Lets the RP verify the Issuer of the Credential. |
+| Credential Validity | `user_pk` | [`PublicKey`; `NUM_KEYS`] | Authenticator public keys registered in the `WorldIDRegistry`. |
+| Credential Validity | `pk_index` | Field element | Index in `user_pk` of the key used to sign. |
+| Credential Validity | `sig_s`, `sig_r` | Field element, [Field element; 2] | EdDSA signature by the selected authenticator key. |
+| Credential Validity | `leaf_index` | Field element | Index of the user's World ID in the `WorldIDRegistry`. |
+| Credential Validity | `siblings` | [Field element; 30] | Sibling nodes from `leaf_index` upwards. |
+| Credential Validity | `claims` | [Field element; `MAX_CLAIMS`] | Credential claims. `claims[CLAIM_INDEX]` holds the credential commitment. |
+| Credential Validity | `cred_s`, `cred_r` | Field element, [Field element; 2] | EdDSA signature by the Issuer over the Credential. |
+| Credential Validity | `cred_associated_data_hash`, `cred_genesis_issued_at`, `cred_expires_at`, `cred_sub_blinding_factor`, `cred_id` | Field element | Remaining Credential fields covered by the Issuer signature. |
+
+A `PublicKey` is as defined in [WIP-100][wip-100]: an EdDSA public key as its coordinates $(x,y)$, each a Field element.
 
 ### Token Claims
 
-The `cwt` is signed by `verifier_key` and defined in [WIP-110][wip-110]. The circuit MUST read these claims from the signed payload and MUST NOT accept them as independent witnesses.
-
-| Claim | Description |
-| --- | --- |
-| `credential_commitment` | Commitment to the credential item. |
-| `live_commitment` | Commitment to the live capture. |
-| `challenge_commitment` | Commitment to the RP's challenge. May be `0` in case this isn't considered for comparison. |
-| `similarity_live` | Score for live against credential. |
-| `similarity_challenge` | Score for challenge against credential. `0` when `challenge_commitment` is `0`. |
+Defined in [WIP-110 Token claims](wip-110.md#token-claims). The circuit reads `iat`, `credential_commitment`, `live_commitment`, `challenge_commitment`, `similarity_live` and `similarity_challenge`. All are private.
 
 ### Commitments
 
@@ -95,7 +103,54 @@ Commitments MUST be over the bytes the Embedding Verifier received. The circuit 
 
 ### Circuit Constraints
 
-> TODO
+The Embedding Similarity Proof circuit MUST implement the following constraints (order is not relevant). The circuit MUST NOT introduce public inputs beyond those in [Circuit Inputs](#circuit-inputs). Groups match those in [Circuit Inputs](#circuit-inputs).
+
+Hashing ($H_t$), EdDSA and Merkle inclusion are as defined in [WIP-100][wip-100]. The Uniqueness Proof and the Query Proof do not yet have their own WIPs; where referenced they mean those circuits as currently implemented.
+
+#### Credential Validity
+
+1. **Key selection.** Select `pk = user_pk[pk_index]`, constraining `pk_index < NUM_KEYS` as a comparison over the full field $F$ and not a truncating cast, for the same `pk_index` witness used to index.
+2. **Empty key slots.** `user_pk` MUST hold `NUM_KEYS` entries in `WorldIDRegistry` slot order, with inactive slots encoded as the identity $(0,1)$. No separate validity check on the selected `pk` is needed: [WIP-100][wip-100] signature verification already requires it to satisfy the curve equation, lie in the prime-order subgroup and not be the identity, which is what rejects an inactive slot in constraint 5.
+3. **Registry leaf.** Compute the `WorldIDRegistry` leaf as the authenticator key set commitment defined in the Query Proof: `key_set_commitment = H_16(MERKLE_LEAF_DS; user_pk[0].x, user_pk[0].y, …, user_pk[6].x, user_pk[6].y)`, the `NUM_KEYS` keys as $(x, y)$ pairs at state indices `1..14` with index `15` zero. All slots MUST be included in order, including inactive ones.
+4. **Merkle inclusion proof.** Recompute the root from `key_set_commitment` at position `leaf_index` using `siblings`, per [WIP-100][wip-100], and constrain it equals `merkle_root`. [WIP-100][wip-100] fixes the depth at 30 and requires $0 < \texttt{leaf\_index} < 2^{30}$, so the circuit takes no depth input.
+5. **Authenticator authorization.** Compute `message = H_4(DS_WIP_111; live_commitment, nonce, rp_id)` and verify `(sig_r, sig_s)` as a `BabyJubJub-EdDSA-Poseidon2` signature by the `pk` of constraint 1 over `message`, following all the verification requirements of [WIP-100][wip-100]. The message differs from the Query Proof, which signs the OPRF `query`.
+6. **Credential subject commitment.** Compute `sub = H_3(DS_CREDENTIAL_SUB; leaf_index, cred_sub_blinding_factor)`.
+7. **Claims hash.** Compute `claims_hash` as the Poseidon2 $t=16$ permutation over `[claims[0], …, claims[14], 0]`. This construction carries no domain separator; `claims[0]` occupies the capacity element. The Uniqueness Proof takes `claims_hash` as a direct input; this circuit MUST take the `claims` array and MUST use the same `claims` witness in constraint 16. FIXME: UPDATE TO CREDENTIAL V2.
+8. **Credential signature.** Compute `message = H_8(DS_CREDENTIAL_V1; issuer_schema_id, sub, cred_genesis_issued_at, cred_expires_at, claims_hash, cred_associated_data_hash, cred_id)` using the `sub` of constraint 6 and the `claims_hash` of constraint 7, and verify `(cred_r, cred_s)` as a `BabyJubJub-EdDSA-Poseidon2` signature by `cred_pk` over `message`, following all the verification requirements of [WIP-100][wip-100].
+9. **Credential validity window.** Range-check `cred_genesis_issued_at` and `cred_expires_at` as 64-bit values. Constrain `now < cred_expires_at` and `genesis_issued_at_min <= cred_genesis_issued_at`.
+10. **Leaf-index binding.** The `leaf_index` blinded into `sub` in constraint 6, the position proven in constraint 4, and the one hashed in constraint 20 MUST be the same witness. The circuit MUST NOT accept independent values. This binding is **essential**, otherwise the circuit only proves the prover controls the `sk` of **some** registered leaf, not the one the Credential was issued to.
+
+#### Authenticator Assertion
+
+11. **Attestation verification.** Verify the `takt` and the `aat` together, as defined in [WIP-106][wip-106]: the `takt` signature by `trust_anchor_key` over the TAKT digest, the `aat` `ES256` signature over its COSE `Sig_structure`, both unexpired at `now`, and `aat.exp` no more than `AAT_MAX_LIFETIME` beyond `now`. The `ES256` key verifying the `aat` MUST be the `assertion_key` the `takt` attests; this is the sole binding between the two tokens. `trust_anchor_key` and `now` MUST be public inputs, otherwise a prover signs its own `takt` or picks a time at which any token is fresh.
+12. **Assertion metadata exposure.** The `sec_flags` public input MUST equal the `takt` claim, unpacked with a range check on every sub-field including reserved bits. The `authenticator_meta` public input MUST equal the `aat` claim.
+13. **AAT request binding.** Constrain `aat.nonce == nonce` and `aat.aud == rp_id`.
+
+#### Embedding Verifier
+
+14. **Token verification.** The `cwt` claims are private inputs, one field element each. Compute the digest as defined in [WIP-110 Signed digest](wip-110.md#signed-digest) and verify it as a `BabyJubJub-EdDSA-Poseidon2` signature by `verifier_key`, following all the verification requirements of [WIP-100][wip-100]. The circuit MUST NOT parse or reconstruct CBOR.
+15. **Comparison age.** Constrain `iat <= now`, then `now - iat <= comparison_age_max`. The first check is required both because a future-dated token would otherwise satisfy any age bound, and because the second underflows in $F$ without it. Also constrain `comparison_age_max <= MAX_COMPARISON_AGE_SECS`, a backstop against an RP that sets no meaningful bound. `iat` stays private: the RP fixes the bound and the circuit applies it, so the exact time of the comparison need not be revealed.
+16. **Credential commitment binding.** `credential_commitment` MUST equal `claims[CLAIM_INDEX]`, for the `claims` witness of constraint 7. This binding is **essential**, otherwise the circuit only proves the Embedding Verifier compared against **some** item, not the one this Credential commits to.
+17. **Live commitment binding.** `live_commitment` MUST equal the `cdh` claim of the `aat`.
+18. **Challenge commitment binding.** The `challenge_commitment` public input MUST equal the `challenge_commitment` claim. The equality is unconditional, so a nil public input requires the claim to be `0`, which is the 2-way flow.
+19. **Similarity floor.** Constrain `similarity_live >= similarity_min`. Let `is_absent` be `1` when `challenge_commitment` is `0` and `0` otherwise, set `effective_min = similarity_min * (1 - is_absent)`, and constrain `similarity_challenge >= effective_min`.
+
+#### RP Inputs
+
+20. **Session commitment.** Compute `computed = H_3(DS_SESSION_COMMITMENT; leaf_index, session_id_r)` and constrain `session_id * (session_id - computed) === 0`, so `session_id` is either nil or the correct commitment.
+21. **Verifier-supplied input validation.** `nonce`, `rp_id`, `now`, `similarity_min` and `comparison_age_max` MUST NOT equal `0`. These are usually intended as sentinel values and could surface an incorrect use of them.
+
+### Verification
+
+The circuit proves its constraints hold. It cannot decide whether the parties involved are ones the RP trusts, or whether the comparison is recent enough for the RP's purpose. Verifiers (i.e. RPs) MUST perform the following checks outside the proof:
+
+1. **Comparison age.** `comparison_age_max` MUST be the value your policy requires; the circuit has already enforced it against the comparison time. It is RECOMMENDED to use a very short window, in the realm of a few minutes. The circuit's `MAX_COMPARISON_AGE_SECS` ceiling is only a backstop.
+2. **Verifier trust.** `verifier_key` MUST be on the RP's allowlist, and its key attestation MUST be verified out of band. See [WIP-110][wip-110].
+3. **Authenticator trust.** `trust_anchor_key` MUST be on the RP's allowlist, and `sec_flags` and `authenticator_meta` MUST satisfy the RP's policy. See [WIP-106][wip-106].
+4. **Timestamp.** `now` MUST be a valid current timestamp. It is RECOMMENDED to accept values within 5 minutes of the verifier's local time, per [WIP-106][wip-106].
+5. **Threshold and challenge.** `similarity_min` MUST be the value the RP requires, and `challenge_commitment` MUST be the commitment the RP computed over the item it supplied.
+
+Faling to verify the public inputs from the circuit breaks security and trust assumptions. Such verifications MUST NOT be skipped.
 
 ## Trust Assumptions
 
@@ -139,6 +194,8 @@ The RP trusts the Issuer to have committed an item that describes the subject, t
 
 ## Rationale
 
+> TODO
+
 ## Alternatives Considered
 
 > TODO
@@ -150,10 +207,6 @@ The RP trusts the Issuer to have committed an item that describes the subject, t
 ## Backwards Compatibility
 
 This World Improvement Proposal (WIP) introduces a new interface; no existing contracts or other previously existing functionality is affected.
-
-## Appendix: Test Vectors
-
-> TODO
 
 [wip-100]: https://github.com/worldcoin/world-id-protocol/pull/888
 [wip-106]: https://github.com/worldcoin/world-id-protocol/pull/676

--- a/docs/WIPs/wip-111.md
+++ b/docs/WIPs/wip-111.md
@@ -3,10 +3,13 @@ wip: 111
 title: Proof of Embedding Similarity
 description: Mechanism to prove similarity between vector embeddings based on a World ID credential.
 author: Paolo D'Amico (@paolodamico), Kilian Glas (@kilianglas)
-status: Draft
-type: Informative
+status: 🚧 Draft
+type: Informational
 created: 2026-08-03
 ---
+
+> [!NOTE]  
+> This spec outlines a draft functionality for beta testing. Changes are expected.
 
 ## Abstract
 
@@ -57,7 +60,7 @@ This circuit does not introduce new constants.
 | Credential Validity | **Pub.** `merkle_root` | Lets the RP verify the correct `WorldIDRegistry` was used. |
 | Credential Validity | Authenticator authorization (`sig_s`, `sig_r`, `pk_index`, `pk_set[]`) | Proves an authorized authenticator is executing the operation. |
 | Credential Validity | Credential inputs (`cred_associated_data_hash`, `cred_genesis_issued_at`, `cred_expires_at`, `cred_s`, `cred_r`, `cred_sub_blinding_factor`, `cred_id`) | Ensures a valid credential is used. |
-| Credential Validity | `claims[]` from the credential, an array of 16 `FieldElement` | Holds the credential commitment. |
+| Credential Validity | `claims[]` from the credential, an array of 16 `FieldElement` | Holds the credential commitment (among other claims). |
 | Credential Validity | **Pub**. `cred_pk` (signer of the user's credential) | Lets the RP verify the Issuer of the Credential. |
 
 ### Token Claims

--- a/docs/WIPs/wip-111.md
+++ b/docs/WIPs/wip-111.md
@@ -1,5 +1,5 @@
 ---
-wip: 110
+wip: 111
 title: Proof of Embedding Similarity
 description: Mechanism to prove similarity between vector embeddings based on a World ID credential.
 author: Paolo D'Amico (@paolodamico), Kilian Glas (@kilianglas)
@@ -10,15 +10,21 @@ created: 2026-08-03
 
 ## Abstract
 
+This spec introduces a new ZK circuit ("Embedding Similarity Proof") which proves that an embedding committed in a user's [Credential](https://docs.rs/world-id-primitives/latest/world_id_primitives/credential/struct.Credential.html) is similar to one or two other embeddings, without revealing any of them to the verifying party (an RP).
+
+The circuit neither extracts embeddings nor computes similarity. An Embedding Verifier ([WIP-110][wip-110]) does both, and signs a token committing to each input it consumed and each score it produced. This circuit verifies that token and checks three things: each commitment matches the party that vouches for it, the scores clear the RP's threshold, and the credential is valid.
+
 ## Motivation
 
-Being able to prove you are a particular person online is becoming increasingly important, such as combating deepfakes. Through the World ID Protocol, issuers can emit credentials to users committing to a particular vector embedding (e.g. representing a user's face). This spec introduces a mechanism by which an RP can challenge a user to prove they have a [Credential](https://docs.rs/world-id-primitives/latest/world_id_primitives/credential/struct.Credential.html) with an embedding which matches a challenged or expected embedding. One particular use case is proving you are the expected person behind a digital call using for example a Credential where an Issuer attests to how your face looks. 
-
+Being able to prove you are a particular person online is becoming increasingly important, such as combating deepfakes. Through the World ID Protocol, issuers can emit credentials to users committing to a particular vector embedding (e.g. representing a user's face). This spec introduces a mechanism by which an RP can challenge a user to prove they have a [Credential](https://docs.rs/world-id-primitives/latest/world_id_primitives/credential/struct.Credential.html) with an embedding which matches a challenged or expected embedding. One particular use case is proving you are the expected person behind a digital call using for example a Credential where an Issuer attests to how your face looks.
 
 ## Specification
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).
 
+The terms [Authenticator](https://docs.rs/world-id-core/latest/world_id_core/struct.Authenticator.html), Issuer and [Credential](https://docs.rs/world-id-primitives/latest/world_id_primitives/credential/struct.Credential.html) are as defined in the World ID Protocol. **Embedding Verifier** is as defined in [WIP-110][wip-110].
+
+This circuit compares three items: the **credential** item, the **live** capture, and the RP's **challenge**. It never sees any of them. It sees a commitment to each (asa a `FieldElement`), and a similarity score per compared pair. Whether an item was an image or a vector is decided in [WIP-110][wip-110] and is invisible here.
 
 ### Circuit constants
 
@@ -26,97 +32,126 @@ The Field ($F$), the Curve, and the Hashing ($H_t$) definitions MUST follow the 
 
 This circuit does not introduce new constants.
 
-
 ### Circuit Inputs
 
-`Pub` defines a public input to the circuit. Any inputs not defined as **Pub** MUST remain private. The purpose listed below is for reference, but is non-normative. Please see the [Circuit Constraints](#circuit-constraints) for details.
+`Pub` defines a public input to the circuit. Any inputs not defined as **Pub** MUST remain private. The purpose listed below is for reference, but is non-normative.
 
 | **Group** | Input | Purpose (Non-normative) |
 | --- | --- | --- |
-| Authenticator Assertion (WIP-106) | `aat` (Authenticator Assertion Token) | Provides (basic) integrity to the live image used for comparison based on Authenticator trust.<br />Ensures the image that was asserted in the AAT matches the image that was compared by the verifier TEE |
-| Authenticator Assertion (WIP-106) | **Pub.** `trust_anchor_key` (x, y) | Allows the RP to determine which Authenticator Providers they trust and that the AAT comes from a valid provider. |
-| Authenticator Assertion (WIP-106) | **Pub.** `sec_flags` | Allows the RP to review security metadata to make decisions on whether to accept the request or not. |
-| RP Inputs | **Pub.** `nonce` | Prevents replays. |
-| RP Inputs | **Pub.** `session_id` (**may be _nil_**) | Allows the RP to verify the same World ID is performing this proof. |
-| RP Inputs | **Pub.** `genesis_issued_at_min` | Allows the RP to specify a minimum timestamp when the type of credential was first issued. |
-| RP Inputs | **Pub**. `expires_at_min` | Allows the RP to verify that a non-expired credential was used. |
-| Embedding Verifier Inputs (WIP-110) | `cwt` | Provides verification that the embedding extraction and comparison process occurred in a trusted environment. |
-| Embedding Verifier Inputs (WIP-110) | **Pub.** `cwt_verifier_key` | Allows the RP to verify the environment which performed the embedding extraction and comparison. |
-| Embedding Verifier Inputs (WIP-110) | **Pub.** `challenge_image_hash` | Allows the RP to verify that the challenge image is the image to which the comparison is expected. |
-| Embedding Verifier Inputs (WIP-110) | **Pub.** `match_min_threshold` | Allows the RP to verify that the comparison result matched their minimum match threshold. |
-| Credential Validity | Merkle tree inclusion proof (`leaf_index`, `siblings`, `depth`) | Used to prove the World ID is validly registered in the `WorldIDRegistry`. |
-| Credential Validity | **Pub.** `merkle_root` | RP can verify the correct `WorldIDRegistry` was used. |
-| Credential Validity | Authenticator authorization (`sig_s`, `sig_r`, `pk_index`, `pk_set[]`) | To prove an authorized authenticator is executing the operation. |
-| Credential Validity | Credential inputs (`cred_associated_data_hash`, `cred_genesis_issued_at`, `cred_expires_at`, `cred_s`, `cred_r`, `cred_sub_blinding_factor`, `cred_id`) | Ensures a valid credential is used for the verification process |
-| Credential Validity | `claims[]` set from the credential as an array of 16 `FieldElement` | Ensures the image used in the verification environment is committed in the credential being used. |
-| Credential Validity | **Pub**. `cred_pk` (signer of the user’s credential) | To verify the correct issuer of the Credential. |
+| Authenticator Assertion (WIP-106) | `aat` (Authenticator Assertion Token) | Vouches for the live capture. Its `cdh` claim commits to the live item. |
+| Authenticator Assertion (WIP-106) | `takt` (Trust Anchor Key Token) | Attests the `assertion_key` that signed the `aat`. |
+| Authenticator Assertion (WIP-106) | **Pub.** `trust_anchor_key` (x, y) | Lets the RP decide which Authenticator Providers it trusts. |
+| Authenticator Assertion (WIP-106) | **Pub.** `sec_flags` | TAKT security metadata about the `assertion_key`. |
+| Authenticator Assertion (WIP-106) | **Pub.** `authenticator_meta` | AAT metadata, e.g. user presence. |
+| RP Inputs | **Pub.** `nonce` | Prevents replays. Also the `aat` `nonce`. |
+| RP Inputs | **Pub.** `rp_id` | The `aat` audience. |
+| RP Inputs | **Pub.** `now` | Current timestamp, to check expiries. |
+| RP Inputs | **Pub.** `session_id` (**may be _nil_**) | Lets the RP verify the same World ID is performing this proof. |
+| RP Inputs | **Pub.** `genesis_issued_at_min` | Minimum timestamp for when the credential type was first issued. |
+| RP Inputs | **Pub**. `expires_at_min` | Lets the RP verify a non-expired credential was used. |
+| Embedding Verifier (WIP-110) | `cwt` | Carries every commitment and score. See [Token Claims](#token-claims). |
+| Embedding Verifier (WIP-110) | **Pub.** `verifier_key` | Lets the RP identify which Embedding Verifier ran. Signed the `cwt`. |
+| Embedding Verifier (WIP-110) | **Pub.** `challenge_commitment` (**may be _nil_**) | Lets the RP verify its own challenge item was the one compared. Nil (`0`) in the 2-way flow. |
+| Embedding Verifier (WIP-110) | **Pub.** `similarity_min` | Lets the RP verify every score cleared its threshold. |
+| Credential Validity | Merkle tree inclusion proof (`leaf_index`, `siblings`, `depth`) | Proves the World ID is registered in the `WorldIDRegistry`. |
+| Credential Validity | **Pub.** `merkle_root` | Lets the RP verify the correct `WorldIDRegistry` was used. |
+| Credential Validity | Authenticator authorization (`sig_s`, `sig_r`, `pk_index`, `pk_set[]`) | Proves an authorized authenticator is executing the operation. |
+| Credential Validity | Credential inputs (`cred_associated_data_hash`, `cred_genesis_issued_at`, `cred_expires_at`, `cred_s`, `cred_r`, `cred_sub_blinding_factor`, `cred_id`) | Ensures a valid credential is used. |
+| Credential Validity | `claims[]` from the credential, an array of 16 `FieldElement` | Holds the credential commitment. |
+| Credential Validity | **Pub**. `cred_pk` (signer of the user's credential) | Lets the RP verify the Issuer of the Credential. |
 
+### Token Claims
+
+The `cwt` is signed by `verifier_key` and defined in [WIP-110][wip-110]. The circuit MUST read these claims from the signed payload and MUST NOT accept them as independent witnesses.
+
+| Claim | Description |
+| --- | --- |
+| `credential_commitment` | Commitment to the credential item. |
+| `live_commitment` | Commitment to the live capture. |
+| `challenge_commitment` | Commitment to the RP's challenge. May be `0` in case this isn't considered for comparison. |
+| `similarity_live` | Score for live against credential. |
+| `similarity_challenge` | Score for challenge against credential. `0` when `challenge_commitment` is `0`. |
+
+### Commitments
+
+The equality between commitments is what anchors the proof to ecah input.
+
+| Commitment | Equals | Vouched for by |
+| --- | --- | --- |
+| `credential_commitment` | `claims[i]` of the Credential | the Issuer |
+| `live_commitment` | the `cdh` claim of the `aat` | the Authenticator Provider |
+| `challenge_commitment` | the `challenge_commitment` public input | the RP |
+
+The Embedding Verifier does not see the `aat`, the Credential, or the RP's public input. It only hashes the bytes it was given. Each commitment MUST be computed in the following manner:
+
+- `credential_commitment` must be the Poseidon2 sponge defined in [WIP-100][wip-100] with the variable domain separator `CLAIMS_HASH_V1`.
+- `live_commitment` must be the Poseidon2 sponge defined in [WIP-100][wip-100] with the variable domain separator `WORLD-ID/WIP-111/LIVE`.
+- `challenge_commitment` must be the Poseidon2 sponge defined in [WIP-100][wip-100] with the variable domain separator `WORLD-ID/WIP-111/CHALLENGE`.
+
+Commitments MUST be over the bytes the Embedding Verifier received. The circuit hashes nothing. Every binding above is an equality in $F$.
 
 ### Circuit Constraints
 
-The Embedding Similarity Proof circuit MUST implement the following constraints (order is not relevant):
-
+> TODO
 
 ## Trust Assumptions
 
-It is imperative for RPs to understand the trust assumptions behind this proof. Similar to how using any Credential requires taking certain assumptions from the Issuer. This section is **non-normative**, but it clearly outlines all the trust assumptions.
+RPs need to understand what they are trusting. This section is **non-normative**.
 
 ```mermaid
 flowchart TB
-  %% Trust Assumptions
   TAK(["🔑 trust_anchor_key"]):::anchor
   ISS(["🔑 cred_pk"]):::anchor
-  VK(["🔑 cwt_verifier_key"]):::anchor
-  CH(["📌 Challenge image hash<br/>RP-computed from captured bytes"]):::anchor
-  MIN(["📌 match_min_threshold<br/>RP-supplied"]):::anchor
+  VK(["🔑 verifier_key"]):::anchor
+  CH(["📌 challenge_commitment<br/>RP-computed"]):::anchor
+  MIN(["📌 similarity_min<br/>RP-supplied"]):::anchor
 
-  %% Input sources
-  AAT["AAT<br/>signal = H(live_image)"]
-  CRED["Credential<br/>claim[11] = image_hash"]
-  CWT["Verifier TEE CWT<br/>live_image_hash · credential_claim<br/>challenger_image_hash · match_coefficient"]
+  AAT["AAT<br/>cdh = live_commitment"]
+  CRED["Credential<br/>claims[i] = credential_commitment"]
+  CWT["Embedding Verifier token<br/>3 commitments + scores"]
 
-  CIRCUIT{{"WIP-111 Circuit<br/>binds all + checks they match"}}
+  CIRCUIT{{"WIP-111 Circuit"}}
   RP(["Relying Party"])
 
   TAK -->|attests| AAT
   ISS -->|signs| CRED
   VK -->|signs| CWT
 
-  AAT -->|"signal == live_image_hash"| CIRCUIT
-  CRED -->|"claims == credential_claim"| CIRCUIT
-  CH -->|"== challenger_image_hash"| CIRCUIT
-  MIN -->|"match_coefficient ≥ min"| CIRCUIT
-  CWT -->|"comparison + committed hashes"| CIRCUIT
+  CRED -->|"= credential_commitment"| CIRCUIT
+  AAT -->|"cdh = live_commitment"| CIRCUIT
+  CH -->|"= challenge_commitment"| CIRCUIT
+  MIN -->|"scores ≥ min"| CIRCUIT
+  CWT -->|"extraction + comparison"| CIRCUIT
 
   CIRCUIT -->|proof| RP
 
   classDef anchor fill:#e8ecff,stroke:#3355bb,color:#111,stroke-width:2px;
 ```
 
+The RP trusts the Issuer to have committed an item that describes the subject, the Authenticator Provider to have captured the live item (including having performed relevant checks to prevent/mitigate tampering with the input sensor), and the Embedding Verifier to have extracted and compared honestly. The circuit adds no trust of its own. It only proves the three attestations concern the same items.
+
 ## Use Cases
 
-
+> TODO
 
 ## Rationale
 
-
 ## Alternatives Considered
 
-
-
-
+> TODO
 
 ## Security
 
-
+> TODO
 
 ## Backwards Compatibility
 
 This World Improvement Proposal (WIP) introduces a new interface; no existing contracts or other previously existing functionality is affected.
 
-
 ## Appendix: Test Vectors
 
-
+> TODO
 
 [wip-100]: https://github.com/worldcoin/world-id-protocol/pull/888
+[wip-106]: https://github.com/worldcoin/world-id-protocol/pull/676
+[wip-110]: wip-110.md


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only draft specs with no runtime, contract, or cryptographic implementation changes in this PR.
> 
> **Overview**
> Adds two new **draft** World Improvement Proposals under `docs/WIPs/` for embedding-based identity proofs.
> 
> **WIP-110 (Trusted Embedding Verifier)** is mostly a skeleton: it frames a TEE-backed interface for extracting embeddings from images and comparing them, with RFC 2119 boilerplate and empty sections left to fill in.
> 
> **WIP-111 (Proof of Embedding Similarity)** is further along. It describes how a relying party can challenge a user to prove a World ID credential’s embedding matches an expected/challenge embedding (e.g. live video vs. issuer-attested face). The spec ties **WIP-100** crypto constants, **WIP-106** authenticator assertion (`aat`, trust anchor, `sec_flags`), **WIP-110** verifier outputs (`cwt`, public hashes/threshold keys), and standard credential/registry inputs into one circuit input table. It also adds a **trust assumptions** mermaid diagram showing how AAT, credential claims, RP-supplied challenge hash/threshold, and verifier CWT bind in the circuit.
> 
> Both WIPs state they introduce new interfaces only and do not affect existing contracts. **Note:** `wip-111.md` frontmatter currently sets `wip: 110` while the title is Proof of Embedding Similarity—likely a copy-paste error to fix before merge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 096d115e5b387c537f0afda4ae6bfdce2b732c4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->