### PR TITLE
ci: diagnose public Git clone failures on ARC runners

### DIFF
--- a/.github/scripts/diagnose-github-clones.py
+++ b/.github/scripts/diagnose-github-clones.py
@@ -6,6 +6,7 @@ import json
 import os
 import re
 import subprocess
+import sys
 import tempfile
 import time
 from pathlib import Path
@@ -19,7 +20,7 @@ REPOS = [
     "TaceoLabs/oprf-key-registry",
     "ethereum-optimism/optimism",
 ]
-TOKEN = os.environ.pop("DIAGNOSTIC_TOKEN")
+TOKEN = os.environ.pop("DIAGNOSTIC_TOKEN", "")
 BASIC = base64.b64encode(f"x-access-token:{TOKEN}".encode()).decode()
 SAFE_HEADER = re.compile(
     r"^(HTTP/|date:|server:|content-type:|www-authenticate:|retry-after:|"
@@ -28,16 +29,46 @@ SAFE_HEADER = re.compile(
 
 
 def redact(value):
-    return value.replace(TOKEN, "[REDACTED]").replace(BASIC, "[REDACTED]")
+    return value.replace(TOKEN, "[REDACTED]").replace(BASIC, "[REDACTED]") if TOKEN else value
 
 
-def run(args, **kwargs):
+def run(args, timeout=45, **kwargs):
     started = time.monotonic()
     try:
-        result = subprocess.run(args, capture_output=True, text=True, timeout=45, **kwargs)
+        result = subprocess.run(args, capture_output=True, text=True, timeout=timeout, **kwargs)
         return result.returncode, result.stdout, result.stderr, round(time.monotonic() - started, 2)
     except subprocess.TimeoutExpired:
-        return 124, "", "Timed out after 45 seconds", 45
+        return 124, "", f"Timed out after {timeout} seconds", timeout
+
+
+if len(sys.argv) > 1 and sys.argv[1] in ("--build", "--recover"):
+    with tempfile.TemporaryDirectory() as tmp:
+        trace = Path(tmp) / "git-http.log"
+        env = os.environ.copy()
+        env.update(GIT_TERMINAL_PROMPT="0", GIT_TRACE_CURL=str(trace), GIT_TRACE_CURL_NO_DATA="1")
+        if sys.argv[1] == "--recover":
+            assert TOKEN
+            env.update(
+                GIT_CONFIG_COUNT="1",
+                GIT_CONFIG_KEY_0="http.https://github.com/.extraheader",
+                GIT_CONFIG_VALUE_0=f"AUTHORIZATION: basic {BASIC}",
+            )
+        code, out, err, duration = run(["make", "sol-build"], env=env, timeout=900)
+        for line in (out + "\n" + err).splitlines():
+            if not any(x in line for x in ("Receiving objects:", "Resolving deltas:", "Counting objects:", "Compressing objects:")):
+                print(redact(line))
+        print(f"build exit={code}, seconds={duration}")
+        if trace.exists():
+            print("::group::Actual clone HTTP responses")
+            for line in trace.read_text().splitlines():
+                if "<= Recv header:" in line:
+                    header = line.split("<= Recv header:", 1)[1].strip()
+                    if SAFE_HEADER.match(header):
+                        print(redact(line))
+                elif re.search(r"=> Send header: (GET|POST) ", line):
+                    print(redact(line))
+            print("::endgroup::")
+        sys.exit(code)
 
 
 print("UTC:", datetime.datetime.now(datetime.timezone.utc).isoformat(), flush=True)

--- a/.github/scripts/diagnose-github-clones.py
+++ b/.github/scripts/diagnose-github-clones.py
@@ -1,0 +1,113 @@
+"""Bounded probes of Git HTTP auth failures; never print request credentials."""
+
+import base64
+import datetime
+import json
+import os
+import re
+import subprocess
+import tempfile
+import time
+from pathlib import Path
+
+
+REPOS = [
+    "foundry-rs/forge-std",
+    "OpenZeppelin/openzeppelin-contracts",
+    "OpenZeppelin/openzeppelin-contracts-upgradeable",
+    "0xOsiris/poseidon-solidity",
+    "TaceoLabs/oprf-key-registry",
+    "ethereum-optimism/optimism",
+]
+TOKEN = os.environ.pop("DIAGNOSTIC_TOKEN")
+BASIC = base64.b64encode(f"x-access-token:{TOKEN}".encode()).decode()
+SAFE_HEADER = re.compile(
+    r"^(HTTP/|date:|server:|content-type:|www-authenticate:|retry-after:|"
+    r"x-ratelimit-|x-github-request-id:|via:|x-cache:)", re.I
+)
+
+
+def redact(value):
+    return value.replace(TOKEN, "[REDACTED]").replace(BASIC, "[REDACTED]")
+
+
+def run(args, **kwargs):
+    started = time.monotonic()
+    try:
+        result = subprocess.run(args, capture_output=True, text=True, timeout=45, **kwargs)
+        return result.returncode, result.stdout, result.stderr, round(time.monotonic() - started, 2)
+    except subprocess.TimeoutExpired:
+        return 124, "", "Timed out after 45 seconds", 45
+
+
+print("UTC:", datetime.datetime.now(datetime.timezone.utc).isoformat(), flush=True)
+print(run(["git", "--version"])[1].strip())
+print(run(["curl", "--version"])[1].splitlines()[0])
+# Report presence only: configuration values may contain credentials.
+for key in ("HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY", "http_proxy", "https_proxy", "all_proxy", "GIT_CONFIG_COUNT"):
+    print(f"{key}: {'set' if key in os.environ else 'unset'}")
+for category, pattern in (
+    ("URL rewrites", r"^url\..*\.insteadof$"),
+    ("credential helpers", r"^credential\..*helper$"),
+    ("HTTP overrides", r"^http\."),
+):
+    code, out, _, _ = run(["git", "config", "--get-regexp", pattern])
+    print(f"{category}: {len(out.splitlines()) if code == 0 else 0} entries")
+
+with tempfile.TemporaryDirectory() as tmp:
+    for repo in REPOS:
+        print(f"::group::{repo}", flush=True)
+        # Plain curl tests the same discovery endpoint without Git config or helpers.
+        for label, url in (
+            ("git-discovery", f"https://github.com/{repo}/info/refs?service=git-upload-pack"),
+        ):
+            headers, body = Path(tmp) / "headers", Path(tmp) / "body"
+            code, out, err, duration = run([
+                "curl", "-q", "-sS", "--max-time", "30", "-L",
+                "-H", "Git-Protocol: version=2", "-D", str(headers),
+                "-o", str(body), "-w", "%{http_code}", url,
+            ])
+            print(f"{label}: exit={code}, HTTP={out}, seconds={duration}")
+            if headers.exists():
+                for line in headers.read_text().splitlines():
+                    if SAFE_HEADER.match(line):
+                        print(redact(line))
+            if out != "200" and body.exists():
+                print("error body:", redact(body.read_bytes()[:1500].decode(errors="replace")))
+            if err:
+                print(redact(err))
+        for mode in ("anonymous-default-config", "anonymous-clean-config", "authenticated-clean-config"):
+            env = os.environ.copy()
+            env.update(GIT_TERMINAL_PROMPT="0", GIT_TRACE_CURL="1", GIT_TRACE_CURL_NO_DATA="1")
+            if "clean-config" in mode:
+                env.update(GIT_CONFIG_NOSYSTEM="1", GIT_CONFIG_GLOBAL="/dev/null", GIT_CONFIG_COUNT="0")
+                env.pop("GIT_CONFIG_PARAMETERS", None)
+            if mode == "authenticated-clean-config":
+                env.update(
+                    GIT_CONFIG_COUNT="1",
+                    GIT_CONFIG_KEY_0="http.https://github.com/.extraheader",
+                    GIT_CONFIG_VALUE_0=f"AUTHORIZATION: basic {BASIC}",
+                )
+            code, out, err, duration = run(
+                ["git", "ls-remote", f"https://github.com/{repo}", "HEAD"], env=env, cwd=tmp
+            )
+            print(f"{mode}: exit={code}, seconds={duration}, HEAD={out.strip()}")
+            # Only selected inbound headers and Git errors. Never emit outgoing headers.
+            for line in err.splitlines():
+                if "<= Recv header:" in line:
+                    header = line.split("<= Recv header:", 1)[1].strip()
+                    if SAFE_HEADER.match(header):
+                        print(redact(header))
+                elif line.startswith(("fatal:", "error:", "remote:", "Timed out")):
+                    print(redact(line))
+        print("::endgroup::", flush=True)
+
+    print("::group::REST quota (separate from Git transport)", flush=True)
+    code, out, err, duration = run(["curl", "-q", "-sS", "--max-time", "30", "https://api.github.com/rate_limit"])
+    print(f"exit={code}, seconds={duration}")
+    try:
+        data = json.loads(out)
+        print(json.dumps(data.get("resources", data), indent=2))
+    except ValueError:
+        print(redact(out[:1500]))
+    print("::endgroup::", flush=True)

--- a/.github/scripts/diagnose-github-clones.py
+++ b/.github/scripts/diagnose-github-clones.py
@@ -41,6 +41,52 @@ def run(args, timeout=45, **kwargs):
         return 124, "", f"Timed out after {timeout} seconds", timeout
 
 
+if len(sys.argv) > 1 and sys.argv[1] == "--clone-check":
+    results = []
+    with tempfile.TemporaryDirectory() as tmp:
+        for attempt in range(1, 4):
+            for repo in ("foundry-rs/forge-std", "0xOsiris/poseidon-solidity"):
+                for mode in ("anonymous-h2", "anonymous-h1", "authenticated-h2"):
+                    label = f"{repo} / {mode} / attempt {attempt}"
+                    print(f"::group::{label}", flush=True)
+                    env = os.environ.copy()
+                    env.update(
+                        GIT_TERMINAL_PROMPT="0", GIT_TRACE_CURL="1", GIT_TRACE_CURL_NO_DATA="1",
+                        GIT_CONFIG_NOSYSTEM="1", GIT_CONFIG_GLOBAL="/dev/null",
+                        GIT_CONFIG_COUNT="1", GIT_CONFIG_KEY_0="http.version",
+                        GIT_CONFIG_VALUE_0="HTTP/1.1" if mode == "anonymous-h1" else "HTTP/2",
+                    )
+                    env.pop("GIT_CONFIG_PARAMETERS", None)
+                    if mode == "authenticated-h2":
+                        env.update(
+                            GIT_CONFIG_COUNT="2",
+                            GIT_CONFIG_KEY_1="http.https://github.com/.extraheader",
+                            GIT_CONFIG_VALUE_1=f"AUTHORIZATION: basic {BASIC}",
+                        )
+                    dest = str(Path(tmp) / f"clone-{len(results)}")
+                    code, out, err, duration = run(
+                        ["git", "clone", "--no-checkout", f"https://github.com/{repo}", dest],
+                        env=env, cwd=tmp,
+                    )
+                    for line in err.splitlines():
+                        if "<= Recv header:" in line:
+                            header = line.split("<= Recv header:", 1)[1].strip()
+                            if SAFE_HEADER.match(header):
+                                print(redact(line))
+                        elif re.search(r"=> Send header: (GET|POST) ", line) or line.startswith(("fatal:", "error:", "remote:", "Timed out")):
+                            print(redact(line))
+                    result = dict(repo=repo, mode=mode, attempt=attempt, exit=code, seconds=duration)
+                    results.append(result)
+                    print(json.dumps(result), flush=True)
+                    print("::endgroup::", flush=True)
+    print(json.dumps(results, indent=2))
+    with open(os.environ["GITHUB_STEP_SUMMARY"], "a") as summary:
+        summary.write("| Repository | Mode | Attempt | Exit | Seconds |\n|---|---|---|---|---|\n")
+        for r in results:
+            summary.write(f"| {r['repo']} | {r['mode']} | {r['attempt']} | {r['exit']} | {r['seconds']} |\n")
+    sys.exit(0)
+
+
 if len(sys.argv) > 1 and sys.argv[1] in ("--build", "--recover"):
     with tempfile.TemporaryDirectory() as tmp:
         trace = Path(tmp) / "git-http.log"

--- a/.github/workflows/diagnose-github-clones.yml
+++ b/.github/workflows/diagnose-github-clones.yml
@@ -12,6 +12,7 @@ permissions:
 
 jobs:
   compare:
+    if: github.event_name == 'workflow_dispatch'
     name: Clone diagnostics (${{ matrix.name }})
     strategy:
       fail-fast: false
@@ -49,3 +50,24 @@ jobs:
         env:
           DIAGNOSTIC_TOKEN: ${{ github.token }}
         run: python3 .github/scripts/diagnose-github-clones.py --recover
+
+  focused:
+    name: Focused clones (${{ matrix.name }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: arc
+            runner: '{"group":"arc-public-large-amd64-runner"}'
+          - name: github-hosted
+            runner: '"ubuntu-latest"'
+    runs-on: ${{ fromJSON(matrix.runner) }}
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
+      - name: Compare fresh clones across authentication and HTTP versions
+        env:
+          DIAGNOSTIC_TOKEN: ${{ github.token }}
+        run: python3 .github/scripts/diagnose-github-clones.py --clone-check

--- a/.github/workflows/diagnose-github-clones.yml
+++ b/.github/workflows/diagnose-github-clones.yml
@@ -1,0 +1,39 @@
+name: Diagnose GitHub clones
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/diagnose-github-clones.yml
+      - .github/scripts/diagnose-github-clones.py
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  compare:
+    name: Clone diagnostics (${{ matrix.name }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: arc
+            runner: '{"group":"arc-public-large-amd64-runner"}'
+          - name: github-hosted
+            runner: '"ubuntu-latest"'
+    runs-on: ${{ fromJSON(matrix.runner) }}
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
+      - name: Compare Git transport and API responses
+        env:
+          DIAGNOSTIC_TOKEN: ${{ github.token }}
+        run: python3 .github/scripts/diagnose-github-clones.py
+      - uses: foundry-rs/foundry-toolchain@908c540300062bd5a7e473851cdb4282204cee09
+        with:
+          version: 1.7.1
+          cache: false
+      - name: Reproduce original uncached contract build
+        run: make sol-build

--- a/.github/workflows/diagnose-github-clones.yml
+++ b/.github/workflows/diagnose-github-clones.yml
@@ -36,4 +36,16 @@ jobs:
           version: 1.7.1
           cache: false
       - name: Reproduce original uncached contract build
-        run: make sol-build
+        id: build
+        continue-on-error: true
+        run: python3 .github/scripts/diagnose-github-clones.py --build
+      - name: Probe immediately after clone failure
+        if: steps.build.outcome == 'failure'
+        env:
+          DIAGNOSTIC_TOKEN: ${{ github.token }}
+        run: python3 .github/scripts/diagnose-github-clones.py
+      - name: Retry failed build with Git authentication
+        if: steps.build.outcome == 'failure'
+        env:
+          DIAGNOSTIC_TOKEN: ${{ github.token }}
+        run: python3 .github/scripts/diagnose-github-clones.py --recover


### PR DESCRIPTION
Public dependency clones intermittently fail on ARC because GitHub challenges anonymous Git traffic with HTTP 401 during negotiation. The experiment reproduces the original failure on ARC while identical GitHub-hosted contract builds succeed. Authenticating the Git requests with the existing job `GITHUB_TOKEN` succeeds during the same ARC diagnostic session.

This is a diagnostic draft, not a production workflow migration.

### Evidence

| Experiment | ARC | GitHub-hosted |
|---|---|---|
| First uncached `make sol-build` | Failed cloning `poseidon-solidity` | Passed |
| Second uncached `make sol-build` | Passed; failure is intermittent | Passed |
| Second run's Git probes | 7/12 anonymous requests failed; 6/6 authenticated requests passed | See linked logs |
| Fresh clone comparison: two repositories, three repetitions per mode | All 18 passed | All 18 passed |

- [First comparison](https://github.com/worldcoin/world-id-protocol/actions/runs/34232293313): reproduces the same username/flush errors as the original run.
- [Traced ARC run](https://github.com/worldcoin/world-id-protocol/actions/runs/34232701727/job/102082555958): anonymous `poseidon-solidity` discovery returns HTTP 200, followed by HTTP 103/401 and `www-authenticate: Basic realm="GitHub"`. Both default and clean Git configuration fail. The immediately following authenticated request returns HTTP 200 and exits successfully. Anonymous REST core quota remains 60/60; the Git responses do not report a numerical rate limit or retry deadline.
- [Focused clone comparison](https://github.com/worldcoin/world-id-protocol/actions/runs/34233160256): anonymous HTTP/2, anonymous HTTP/1.1, and authenticated HTTP/2 each pass 6/6 on each runner in this later sample. This does not prove HTTP/1.1 is a durable workaround.

[GitHub's September 3 staff explanation](https://github.com/orgs/community/discussions/206581) confirms expanded protections for anonymous Git traffic deliberately return 401 so clients can retry with credentials and receive higher limits. This matches our observed transport responses and the incident timing.

### Conclusion and remediation

The failure is GitHub's anonymous Git traffic protection on the ARC request path, not exhaustion of the REST API's 60-request quota. `persist-credentials: false` removes checkout authentication before `forge install`, leaving dependency fetches anonymous and unable to answer the challenge. The experiments do not reveal GitHub's exact threshold or prove which IP/region/traffic signal triggered the protection.

Authenticate dependency installation with the job's existing read-only `GITHUB_TOKEN`, scoped to that step and inherited by Git subprocesses. The diagnostic script demonstrates an environment-scoped `http.https://github.com/.extraheader` without persisting credentials. A new PAT is unnecessary for these public dependencies. Another option is fetching submodules during authenticated checkout. Moving the job to GitHub-hosted runners passed twice, but authentication addresses the observed challenge directly.

### Diagnostic workflow

PR changes run the bounded fresh-clone comparison. Manual dispatch additionally runs uncached contract builds and authenticated recovery after failure. The script prints only selected inbound headers and outgoing HTTP request paths, never outgoing credential headers; each command/job has a timeout. Existing production workflows are unchanged.

Validation: Python syntax parsing, `git diff --check`, two full runner comparisons, and the focused clone matrix completed. Probe jobs intentionally record individual failures without failing the diagnostic step; inspect the recorded exit codes rather than only the green job status.
