### PR TITLE
fix: reject recovery-revoked authenticators from registry state

### DIFF
--- a/crates/authenticator/src/authenticator.rs
+++ b/crates/authenticator/src/authenticator.rs
@@ -118,6 +118,8 @@ impl Authenticator {
     /// while a create-account or authenticator-management operation is still pending on-chain and
     /// the authenticator address has not been registered yet. Consumers that are coordinating such
     /// operations should poll the gateway request and retry initialization after finalization.
+    /// A recovery-revoked authenticator instead returns [`AuthenticatorError::PublicKeyNotFound`];
+    /// callers must request reauthorization rather than create a replacement World ID.
     ///
     /// Indexer DB catch-up is separate and does not block initialization, since packed account data
     /// is read from the registry (directly or via the indexer's chain-backed packed-account
@@ -130,6 +132,8 @@ impl Authenticator {
     /// - Will return [`AuthenticatorError::AccountDoesNotExist`] if the authenticator address
     ///   derived from `seed` is not currently registered on-chain, whether permanently or because a
     ///   relevant on-chain operation has not finalized yet.
+    /// - Will return [`AuthenticatorError::PublicKeyNotFound`] if account recovery revoked this
+    ///   authenticator.
     pub async fn init(
         seed: &[u8],
         config: Config,
@@ -354,8 +358,8 @@ impl Authenticator {
                 let packed_recovery_counter = (packed_account_data & MASK_RECOVERY_COUNTER) >> 224;
                 let current_recovery_counter =
                     registry.getRecoveryCounter(leaf_index).call().await?;
-                if current_recovery_counter > packed_recovery_counter {
-                    return Err(AuthenticatorError::AccountDoesNotExist);
+                if current_recovery_counter != packed_recovery_counter {
+                    return Err(AuthenticatorError::PublicKeyNotFound);
                 }
             }
 
@@ -380,6 +384,9 @@ impl Authenticator {
                         return match error_resp.code {
                             IndexerErrorCode::AccountDoesNotExist => {
                                 Err(AuthenticatorError::AccountDoesNotExist)
+                            }
+                            IndexerErrorCode::AuthenticatorRevoked => {
+                                Err(AuthenticatorError::PublicKeyNotFound)
                             }
                             _ => Err(AuthenticatorError::IndexerError {
                                 status,
@@ -740,6 +747,44 @@ mod tests {
             Err(AuthenticatorError::AccountDoesNotExist)
         ));
         mock.assert_async().await;
+        drop(server);
+    }
+
+    #[tokio::test]
+    async fn test_revoked_authenticator_is_not_an_unregistered_account() {
+        let mut server = mockito::Server::new_async().await;
+        let indexer_url = server.url();
+        let mut gateway = mockito::Server::new_async().await;
+        let registration = gateway
+            .mock("POST", mockito::Matcher::Any)
+            .expect(0)
+            .create_async()
+            .await;
+        let mock = server
+            .mock("POST", "/packed-account")
+            .with_status(403)
+            .with_header("content-type", "application/json")
+            .with_body(serde_json::json!({ "code": "authenticator_revoked", "message": "Authenticator revoked by recovery" }).to_string())
+            .create_async()
+            .await;
+        let config = Config::new(
+            None,
+            1,
+            address!("0x0000000000000000000000000000000000000001"),
+            ServiceEndpoint::direct(indexer_url),
+            ServiceEndpoint::direct(gateway.url()),
+            Vec::new(),
+            2,
+        )
+        .unwrap();
+
+        let result =
+            Authenticator::init_or_register(&[42; 32], config, None, dummy_zk_artifact_source())
+                .await;
+
+        assert!(matches!(result, Err(AuthenticatorError::PublicKeyNotFound)));
+        mock.assert_async().await;
+        registration.assert_async().await;
         drop(server);
     }
 

--- a/crates/authenticator/tests/ohttp_authenticator_integration.rs
+++ b/crates/authenticator/tests/ohttp_authenticator_integration.rs
@@ -717,6 +717,38 @@ async fn packed_account_not_found_maps_to_account_does_not_exist() -> eyre::Resu
 }
 
 #[tokio::test]
+async fn revoked_authenticator_never_registers_a_replacement() -> eyre::Result<()> {
+    install_crypto_provider();
+    let f = OhttpFixture::start().await?;
+
+    let error_body = json!({
+        "code": "authenticator_revoked",
+        "message": "Authenticator revoked by recovery",
+    });
+
+    f.set_indexer_response(
+        "/packed-account",
+        AxumStatusCode::FORBIDDEN,
+        serde_json::to_vec(&error_body)?,
+    )
+    .await;
+
+    let config = f.authenticator_config();
+
+    let result = Authenticator::init_or_register(&TEST_SEED, config, None, dummy_zk_source()).await;
+    assert!(
+        matches!(result, Err(AuthenticatorError::PublicKeyNotFound)),
+        "expected PublicKeyNotFound, got: {result:?}"
+    );
+
+    assert!(
+        f.last_gateway_request().await.is_none(),
+        "Revocation must not create another account"
+    );
+    Ok(())
+}
+
+#[tokio::test]
 async fn gateway_error_propagates_through_ohttp() -> eyre::Result<()> {
     let f = OhttpFixture::start().await?;
 

--- a/crates/core/tests/e2e_recovery_revokes_authenticator.rs
+++ b/crates/core/tests/e2e_recovery_revokes_authenticator.rs
@@ -111,8 +111,5 @@ async fn init_fails_for_authenticator_revoked_by_recovery() {
         .unwrap();
 
     let result = Authenticator::init(&seed, config, dummy_zk_source()).await;
-    assert!(matches!(
-        result,
-        Err(AuthenticatorError::AccountDoesNotExist)
-    ));
+    assert!(matches!(result, Err(AuthenticatorError::PublicKeyNotFound)));
 }

--- a/crates/primitives/src/api_types.rs
+++ b/crates/primitives/src/api_types.rs
@@ -537,6 +537,8 @@ pub enum IndexerErrorCode {
     Locked,
     /// The account does not exist.
     AccountDoesNotExist,
+    /// This authenticator lost access after account recovery.
+    AuthenticatorRevoked,
     /// The request timed out.
     RequestTimeout,
 }

--- a/services/indexer/README.md
+++ b/services/indexer/README.md
@@ -39,6 +39,13 @@ In `HttpOnly` mode the tree is not versioned; instead a background loop polls th
 
 The HTTP server serves inclusion proofs for public keys. It is backed by the shared DB and in-memory tree. An optional periodic sanity check (`SANITY_CHECK_INTERVAL_SECS`) calls `isValidRoot` on the registry contract to verify the in-memory root is still valid on-chain.
 
+The `/packed-account` endpoint reads both packed account data and the current recovery counter
+from the registry. Recovery revocation therefore does not depend on database catch-up. An
+unknown authenticator returns HTTP 400 with `account_does_not_exist`; an authenticator revoked
+by recovery returns HTTP 403 with `authenticator_revoked`. Clients must not treat revocation as
+permission to register another World ID. RPC failures return a server error rather than
+authorizing the authenticator from cached database state.
+
 ### Reorg Handling
 
 Reorgs are detected during batch commit in two ways:
@@ -92,3 +99,17 @@ cp .env.example .env
 ```
 docker compose -f services/docker-compose.yml up
 ```
+
+### Integration tests
+
+Integration tests use a disposable PostgreSQL container by default. To use an existing local
+test server instead, set `WORLD_ID_INDEXER_TEST_DATABASE_URL` to its connection URL and run:
+
+```sh
+cargo test -p world-id-indexer --features integration-tests --test test_get_packed_account
+```
+
+The supplied database is used only to connect to the server. Each test creates and drops its
+own `test_db_<uuid>` database, so the test user needs database-creation privileges. Foundry
+(`forge` and `anvil`) must also be installed. If contract artifacts have already been built,
+set `CONTRACTS_PREBUILT=1` to reuse them.

--- a/services/indexer/src/routes/get_packed_account.rs
+++ b/services/indexer/src/routes/get_packed_account.rs
@@ -22,7 +22,8 @@ const LEAF_INDEX_MASK: U256 = U256::from_limbs([u64::MAX, 0, 0, 0]);
     request_body = IndexerPackedAccountRequest,
     responses(
         (status = 200, body = IndexerPackedAccountResponse),
-        (status = 400, description = "Account does not exist for the given authenticator address, or the authenticator was revoked by recovery", body = IndexerErrorBody),
+        (status = 400, description = "Account does not exist for the given authenticator address", body = IndexerErrorBody),
+        (status = 403, description = "Authenticator was revoked by recovery", body = IndexerErrorBody),
     ),
     tag = "indexer"
 )]
@@ -48,23 +49,26 @@ pub(crate) async fn handler(
     }
 
     let leaf_index = (packed_account_data & LEAF_INDEX_MASK).to::<u64>();
-    let packed_recovery_counter = (packed_account_data >> RECOVERY_COUNTER_SHIFT).to::<u64>();
+    let packed_recovery_counter = packed_account_data >> RECOVERY_COUNTER_SHIFT;
 
-    let indexed_recovery_counter = state
-        .db
-        .accounts()
-        .get_recovery_counter(leaf_index)
+    // Packed mappings for revoked authenticators remain on-chain after recovery.
+    // Compare with the registry's current counter, not an eventually consistent
+    // indexer row: a missing or lagging row must never authorize the old device.
+    let current_recovery_counter = state
+        .registry
+        .getRecoveryCounter(leaf_index)
+        .call()
         .await
         .map_err(|err| {
-            tracing::error!(leaf_index, "DB error fetching recovery counter: {err}");
+            tracing::error!(leaf_index, "RPC error fetching recovery counter: {err}");
             IndexerErrorResponse::internal_server_error()
         })?;
 
-    // Fails open: rejects only if the authenticator is confirmed revoked
-    if indexed_recovery_counter.is_some_and(|indexed| indexed > packed_recovery_counter) {
-        return Err(IndexerErrorResponse::bad_request(
-            IndexerErrorCode::AccountDoesNotExist,
+    if current_recovery_counter != packed_recovery_counter {
+        return Err(IndexerErrorResponse::new(
+            IndexerErrorCode::AuthenticatorRevoked,
             "This authenticator was revoked by an account recovery".to_string(),
+            http::StatusCode::FORBIDDEN,
         ));
     }
 

--- a/services/indexer/tests/helpers/db_helpers.rs
+++ b/services/indexer/tests/helpers/db_helpers.rs
@@ -69,10 +69,13 @@ impl Drop for TestDatabase {
 /// Returns a TestDatabase guard that will automatically cleanup on drop
 pub async fn create_unique_test_db() -> TestDatabase {
     let unique_name = format!("test_db_{}", Uuid::new_v4().to_string().replace('-', "_"));
-    let base_url = shared_postgres_testcontainer()
-        .await
-        .expect("failed to start Postgres testcontainer")
-        .to_owned();
+    let base_url = match std::env::var("WORLD_ID_INDEXER_TEST_DATABASE_URL") {
+        Ok(url) => url,
+        Err(_) => shared_postgres_testcontainer()
+            .await
+            .expect("failed to start Postgres testcontainer")
+            .to_owned(),
+    };
 
     // Connect to postgres database to create our test database
     let pool = PgPoolOptions::new()

--- a/services/indexer/tests/test_get_packed_account.rs
+++ b/services/indexer/tests/test_get_packed_account.rs
@@ -186,8 +186,8 @@ async fn test_packed_account_rejects_authenticator_revoked_by_recovery() {
     wait_for_recovery_indexed(&setup.pool, leaf_index as i64).await;
 
     let (status, json) = packed_account(host, old_auth_addr).await;
-    assert_eq!(status, StatusCode::BAD_REQUEST); // after recovery, the old authenticator is revoked
-    assert_eq!(json["code"].as_str().unwrap(), "account_does_not_exist");
+    assert_eq!(status, StatusCode::FORBIDDEN); // after recovery, the old authenticator is revoked
+    assert_eq!(json["code"].as_str().unwrap(), "authenticator_revoked");
 
     // the other authenticator works
     let (status, json) = packed_account(host, new_auth_addr).await;
@@ -196,6 +196,28 @@ async fn test_packed_account_rejects_authenticator_revoked_by_recovery() {
         packed_data(&json),
         (U256::from(1) << 224) | U256::from(leaf_index)
     );
+
+    // Revocation must not depend on the indexer's recovery event having caught up.
+    sqlx::query("UPDATE accounts SET recovery_counter = 0 WHERE leaf_index = $1")
+        .bind(leaf_index as i64)
+        .execute(&setup.pool)
+        .await
+        .unwrap();
+    let (status, json) = packed_account(host, old_auth_addr).await;
+    assert_eq!(status, StatusCode::FORBIDDEN);
+    assert_eq!(json["code"], "authenticator_revoked");
+    assert_eq!(packed_account(host, new_auth_addr).await.0, StatusCode::OK);
+
+    // A missing account row is not evidence that the old authenticator is valid.
+    sqlx::query("DELETE FROM accounts WHERE leaf_index = $1")
+        .bind(leaf_index as i64)
+        .execute(&setup.pool)
+        .await
+        .unwrap();
+    let (status, json) = packed_account(host, old_auth_addr).await;
+    assert_eq!(status, StatusCode::FORBIDDEN);
+    assert_eq!(json["code"], "authenticator_revoked");
+    assert_eq!(packed_account(host, new_auth_addr).await.0, StatusCode::OK);
 
     indexer_task.abort();
 }


### PR DESCRIPTION
Account recovery leaves stale packed mappings for the revoked authenticator. The indexer previously relied on an eventually consistent database counter, and the client classified revocation as an unregistered account, allowing `init_or_register` to create a replacement World ID.

Read the authoritative registry recovery counter, reject mismatches with HTTP 403 `authenticator_revoked`, and map that result to `PublicKeyNotFound` in both indexer and direct-RPC initialization. WalletKit already maps this error to `UnauthorizedAuthenticator`. A revoked authenticator never enters automatic registration. Existing clients that do not recognize the new error fail closed with an indexer/network error.

Validation: 20 authenticator unit tests pass; both packed-account integration tests pass against PostgreSQL 16 and Anvil, including stale and missing indexer rows; the real on-chain recovery test passes. Clippy passes for indexer/authenticator with all targets and indexer integration tests. Nightly formatting and diff checks pass. OHTTP regression coverage is added but its Docker-dependent test was not run locally. No contracts changed, no deployment performed. An opt-in local test database URL is documented; tests still create/drop only their own UUID databases.

Release dependency: publish the protocol crate and update WalletKit before relying on the specific revoked-device UI error. The indexer change independently closes the stale-database authorization gap.

AI disclosure: implemented and tested with OpenAI Codex.