### PR TITLE
feat: add sections to WIPs and update statuses

### DIFF
--- a/docs/WIPs/wip-101.md
+++ b/docs/WIPs/wip-101.md
@@ -1,24 +1,24 @@
 ---
 wip: 101
 title: RP Request Authorization Method for Smart Contracts
-description: Standard to verify a relying party proof request for a World ID Proof in Smart Contracts 
+description: Standard to verify a relying party proof request for a World ID Proof in Smart Contracts
 author: Paolo D'Amico (@paolodamico), 0xThemis (@0xThemis)
-status: Draft
+status: 🟠 Last Call
 type: Standards Track
 created: 2026-03-18
 ---
 
-## Abstract
+## 1. Abstract
 
 This spec introduces a method to verify Relying Party (RP) proof requests in the World ID Protocol through on-chain smart contracts. As some RPs may not have a backend and be simply a contract, this allows OPRF Nodes to answer **"Does the RP authorize this request?"** in order to process relevant OPRF requests such as for nullifier generation.
 
-## Motivation
+## 2. Motivation
 
 **Context**: Proof requests from Relying Parties in the World ID Protocol MUST be signed in order to be recognized. This serves to ensure proofs are authorized for the intended recipient and reduce the attack surface in post-compromise scenarios for Authenticators.
 
 A Relying Party MAY be a Smart Contract without a backend. When this is the case, having a private key to sign the request is impractical or even impossible in a secure way. Hence, we need a way for Relying Parties to authorize the request in a way compatible with Smart Contracts.
 
-## Specification
+## 3. Specification
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).
 
@@ -26,58 +26,90 @@ In this document, "contract" and "smart contract" are used interchangeably.
 
 This specification introduces both concerns of "Authorization" and "Validation" of Relying Party (RP) Proof requests. When an RP requests a proof without a smart contract, they construct the proof request and sign the data they constructed. If the RP does not have a backend or other trusted environment, they cannot control the inputs to the Proof request. Hence, the contract SHOULD implement validation rules for the request. For example, an RP should determine what is the maximum expiration period they should allow for Proof requests and enforce it during verification.
 
