### PR TITLE
fix(authenticator): properly track recovery counter before initialization

### DIFF
--- a/crates/authenticator/src/authenticator.rs
+++ b/crates/authenticator/src/authenticator.rs
@@ -342,10 +342,24 @@ impl Authenticator {
         // If the registry is available through direct RPC calls, use it. Otherwise fallback to the indexer.
         let raw_index = if let Some(registry) = registry {
             // TODO: Better error handling to expose the specific failure
-            registry
+            let packed_account_data = registry
                 .getPackedAccountData(onchain_signer_address)
                 .call()
-                .await?
+                .await?;
+
+            // The registry keeps stale packed data for authenticators revoked by a recovery,
+            // so compare the embedded recovery counter against the account's current one.
+            if packed_account_data != U256::ZERO {
+                let leaf_index = (packed_account_data & MASK_LEAF_INDEX).to::<u64>();
+                let packed_recovery_counter = (packed_account_data & MASK_RECOVERY_COUNTER) >> 224;
+                let current_recovery_counter =
+                    registry.getRecoveryCounter(leaf_index).call().await?;
+                if current_recovery_counter > packed_recovery_counter {
+                    return Err(AuthenticatorError::AccountDoesNotExist);
+                }
+            }
+
+            packed_account_data
         } else {
             let req = IndexerPackedAccountRequest {
                 authenticator_address: onchain_signer_address,

--- a/crates/core/tests/e2e_recovery_revokes_authenticator.rs
+++ b/crates/core/tests/e2e_recovery_revokes_authenticator.rs
@@ -1,0 +1,118 @@
+#![cfg(feature = "authenticator")]
+
+use std::sync::Arc;
+
+use alloy::{
+    primitives::U256,
+    providers::{Provider, ProviderBuilder},
+    signers::local::PrivateKeySigner,
+};
+use world_id_core::{
+    Authenticator, AuthenticatorError,
+    artifacts::{ZkArtifactSource, dummy::DummyZkArtifactSource},
+    world_id_registry::{WorldIdRegistry, domain, sign_recover_account},
+};
+use world_id_primitives::{Config, ServiceEndpoint};
+use world_id_test_utils::anvil::TestAnvil;
+
+fn dummy_zk_source() -> Arc<dyn ZkArtifactSource> {
+    Arc::new(DummyZkArtifactSource)
+}
+
+// After an on-chain recovery, the registry still returns the old authenticator's packed
+// account data, so `Authenticator::init` over direct RPC must reject it via the recovery
+// counter instead of initializing against the recovered account's leaf index.
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn init_fails_for_authenticator_revoked_by_recovery() {
+    rustls::crypto::aws_lc_rs::default_provider()
+        .install_default()
+        .expect("can install");
+
+    let anvil = TestAnvil::spawn().expect("failed to spawn anvil");
+    let deployer = anvil.signer(0).unwrap();
+    let recovery_agent = anvil.signer(1).unwrap();
+    let registry_address = anvil
+        .deploy_world_id_registry(deployer.clone())
+        .await
+        .unwrap();
+
+    let provider = ProviderBuilder::new()
+        .wallet(deployer)
+        .connect_http(anvil.endpoint().parse().unwrap());
+    let chain_id = provider.get_chain_id().await.unwrap();
+    let registry = WorldIdRegistry::new(registry_address, provider);
+
+    // Register an account whose only authenticator is the address derived from `seed`.
+    let seed = [7u8; 32];
+    let auth_addr = PrivateKeySigner::from_bytes(&seed.into())
+        .unwrap()
+        .address();
+    let old_commitment = U256::from(2);
+    registry
+        .createAccount(
+            recovery_agent.address(),
+            vec![auth_addr],
+            vec![U256::from(1)],
+            old_commitment,
+        )
+        .send()
+        .await
+        .unwrap()
+        .get_receipt()
+        .await
+        .unwrap();
+
+    let config = Config::new(
+        Some(anvil.endpoint().to_string()),
+        chain_id,
+        registry_address,
+        ServiceEndpoint::direct("http://127.0.0.1:0".to_string()),
+        ServiceEndpoint::direct("http://127.0.0.1:0".to_string()),
+        Vec::new(),
+        2,
+    )
+    .unwrap();
+
+    let auth = Authenticator::init(&seed, config.clone(), dummy_zk_source())
+        .await
+        .unwrap();
+    let leaf_index = auth.leaf_index();
+
+    // Recover the account to a fresh authenticator, revoking the original one.
+    let new_auth_addr = anvil.signer(2).unwrap().address();
+    let new_commitment = U256::from(3);
+    let nonce = registry.getSignatureNonce(leaf_index).call().await.unwrap();
+    let signature = sign_recover_account(
+        &recovery_agent,
+        leaf_index,
+        new_auth_addr,
+        U256::from(4),
+        new_commitment,
+        nonce,
+        &domain(chain_id, registry_address),
+    )
+    .await
+    .unwrap();
+    registry
+        .recoverAccount(
+            leaf_index,
+            new_auth_addr,
+            U256::from(4),
+            old_commitment,
+            new_commitment,
+            signature.as_bytes().to_vec().into(),
+            nonce,
+        )
+        .send()
+        .await
+        .unwrap()
+        .get_receipt()
+        .await
+        .unwrap();
+
+    let result = Authenticator::init(&seed, config, dummy_zk_source()).await;
+    assert!(matches!(
+        result,
+        Err(AuthenticatorError::AccountDoesNotExist)
+    ));
+}


### PR DESCRIPTION
Properly track account recovery counter in the authenticator after - https://github.com/worldcoin/world-id-protocol/pull/968

The registry stores stale `packedAccountData` for authenticators associated with a recovered account. The indexer already tracks the recovery count properly before returning the `packedAccountData`. This PR just makes the local authenticator logic match the indexer by rejecting an authenticator whose recovery counter is out of sync with the `WorldIDRegistry`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 689e66ae46297bb10a4ac9d9609320ac6a0f8b47. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->