-1. In order for a contract, acting as an RP, to be compatible with signature verification, it MUST conform to the following interface.
-  ```solidity
-  /**
-   * @dev Interface of the WIP-101 standard for World ID,
-   *   RP Request Authorization Method for Smart Contracts.
-   */
-  interface IWIP101 is IERC165 {
-      /**
-       * @dev The RP request is not valid. The code may be used to provide additional debugging information.
-       */
-      error RpInvalidRequest(uint256 code);
+### 3.1 Contract Interface
 
-      /**
-       * @notice Verifies a World ID Proof Request is authorized by the RP.
-       * @dev Should return whether the RP request is valid and should be honored. The `rpId` is implicit in this request,
-       *  any contract implementing this interface will be pointed to in the `RpRegistry`.
-       * @param version The version determines the format of the request.
-       * @param nonce Unique nonce for this request
-       * @param createdAt Creation timestamp of the request
-       * @param expiresAt Expiration timestamp specified for the request
-       * @param action Provided action for the request. Importantly, this is already a hashed
-       *  action as a field element.
-       * @param data Arbitrary data useful for the verification.
-       * @return magicValue The expected magic value when the request is valid. Reverts otherwise.
-       * 
-       * MUST return the bytes4 magic value 0x35dbc8de when function passes (function selector for verifyRpRequest).
-       * MUST NOT modify state (view modifier for solc > 0.5)
-       * MUST allow external calls
-       */
-      function verifyRpRequest(
-          uint8 version,
-          uint256 nonce,
-          uint64 createdAt,
-          uint64 expiresAt,
-          uint256 action,
-          bytes calldata data
-      ) external view returns (bytes4 magicValue);
-  }
-  ```
-2. If the request is not authorized, the `verifyRpRequest` MUST revert. When requests are invalid, implementers SHOULD revert with the explicit `RpInvalidRequest` error. OPRF Nodes MUST handle this explicit revert and return the inner `code` to the requester (for debugging purposes).
-3. Callers MUST treat any return value other than the magic value of `0x35dbc8de` as an invalid request.
-4. The contract (implementer) MUST also adhere to [ERC-165](https://eips.ethereum.org/EIPS/eip-165) and return `true` from `supportsInterface` for `type(IWIP101).interfaceId`.
-5. When a contract is deployed compliant with this spec, the contract address can be set as a `signer` in the `RpRegistry` contract (e.g. through the `updateRp` function).
-6. The `verifyRpRequest` method will be used by OPRF Nodes to verify an incoming proof request before generating the required output to construct a `nullifier`. OPRF Nodes MAY enforce a timeout on the resolution of this request so it is RECOMMENDED implementers don't rely on computationally expensive logic. Following the main threat model of this spec, OPRF Nodes MUST pass the `action` to the `verifyRpRequest` function the same action value that will be used as input to the OPRF computation.
-7. OPRF Nodes MUST use this spec (WIP-101) verification if the `signer` in the `RpRegistry` implements [ERC-165](https://eips.ethereum.org/EIPS/eip-165) for `type(IWIP101).interfaceId`. OPRF Nodes MAY check whether a contract is deployed at the registered `signer` address. If there is and it's not compliant with WIP-101, OPRF Nodes MAY return a specific error code. OPRF Nodes are NOT REQUIRED to verify signature via ECDSA if there is a contract deployed at the `signer` address.
-8. OPRF Nodes MAY cache an RP's `signer` for performance. This cache may include the consideration on whether the `signer` is WIP-101 compliant or not. The cache MUST NOT exceed 30 days. OPRF Nodes MUST invalidate the `signer` cache on any `RpUpdated` event emission from the `RpRegistry`.
-9. It is RECOMMENDED implementers ensure that any upgrades to validation logic are backwards-compatible for the duration of the maximum `expiresAt` window.
-10. RPs MAY define any number of `code`s in the `RpInvalidRequest`. These codes are intended only for RP debugging, hence the RP can establish any format/definition for this attribute.
-11. The maximum length of `data` is 8192 bits (1024 bytes). OPRF Nodes may enforce this maximum length and reject requests which exceed it.
-12. Implementations of **WIP-101** MUST be deployed on World Chain Mainnet (Chain ID: `480`). OPRF Nodes MUST only verify contract execution on this chain. _**Note**: For RPs using other chains, proof verification MAY occur elsewhere, it's only the request authorization that MUST happen on World Chain._
+1. To be compatible with signature verification, a contract acting as an RP MUST conform to the `IWIP101` interface below. `verifyRpRequest` MUST NOT modify state (declared `view` for solc > 0.5) and MUST allow external calls.
+2. On a valid request, `verifyRpRequest` MUST return the `bytes4` magic value `0x35dbc8de` (the function selector for `verifyRpRequest`). Reverts otherwise.
+3. The contract (implementer) MUST also adhere to [ERC-165](https://eips.ethereum.org/EIPS/eip-165) and return `true` from `supportsInterface` for `type(IWIP101).interfaceId`.
 
-### Additional Context
+```solidity
+/**
+ * @dev Interface of the WIP-101 standard for World ID,
+ *   RP Request Authorization Method for Smart Contracts.
+ */
+interface IWIP101 is IERC165 {
+    /**
+     * @dev The RP request is not valid. The code may be used to provide additional debugging information.
+     */
+    error RpInvalidRequest(uint256 code);
+
+    /**
+     * @notice Verifies a World ID Proof Request is authorized by the RP.
+     * @dev Should return whether the RP request is valid and should be honored. The `rpId` is implicit in this request,
+     *  any contract implementing this interface will be pointed to in the `RpRegistry`.
+     * @param version The version determines the format of the request.
+     * @param nonce Unique nonce for this request
+     * @param createdAt Creation timestamp of the request
+     * @param expiresAt Expiration timestamp specified for the request
+     * @param action Provided action for the request. Importantly, this is already a hashed
+     *  action as a field element.
+     * @param data Arbitrary data useful for the verification.
+     * @return magicValue The expected magic value when the request is valid. Reverts otherwise.
+     *
+     * MUST return the bytes4 magic value 0x35dbc8de when function passes (function selector for verifyRpRequest).
+     * MUST NOT modify state (view modifier for solc > 0.5)
+     * MUST allow external calls
+     */
+    function verifyRpRequest(
+        uint8 version,
+        uint256 nonce,
+        uint64 createdAt,
+        uint64 expiresAt,
+        uint256 action,
+        bytes calldata data
+    ) external view returns (bytes4 magicValue);
+}
+```
+
+### 3.2 Request Validation and Errors
+
+1. If the request is not authorized, `verifyRpRequest` MUST revert.
+2. When a request is invalid, implementers SHOULD revert with the explicit `RpInvalidRequest` error.
+3. Callers MUST treat any return value other than the magic value `0x35dbc8de` as an invalid request.
+4. RPs MAY define any number of `code`s in `RpInvalidRequest`. These codes are intended only for RP debugging, hence the RP can establish any format/definition for this attribute.
+5. It is RECOMMENDED implementers ensure that any upgrades to validation logic are backwards-compatible for the duration of the maximum `expiresAt` window.
+
+### 3.3 OPRF Node Behavior
+
+The `verifyRpRequest` method will be used by OPRF Nodes to verify an incoming proof request before generating the required output to construct a `nullifier`. When a contract compliant with this spec is deployed, its address can be set as a `signer` in the `RpRegistry` contract (e.g. through the `updateRp` function).
+
+1. OPRF Nodes MUST use this spec (WIP-101) verification if the `signer` in the `RpRegistry` implements [ERC-165](https://eips.ethereum.org/EIPS/eip-165) for `type(IWIP101).interfaceId`.
+2. Following the main threat model of this spec, OPRF Nodes MUST pass to `verifyRpRequest` the same `action` value that will be used as input to the OPRF computation.
+3. On an explicit `RpInvalidRequest` revert, OPRF Nodes MUST return the inner `code` to the requester (for debugging purposes).
+4. OPRF Nodes MAY enforce a timeout on the resolution of `verifyRpRequest`.
+5. Implementers SHOULD NOT rely on computationally expensive validation logic, so a call resolves within any node-enforced timeout.
+6. OPRF Nodes MAY check whether a contract is deployed at the registered `signer` address, and MAY return a specific error code if a deployed contract is not WIP-101 compliant.
+7. OPRF Nodes are NOT REQUIRED to verify signature via ECDSA if there is a contract deployed at the `signer` address.
+
+### 3.4 Signer Caching
+
+1. OPRF Nodes MAY cache an RP's `signer` for performance. This cache may include the consideration on whether the `signer` is WIP-101 compliant or not.
+2. A cached `signer` entry MUST NOT exceed a 30-day TTL.
+3. OPRF Nodes MUST invalidate the `signer` cache on any `RpUpdated` event emission from the `RpRegistry`.
+
+### 3.5 Request Field Constraints
+
+1. The maximum length of `data` is 8192 bits (1024 bytes); the `data` field MUST NOT exceed this length.
+2. OPRF Nodes MAY enforce this maximum length and reject requests which exceed it.
+
+### 3.6 Deployment
+
+1. Implementations of **WIP-101** MUST be deployed on World Chain Mainnet (Chain ID: `480`).
+2. OPRF Nodes MUST only verify contract execution on chain ID `480`.
+
+_**Note**: For RPs using other chains, proof verification MAY occur elsewhere, it's only the request authorization that MUST happen on World Chain._
+
+### 3.7 Additional Context (non-normative)
 
 **Version.**
 
@@ -85,7 +117,7 @@ The version of the [`ProofRequest`](https://docs.rs/world-id-primitives/latest/w
 
 **Invalidating Signer Cache.**
 
-Note that RPs can trigger a cache invalidation of the `signer` by doing a no-op (or an actual) update with the `updateRp` method in the `RpRegistry` (see point #8). This is useful if for example the `signer` is an [ERC-1967](https://eips.ethereum.org/EIPS/eip-1967) proxy and the implementation was updated in a way material to determine compliance or non-compliance with this spec (e.g. a bug in the implementation of the [ERC-165](https://eips.ethereum.org/EIPS/eip-165) interface).
+Note that RPs can trigger a cache invalidation of the `signer` by doing a no-op (or an actual) update with the `updateRp` method in the `RpRegistry` (see [§3.4](#34-signer-caching)). This is useful if for example the `signer` is an [ERC-1967](https://eips.ethereum.org/EIPS/eip-1967) proxy and the implementation was updated in a way material to determine compliance or non-compliance with this spec (e.g. a bug in the implementation of the [ERC-165](https://eips.ethereum.org/EIPS/eip-165) interface).
 
 **Authorizing Sessions.**
 
@@ -95,7 +127,7 @@ Implementers MAY encode different handling depending on the type of request. For
 - If the RP does not support sessions, reject proofs if the prefix does not equal `0x00`.
 - If the RP supports sessions, the actions are randomly generated, so as long as the prefix matches one of the expected values (e.g. `0x01`, `0x02`), the action check can be considered fulfilled.
 
-## Rationale
+## 4. Rationale
 
 The `verifyRpRequest` allows an RP to verify all the inputs that would otherwise be signed, so any rules that an RP would normally use when constructing an off-chain request can be encoded in the RP's contract for pure on-chain interactions.
 
@@ -103,7 +135,7 @@ The rationale behind the arbitrary `data` is that the `action` is passed to this
 
 This spec is inspired by [ERC-1271](https://github.com/ethereum/ercs/blob/master/ERCS/erc-1271.md).
 
-## Reference Implementation
+## 5. Reference Implementation
 
 ```solidity
 contract WIP101Example is IWIP101, ERC165 {
@@ -183,7 +215,7 @@ v->>v: invalidate nonce
 ```
 
 
-## Recommended Validations
+## 6. Recommended Validations
 
 It is RECOMMENDED to implement the following validations for a Proof request:
 1. Reject a request which `version` is larger than the maximum known, as future version changes MAY be incompatible with previous versions.
@@ -193,11 +225,11 @@ It is RECOMMENDED to implement the following validations for a Proof request:
 5. `action` hash is the expected value for Uniqueness Proofs.
 6. If the RP does not support Session Proofs, the first 8 bits of the action must all equal `0`.
 
-## Security
+## 7. Security
 
-1. The main threat model protected with this spec is authorization of RP Requests such that an authenticator (malicious or not) cannot generate `nullifier`s (or other OPRF outputs) for use with an RP without that RP's authorization. This for example helps protect users in post-compromise scenarios. If an RP implements proper authorization logic, even with a compromised authenticator, an attacker would be unable to compute a user's nullifier.
+1. The main threat model protected with this spec is authorization of RP Requests such that an authenticator (malicious or not) cannot generate `nullifier`s (or other OPRF outputs) for use with an RP without that RP's authorization. This for example helps protect users in post-compromise scenarios. If an RP implements proper authorization logic, even with a compromised authenticator, an attacker would be unable to compute a user's nullifier. Binding the OPRF input to the verified `action` ([§3.3](#33-oprf-node-behavior)) is what anchors this guarantee.
 2. Implementers are solely responsible for the security of their validation logic. A `verifyRpRequest` that unconditionally returns the magic value is equivalent to having no authorization and exposes the RP to unbounded nullifier generation for any action as well as users in a post-compromise scenario.
 
-## Backwards Compatibility
+## 8. Backwards Compatibility
 
 This World Improvement Proposal (WIP) introduces a new interface; no existing contracts or other previously existing functionality is affected.

--- a/docs/WIPs/wip-102.md
+++ b/docs/WIPs/wip-102.md
@@ -3,7 +3,7 @@ wip: 102
 title: Simplified Optimistic Recovery Agent Update
 description: Replace the current Recovery Agent update mechanism with an immediate update and revert window, removing the need for a follow-up execute transaction.
 author: Jakub Trad (@dzejkop), Kilian Glas (@kilianglas)
-status: ✅ Final
+status: 🟠 Last Call
 type: Standards Track
 created: 2026-03-31
 ---
@@ -85,7 +85,7 @@ function updateRecoveryAgent(
 
 ### 3.5 `revertRecoveryAgentUpdate`
 
-`revertRecoveryAgentUpdate` can be executed by any authenticator up until `invalidAfter`, matching the authorization model of the current `cancelRecoveryAgentUpdate`.
+`revertRecoveryAgentUpdate` can be executed by any Admin Authenticator (as defined in [WIP-104](wip-104.md)) up until `invalidAfter`, matching the authorization model of the current `cancelRecoveryAgentUpdate`. Reverting a Recovery Agent update is a management operation, so a Proving Authenticator MUST NOT be able to authorize it.
 
 ```solidity
 function revertRecoveryAgentUpdate(
@@ -104,13 +104,13 @@ When `recoverAccount` is called, any active Recovery Agent update (i.e. `invalid
 This solution preserves the original security properties while enabling better ergonomics and user experience. Notably:
 
 1. **No follow-up transaction required.** The update takes effect immediately, removing the need for an execution step after the delay period.
-2. **Equivalent security.** The revert window ensures that an attacker who compromises an authenticator cannot immediately replace the Recovery Agent. Any authenticator retains the ability to revert the change during the delay period.
+2. **Equivalent security.** The revert window ensures that an attacker who compromises an authenticator cannot immediately replace the Recovery Agent. Any Admin Authenticator retains the ability to revert the change during the delay period.
 
 ## 5. Security
 
 1. The delay period MUST be preserved to maintain the security guarantee that a compromised authenticator cannot unilaterally replace the Recovery Agent.
 2. During the delay period, both the previous and new Recovery Agents exist, but recovery MUST only be possible with the previous Recovery Agent until `invalidAfter` elapses.
-3. Any authenticator MAY revert the update at any point before `invalidAfter`, restoring the original state.
+3. Any Admin Authenticator MAY revert the update at any point before `invalidAfter`, restoring the original state.
 
 ## 6. Backwards Compatibility
 

--- a/docs/WIPs/wip-102.md
+++ b/docs/WIPs/wip-102.md
@@ -8,11 +8,11 @@ type: Standards Track
 created: 2026-03-31
 ---
 
-## Abstract
+## 1. Abstract
 
 This spec proposes replacing the current Recovery Agent update mechanism (`initiateRecoveryAgentUpdate`, `cancelRecoveryAgentUpdate`, `executeRecoveryAgentUpdate`), that always requires two transactions, with a new flow (`updateRecoveryAgent`, `revertRecoveryAgentUpdate`) that only requires a second transaction when the update needs to be reverted. The proposal preserves the security delay through a revert window.
 
-## Motivation
+## 2. Motivation
 
 In the current contract implementation the user has to first call `initiateRecoveryAgentUpdate`. This initiates a configurable (e.g. 14 days) period during which the update operation can be cancelled (with a `cancelRecoveryAgentUpdate` call). After the period is over anyone can call a permissionless `executeRecoveryAgentUpdate` transaction to finalize the update.
 
@@ -21,11 +21,11 @@ This introduces the following issues:
 1. The updater has to remember to execute the call after the delay, or someone needs to develop and maintain an auto-executing service.
 2. The new Recovery Agent isn't set on-chain until the delay elapses, which can be problematic e.g. if the user wants to register a Recovery Agent after registering their World ID. The Recovery Agent cannot be sure this has been set up properly for a World ID.
 
-## Specification
+## 3. Specification
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).
 
-### Method Changes
+### 3.1 Method Changes
 
 The existing 3 methods are replaced with 2 new methods:
 
@@ -35,14 +35,14 @@ The existing 3 methods are replaced with 2 new methods:
 | `cancelRecoveryAgentUpdate`   | `revertRecoveryAgentUpdate` |
 | `executeRecoveryAgentUpdate`  | removed                     |
 
-### Mechanism
+### 3.2 Mechanism
 
 Instead of delaying the Recovery Agent update on-chain, the `updateRecoveryAgent` function updates the address immediately, records the previous Recovery Agent in a mapping, and sets a delay on the account. During this delay period an account MUST NOT yet be recoverable with the new Recovery Agent.
 
 - The previous Recovery Agent remains valid until `invalidAfter` elapses and the user MAY revert the update during this window, restoring the previous Recovery Agent. This is to maintain the security mechanism when updating a Recovery Agent to mitigate takeover attacks.
 - The new Recovery Agent SHALL NOT be used until after `invalidAfter`.  Once `invalidAfter` elapses without a revert, the previous Recovery Agent becomes invalid and the new Recovery Agent becomes the sole valid Recovery Agent.
 
-### Storage
+### 3.3 Storage
 
 This change requires storing the `previousRecoveryAgent` address and an `invalidAfter` timestamp per `leafIndex` in the `WorldIDRegistry`. The data stored is equivalent to what is currently stored in the contract but with inverted semantics:
 
@@ -68,7 +68,7 @@ struct PreviousRecoveryAgentUpdate {
 mapping(uint256 => PreviousRecoveryAgentUpdate) internal _prevRecoveryAgentUpdates;
 ```
 
-### `updateRecoveryAgent`
+### 3.4 `updateRecoveryAgent`
 
 `updateRecoveryAgent` uses the same authorization as `initiateRecoveryAgentUpdate`.
 
@@ -83,7 +83,7 @@ function updateRecoveryAgent(
 
 `updateRecoveryAgent` SHALL NOT be called again while the previous Recovery Agent is still valid (i.e. `invalidAfter` has not elapsed) and the call MUST revert if it does. While allowing a second call to overwrite the pending update (keeping `previousRecoveryAgent` and resetting `invalidAfter`) would be well-defined, it adds contract complexity. The same result is achieved more explicitly by reverting the current update first.
 
-### `revertRecoveryAgentUpdate`
+### 3.5 `revertRecoveryAgentUpdate`
 
 `revertRecoveryAgentUpdate` can be executed by any authenticator up until `invalidAfter`, matching the authorization model of the current `cancelRecoveryAgentUpdate`.
 
@@ -95,23 +95,23 @@ function revertRecoveryAgentUpdate(
 ) external virtual onlyProxy onlyInitialized {
 ```
 
-### Interaction with `recoverAccount`
+### 3.6 Interaction with `recoverAccount`
 
 When `recoverAccount` is called, any active Recovery Agent update (i.e. `invalidAfter` has not yet elapsed) MUST be cleared automatically. This handles the attack scenario where an attacker compromises an authenticator, removes the user's authenticators to lock them out, and initiates a Recovery Agent update. When the user recovers their account via the Recovery Agent, the malicious update is reverted as part of the recovery.
 
-## Rationale
+## 4. Rationale
 
 This solution preserves the original security properties while enabling better ergonomics and user experience. Notably:
 
 1. **No follow-up transaction required.** The update takes effect immediately, removing the need for an execution step after the delay period.
 2. **Equivalent security.** The revert window ensures that an attacker who compromises an authenticator cannot immediately replace the Recovery Agent. Any authenticator retains the ability to revert the change during the delay period.
 
-## Security
+## 5. Security
 
 1. The delay period MUST be preserved to maintain the security guarantee that a compromised authenticator cannot unilaterally replace the Recovery Agent.
 2. During the delay period, both the previous and new Recovery Agents exist, but recovery MUST only be possible with the previous Recovery Agent until `invalidAfter` elapses.
 3. Any authenticator MAY revert the update at any point before `invalidAfter`, restoring the original state.
 
-## Backwards Compatibility
+## 6. Backwards Compatibility
 
 This WIP replaces the existing 3-step Recovery Agent update mechanism. Contracts implementing this spec MUST remove the `initiateRecoveryAgentUpdate`, `cancelRecoveryAgentUpdate`, and `executeRecoveryAgentUpdate` methods in favor of the new interface. Any pending Recovery Agent updates at the time of upgrade SHOULD be migrated or invalidated.

--- a/docs/WIPs/wip-102.md
+++ b/docs/WIPs/wip-102.md
@@ -3,7 +3,7 @@ wip: 102
 title: Simplified Optimistic Recovery Agent Update
 description: Replace the current Recovery Agent update mechanism with an immediate update and revert window, removing the need for a follow-up execute transaction.
 author: Jakub Trad (@dzejkop), Kilian Glas (@kilianglas)
-status: Draft
+status: ✅ Final
 type: Standards Track
 created: 2026-03-31
 ---
@@ -115,4 +115,3 @@ This solution preserves the original security properties while enabling better e
 ## Backwards Compatibility
 
 This WIP replaces the existing 3-step Recovery Agent update mechanism. Contracts implementing this spec MUST remove the `initiateRecoveryAgentUpdate`, `cancelRecoveryAgentUpdate`, and `executeRecoveryAgentUpdate` methods in favor of the new interface. Any pending Recovery Agent updates at the time of upgrade SHOULD be migrated or invalidated.
-

--- a/docs/WIPs/wip-103.md
+++ b/docs/WIPs/wip-103.md
@@ -8,15 +8,15 @@ type: Standards Track
 created: 2026-03-26
 ---
 
-## Abstract
+## 1. Abstract
 
 This spec introduces a new ZK circuit ("Ownership Proof") to the World ID Protocol that allows a user to prove they own a specific registered leaf without revealing their `leaf_index` or any private key material to the verifier. The circuit takes a domain-separated commitment, `H(domain_separator, leaf_index, commitment_blinder)`, and proves that the user controls a secret key registered in the `WorldIDRegistry` for that leaf, without exposing the `commitment_blinder` value (e.g. a credential blinding factor) as a public input. The initial use case is Issuer Authentication, where a user proves ownership of a credential `sub` to an Issuer for operations like re-issuance, renewal, or deletion.
 
-## Motivation
+## 2. Motivation
 
 There are use cases that require users to prove ownership for their World ID and a specific commitment. At the time of writing there is a well-known use case for Issuer Authentication.
 
-### Issuer Authentication
+### 2.1 Issuer Authentication
 
 Issuers may require users to authenticate with their World ID. Some examples of such use cases:
 - **Re-issuance**. Allowing the user to get a new copy of their credential due to loss.
@@ -25,7 +25,7 @@ Issuers may require users to authenticate with their World ID. Some examples of 
 
 For the cases above, Issuers need to know the legitimate owner of a Credential is requesting the operation. Issuers do not know the user's `leaf_index` by design, so a mechanism to authenticate based on the Credential's [subject](https://docs.rs/world-id-primitives/latest/world_id_primitives/credential/struct.Credential.html#structfield.sub) (`sub`) is required.
 
-## Specification
+## 3. Specification
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).
 
@@ -45,7 +45,7 @@ The Ownership Proof circuit MUST introduce the following inputs. The circuit MUS
 | `expected_commitment` | **Public** | Field element | The expected output of the hashed commitment (e.g. the `sub` of a credential)            |
 | `merkle_root`         | **Public** | Field element | The root hash of the Merkle tree used for inclusion (representing the `WorldIDRegistry`) |
 | `depth`         | **Public** | Field element | The depth of the `WorldIDRegistry`'s Merkle tree used for inclusion |
-| `nonce`         | **Public** | Field element | One-time use value to prevent replays. See [Nonce](#nonce) section. |
+| `nonce`         | **Public** | Field element | One-time use value to prevent replays. See [Nonce](#33-nonce) section. |
 | `context`       | **Public** | Field element | A verifier-supplied context for which the proof is valid. |
 | `user_pk`       | Private | [PublicKey; NUM_KEYS] | The list of authenticator public keys registered in the `WorldIDRegistry`. |
 | `pk_index`           | Private | Field element | The index in `user_pk` of the key used for signature. |
@@ -53,11 +53,11 @@ The Ownership Proof circuit MUST introduce the following inputs. The circuit MUS
 | `query_r`            | Private | [Field element; 2] | The `r` component from the EdDSA signature on the message (see constraints). |
 | `leaf_index`         | Private | Field element | The index of the user's World ID in the `WorldIDRegistry`. |
 | `siblings`           | Private | [Field element; MAX_DEPTH] | The sequence of all siblings from the `leaf_index` to the `merkle_root` . |
-| `commitment_blinder` | Private | Field element | The blinding value that is hashed with the `leaf_index` to output the `expected_commitment`. The provenance of the value depends on the specific use case (see [Use Cases](#use-cases)). |
+| `commitment_blinder` | Private | Field element | The blinding value that is hashed with the `leaf_index` to output the `expected_commitment`. The provenance of the value depends on the specific use case (see [Use Cases](#4-use-cases)). |
 
 For the inputs above, a `PublicKey` is as defined in the [WIP-100][wip-100] spec (_an EdDSA public key represented as its coordinate points $(x,y)$ with each coordinate being a Field element_). _For reference, `user_pk`, `pk_index`, `leaf_index` (named `mt_index`), `siblings` introduce the same constraints that the Nullifier Proof circuit._
 
-### Circuit constants
+### 3.1 Circuit constants
 
 The Field ($F$), the Curve (`BabyJubJub`), and the Hashing ($H_t$) definitions MUST follow the requirements of [WIP-100][wip-100]. For example, in this spec `H_3` refers to the hash constructed from a Poseidon2 permutation of 3-elements.
 
@@ -69,11 +69,11 @@ The Field ($F$), the Curve (`BabyJubJub`), and the Hashing ($H_t$) definitions M
 | `DS_EDDSA` | `360302137480307891234917541314130533` (`b"EdDSA Signature"`) | For reference, defined in [WIP-100][wip-100]. Domain separator for the EdDSA challenge hash. |
 | `DS_WIP_103` | `95972389630003` (`b"WIP103"`) | Domain separator for the Ownership Proof signed message. MUST NOT be reused outside of the Ownership Proof signed-message construction. |
 
-### Circuit constraints
+### 3.2 Circuit constraints
 
 The Ownership Proof circuit MUST implement the following constraints (order is not relevant):
 
-1. **Expected commitment**. Compute the commitment as: `H_3(domain_separator, leaf_index, commitment_blinder)`. The computed commitment MUST equal the `expected_commitment`. The `domain_separator` is dependent on the [Use Case](#use-cases) and all possible domain separators MUST be hardcoded in the circuit.
+1. **Expected commitment**. Compute the commitment as: `H_3(domain_separator, leaf_index, commitment_blinder)`. The computed commitment MUST equal the `expected_commitment`. The `domain_separator` is dependent on the [Use Case](#4-use-cases) and all possible domain separators MUST be hardcoded in the circuit.
 2. **Signature verification**. Compute the message of the signature as: `message = H_4(DS_WIP_103, expected_commitment, nonce, context)`. The circuit MUST verify `(query_r, query_s)` as an EdDSA-Poseidon2 signature by `pk` over the `message` in order to prove authorization by an authenticator over the particular `nonce` and `context`. The signature computation and verification MUST follow all the requirements from [WIP-100][wip-100].
 3. **Key selection**. The circuit MUST select exactly one public key `pk = user_pk[pk_index]` and MUST constrain:
     1. `pk_index < NUM_KEYS`, enforced as a comparison over the full field $F$ and not as a truncating cast to a smaller integer type. An out-of-range `pk_index` MUST cause proving to fail.
@@ -84,7 +84,7 @@ The Ownership Proof circuit MUST implement the following constraints (order is n
 7. **Leaf-index binding.** The `leaf_index` hashed into the commitment in constraint 1 and the position proven in constraint #6 MUST be the same witness. The circuit MUST NOT accept two independent values. This binding is **essential**, otherwise the circuit is only proving the prover knows the `sk` of **some** leaf, not the one being proven in the `expected_commitment`.
 8. **Verifier-supplied input validation**. The `nonce` and `context` MUST NOT equal `0`. These are usually intended as sentinel values and could surface an incorrect use of them.
 
-### Nonce
+### 3.3 Nonce
 
 The nonce is a security mechanism to prevent replay attacks. Recipients of an **Ownership Proof** (also called "verifiers" in this spec) are responsible for its generation and verification.
 1. **Provenance**. Verifiers MUST generate and provide the nonce. Authenticators MUST NOT generate nonces.
@@ -93,7 +93,7 @@ The nonce is a security mechanism to prevent replay attacks. Recipients of an **
 4. **Expiration**. Nonces MUST have a defined TTL and not be valid after expiration. Verifiers MAY define the mechanism to accomplish this.
 5. The `0` element is NOT a valid nonce.
 
-### Context
+### 3.4 Context
 
 The `context` is the mechanism by which a verifier binds a specific proof to a specific requested operation. The verifier MUST constrain the use of Ownership Proofs to specific operations and assign such operations with a unique context. For example, renewing a credential and deleting a credential are two different contexts. The verifier MUST provide the `context` when requesting a proof and MUST verify the provided `context` is valid for the explicit operation being executed. 
 
@@ -101,12 +101,12 @@ It is RECOMMENDED that Verifiers use contexts shorter than 31 bytes or use a has
 
 The `0` element is NOT a valid context.
 
-## Use Cases
+## 4. Use Cases
 
 1. Authenticators MUST restrict Ownership Proofs subject only to the use cases outlined in this spec or a future spec which references this one.
 2. If future use cases are added, the `commitment_blinder` IS REQUIRED to always be a high entropy value to prevent finding a user's `leaf_index`. Unless otherwise noted, it should be randomly generated from a CSPRNG uniformly distributed over the entire $F$.
 
-### WIP-103-001: Issuer Authentication
+### 4.1 WIP-103-001: Issuer Authentication
 - **Use case**: Authenticating to an Issuer where the Issuer has a `sub` as identifier.
 - **Domain Separator**: `b"H_CS(id, r)"` named `DS_C_CS`.
 - **`commitment_blinder` value**: The credential's blinding factor as stored (or re-derived) by the Authenticator.
@@ -114,23 +114,23 @@ The `0` element is NOT a valid context.
 - **Verification**: Issuers MUST ensure the `expected_commitment` public input of the circuit matches the expected identifier (i.e. Credential's `sub`).
 
 
-## Rationale
+## 5. Rationale
 A keen observer would notice the Ownership Proof circuit is very similar to the Query Proof circuit. Using this circuit is not an option because the verifying party would need to learn the `commitment_blinder` being verified to ensure the hash validity (it's a public input). For example, an Issuer does not need to learn the credential blinding factor, which would defeat the purpose of the blinding factor because the `leaf_index` could be easily brute forced.
 
 
-## Reference Verification
+## 6. Reference Verification
 An Issuer will be able to know a specific user is the legitimate owner of a `sub` by performing the following validations:
 1. Ensuring the received zero-knowledge proof verifies correctly with the correct verifying keys.
 2. The root hash (public input) matches a root hash for a valid Merkle tree of the `WorldIDRegistry`, as well as the expected depth.
 3. The `expected_commitment` public input matches the expected `sub` being verified. This value MAY also be used for lookups when the `sub` is not known in advance.
-4. The `nonce` public input is one the Issuer itself generated, has not expired, and has not been used before. The nonce MUST be invalidated at this point. See [Nonce](#nonce).
-5. The `context` public input is the context the Issuer assigns to the operation it is about to execute. A proof carrying any other context MUST be rejected, even if every other check passes. See [Context](#context).
+4. The `nonce` public input is one the Issuer itself generated, has not expired, and has not been used before. The nonce MUST be invalidated at this point. See [Nonce](#33-nonce).
+5. The `context` public input is the context the Issuer assigns to the operation it is about to execute. A proof carrying any other context MUST be rejected, even if every other check passes. See [Context](#34-context).
 
 Validations 4 and 5 are what make the proof unreplayable and single-purpose. The circuit constrains the `nonce` and `context` to be bound in the authenticator's signature, but it cannot know which values the verifier intended, so a verifier that accepts the values supplied alongside the proof without comparing them to its own gains no replay or cross-context protection.
 
 It is strongly RECOMMENDED that implementations verify the Ownership Proof using a proof format and verification method supported by [ProveKit](https://github.com/worldfnd/provekit).
 
-## Security
+## 7. Security
 
 1. **`commitment_blinder` is never revealed.** Unlike the Query Proof circuit, the `commitment_blinder` value is a private input. For Issuer Authentication (WIP-103-001), this means the credential blinding factor is never exposed to the Issuer. If it were, the Issuer could brute-force the `leaf_index` (the domain of possible values is small) and break the unlinkability property of the blinding factor.
 2. **Domain separation prevents cross-context replay.** Each use case defines its own domain separator, and the `domain_separator` is committed inside the hash. A proof generated for one use case cannot be replayed in another context. Authenticators MUST enforce that only domain separators defined in this spec or a referencing spec are used.
@@ -138,7 +138,7 @@ It is strongly RECOMMENDED that implementations verify the Ownership Proof using
 4. **Nonce and context are bound into the signed message.** The signature verified by the circuit is over `nonce`, `context` and `expected_commitment`, not only over the bare commitment. This means every Ownership Proof requires a fresh signature from the authenticator signing key for that specific `(nonce, context)` tuple (in addition to the `expected_commitment`), anchoring proof generation to an active signing event by the Authenticator.
 5. For note, proofs for the same `expected_commitment` (e.g. the same `sub`) are linkable because they use the same public input. This is intended as the `expected_commitment` is what its getting proven. This proof however prevents cross-verifier linking as the `commitment_blinder` differs.
 
-## Backwards Compatibility
+## 8. Backwards Compatibility
 
 This World Improvement Proposal (WIP) introduces a new interface; no existing contracts or other previously existing functionality is affected.
 

--- a/docs/WIPs/wip-103.md
+++ b/docs/WIPs/wip-103.md
@@ -3,7 +3,7 @@ wip: 103
 title: Proof of Ownership
 description: Mechanism to privately prove ownership of a registered leaf via a blinded leaf index commitment.
 author: Paolo D'Amico (@paolodamico), Daniel Kales (@dkales)
-status: Draft
+status: 🟠 Last Call
 type: Standards Track
 created: 2026-03-26
 ---

--- a/docs/WIPs/wip-104.md
+++ b/docs/WIPs/wip-104.md
@@ -3,7 +3,7 @@ wip: 104
 title: Proving and Admin Authenticators with Fixed Permission Sets
 description: Introduce two classes of authenticators where a Proving Authenticator is not allowed to perform any management operations on a World ID.
 author: Paolo D'Amico (@paolodamico), Philipp Sippl (@philsippl), Kilian Glas (@kilianglas)
-status: Draft
+status: ✅ Final
 type: Standards Track
 created: 2026-04-06
 ---

--- a/docs/WIPs/wip-104.md
+++ b/docs/WIPs/wip-104.md
@@ -8,11 +8,11 @@ type: Standards Track
 created: 2026-04-06
 ---
 
-## Abstract
+## 1. Abstract
 
 This spec introduces a distinction between two classes of Authenticators in the World ID Protocol: **Proving Authenticators** and **Admin Authenticators**. A Proving Authenticator holds only an off-chain public key and is limited to proof generation and presentation. An Admin Authenticator **additionally** holds an on-chain management key (represented as an address registered in `_authenticatorAddressToPackedAccountData`) and can perform all management operations on the World ID. The authenticator type is encoded in the existing pubkey bitmap of the `WorldIDRegistry`. In addition, this spec deprecates the `updateAuthenticator` method.
 
-## Motivation
+## 2. Motivation
 
 Prior to this spec, every authenticator registered for a World ID was required to have a corresponding on-chain management key. This means every authenticator has equal permissions and can perform all management operations (inserting, removing or updating other authenticators, initiating recovery agent updates, etc.). There are multiple use cases where a user may want to have an authenticator capable of generating proofs on their behalf but not managing their World ID. An example of this is when delegating proof generation to some CLI tools, agents or non fully-featured authenticators.
 
@@ -21,20 +21,20 @@ Requiring a management key for authenticators that don't need it expands the att
 2. Reduced storage costs for authenticators that only generate proofs.
 3. Flexibility for future authenticator form factors that lack the ability to hold an Ethereum key pair.
 
-## Specification
+## 3. Specification
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).
 
 The terms [Authenticator](https://docs.rs/world-id-core/latest/world_id_core/struct.Authenticator.html), Issuer and [Credential](https://docs.rs/world-id-primitives/latest/world_id_primitives/credential/struct.Credential.html) are as defined in the World ID Protocol.
 
-### Terminology
+### 3.1 Terminology
 
 This spec introduces the following explicit terminology:
 1. **Signing Key**: This is an EdDSA over BabyJubJub keypair which authenticators use to sign operations off-chain related to proof generation. The signatures from this key are used in ZK circuits (e.g. Query Circuit or [WIP-103 Proof of Ownership](wip-103.md)). _Previously this may have been referred to as off-chain signer_.
 2. **Management Key**: An ECDSA over `secp256k1` keypair (curve used by World Chain) used to sign operations on-chain that change the state of a World ID in the `WorldIDRegistry`. The public key is represented as an Ethereum address. _Previously this may have been referred to as on-chain signer_.
 3. **Management Operations**: Any operation which results in a state change to a user's World ID in the `WorldIDRegistry`. Examples: inserting an authenticator, removing an authenticator, initiating a Recovery Agent update.
 
-### Authenticator Classes
+### 3.2 Authenticator Classes
 
 A distinction is introduced between two classes of Authenticators:
 1. **Proving Authenticator**: Holds only a **Signing Key** and is capable of proof generation and presentation. A Proving Authenticator SHALL NOT perform any management operations on the World ID, i.e. it cannot perform any state changes on the `WorldIDRegistry` for the user. A Proving Authenticator has no entry in `_authenticatorAddressToPackedAccountData`.
@@ -42,7 +42,7 @@ A distinction is introduced between two classes of Authenticators:
 
 Prior to the introduction of this spec, all registered authenticators MUST be considered Admin Authenticators.
 
-### Bitmap Encoding
+### 3.3 Bitmap Encoding
 
 The `WorldIDRegistry` stores a 96-bit pubkey bitmap per account in `_leafIndexToRecoveryAddressPacked`. This spec splits the bitmap into two halves:
 - **Bits [0-47]**: Occupancy. Bit `n` is set if pubkeyId `n` is in use.
@@ -52,7 +52,7 @@ An occupied slot with its class bit clear is an Admin Authenticator. An occupied
 
 As a consequence of this encoding, `MAX_AUTHENTICATORS_HARD_LIMIT` is reduced from 96 to 48. The registry MUST reject `setMaxAuthenticators` calls with a value greater than 48.
 
-### `insertAuthenticator`
+### 3.4 `insertAuthenticator`
 
 The `insertAuthenticator` function MUST accept `address(0)` as the `newAuthenticatorAddress` parameter. When `address(0)` is provided:
 1. The occupancy bit for the given `pubkeyId` MUST be set.
@@ -64,7 +64,7 @@ When a non-zero address is provided, the function behaves as in V1 (occupancy bi
 
 The operation MUST be authorized by an existing Admin Authenticator (no changes).
 
-### `removeAuthenticator`
+### 3.5 `removeAuthenticator`
 
 The `removeAuthenticator` function MUST use the bitmap class bit to determine the removal path:
 1. If the class bit is set (Proving Authenticator), the caller MUST pass `address(0)` as `authenticatorAddress`. No address mapping validation or cleanup is performed. Both the occupancy and class bits MUST be cleared.
@@ -74,48 +74,48 @@ If an incorrect `authenticatorAddress` is passed for the authenticator class bei
 
 The operation MUST be authorized by an existing Admin Authenticator (no changes).
 
-### `updateAuthenticator`
+### 3.6 `updateAuthenticator`
 
 The `updateAuthenticator` function is deprecated in this version. Calls MUST revert with `MethodUnsupported`. Key rotation can be accomplished with a `removeAuthenticator` followed by `insertAuthenticator`.
 
-### Account Creation
+### 3.7 Account Creation
 
 Account creation (`_registerAccount`) is unaffected. `_registerAccount` rejects `address(0)`, so every new account starts with at least one Admin Authenticator.
 
-### Manageability Invariant
+### 3.8 Manageability Invariant
 
 An Admin Authenticator MUST NOT be removed if it is the only Admin Authenticator remaining on the account. Such a call MUST revert with `UnmanageableNotAllowed`. This guarantees that an account always retains at least one Admin Authenticator capable of managing it.
 
-## Rationale
+## 4. Rationale
 
 Introducing two classes of authenticators allows users to have more control over the permissions they assign to different authenticators. This follows common security practices of least privilege.
 
-### Split bitmap over separate storage
+### 4.1 Split bitmap over separate storage
 
 The authenticator class could be stored in a separate mapping (e.g. `mapping(uint64 => uint256)`), but this would add a new cold `SSTORE` (20k gas) per account on first use. The split-bitmap approach reuses the existing 96-bit bitmap with no additional storage cost. The trade-off is halving the maximum authenticator count from 96 to 48, which is acceptable given practical account sizes.
 
-### `updateAuthenticator` disabled
+### 4.2 `updateAuthenticator` disabled
 
 Supporting all type of transitions in a single function adds significant surface area. The same outcomes are achievable via `removeAuthenticator` + `insertAuthenticator`. Furthermore, these operations are expected to seldom occur.
 
-### Authorization model
+### 4.3 Authorization model
 
 Proving Authenticators cannot sign management operations because they have no entry in `_authenticatorAddressToPackedAccountData`, which is required by `_recoverAccountDataFromSignature`. This is enforced structurally rather than with an explicit permission check, and the structural check covers every call site that resolves a signer through `_recoverAccountDataFromSignature` (e.g. `insertAuthenticator`, `removeAuthenticator`, `initiateRecoveryAgentUpdate`, `cancelRecoveryAgentUpdate`).
 
-## Security
+## 5. Security
 
 1. **Proving Authenticators cannot escalate privileges.** The lack of an `_authenticatorAddressToPackedAccountData` entry means `_recoverAccountDataFromSignature` will always revert for a Proving Authenticator's address. There is no code path through which a Proving Authenticator can authorize a management operation.
 2. **Class enforcement on removal.** The bitmap class bit determines the required removal path. A caller cannot use `address(0)` to remove an Admin Authenticator (which would leave its mapping stale) or a non-zero address to remove a Proving Authenticator.
 3. **Bitmap backward compatibility.** V1 accounts have all type bits at zero, correctly classifying existing authenticators as Admin. This holds because `_maxAuthenticators` was never set above 48 in V1. The `setMaxAuthenticators` override enforces this new hard limit going forward.
 4. **Account creation unchanged.** The `_registerAccount` function retains its V1 check that rejects `address(0)`, ensuring every new account starts with at least one Admin Authenticator.
 
-## Backwards Compatibility
+## 6. Backwards Compatibility
 
 - All existing authenticators are classified as Admin Authenticators (class bit defaults to 0). No migration is required.
 - The maximum authenticator count per account is reduced from 96 to 48. Accounts with authenticators at pubkeyId >= 48 are incompatible.
 - `updateAuthenticator` is disabled. Callers relying on this function MUST switch to `removeAuthenticator` + `insertAuthenticator`.
 
-## Alternatives Considered
+## 7. Alternatives Considered
 
 With the introduction of this spec, we also considered completely decoupling Signing Keys from Management Keys, which means that each key is treated independently and there is no explicit concept of an Authenticator encoded in the `WorldIDRegistry`. This was eventually dismissed. Implementing such a system requires one of two options.
 

--- a/docs/WIPs/wip-104.md
+++ b/docs/WIPs/wip-104.md
@@ -50,7 +50,7 @@ The `WorldIDRegistry` stores a 96-bit pubkey bitmap per account in `_leafIndexTo
 
 An occupied slot with its class bit clear is an Admin Authenticator. An occupied slot with its class bit set is a Proving Authenticator. The state `(occupancy=0, class=1)` is unused and MUST NOT occur; an unoccupied slot MUST have both bits clear.
 
-As a consequence of this encoding, `MAX_AUTHENTICATORS_HARD_LIMIT` is reduced from 96 to 48. The registry MUST reject `setMaxAuthenticators` calls with a value greater than 48.
+As a consequence of this encoding, the effective hard limit on authenticators per account is reduced from 96 to 48. This limit MUST be exposed as a separate constant, `MAX_AUTHENTICATORS_V2_HARD_LIMIT`, and the registry MUST reject `setMaxAuthenticators` calls with a value greater than it.
 
 ### 3.4 `insertAuthenticator`
 


### PR DESCRIPTION
### Motivation
As we write more WIPs and implementations, it's become annoying to reference specific points on a WIP.

### Changes
 1. Introduces very simple numbering of sections within WIPs to make them easy to reference.
 2. Adds missing logical sections in WIP-101.
 3. Marks WIP-104 as final. @philsippl 
 4. Marks WIP-101 (cc @0xForerunner), WIP-102 (cc @Dzejkop) and WIP-103 as last call.
 5. Updates WIP-102 to incorporate the changes brought forward with WIP-104.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and spec-status edits only; no runtime or contract code changes in this PR.
> 
> **Overview**
> Updates **WIP-101–104** documentation for easier cross-referencing and lifecycle progression: numbered top-level and nested sections, refreshed internal anchor links, and **status** moves (**WIP-104** → Final; **WIP-101/102/103** → Last Call).
> 
> **WIP-101** splits the former flat specification into logical normative subsections (contract interface, validation/errors, OPRF node behavior, signer caching, field limits, deployment) and marks additional context as non-normative; the security section now explicitly ties the threat model to OPRF **`action`** binding in §3.3.
> 
> **WIP-102** narrows who may call **`revertRecoveryAgentUpdate`**: only **Admin Authenticators** per **WIP-104** (management operation); **Proving Authenticators** are explicitly excluded, with matching updates in rationale and security.
> 
> **WIP-103** is largely structural (numbering and link targets). **WIP-104** documents the authenticator hard cap as **`MAX_AUTHENTICATORS_V2_HARD_LIMIT`** alongside section numbering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b187e4f6144430bd45aa4e19b17250d7da4c25be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->