### PR TITLE
ci: authenticate contract dependency installation on ARC

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -50,6 +50,18 @@ jobs:
         with:
           version: 1.7.1
 
+      - name: Install contract dependencies
+        if: steps.cache-contracts.outputs.cache-hit != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          git_auth=$(printf 'x-access-token:%s' "$GH_TOKEN" | base64 -w0)
+          echo "::add-mask::$git_auth"
+          GIT_CONFIG_COUNT=1 \
+          GIT_CONFIG_KEY_0=http.https://github.com/.extraheader \
+          GIT_CONFIG_VALUE_0="AUTHORIZATION: basic $git_auth" \
+          forge install --root contracts
+
       - name: Build contracts and extract ABIs
         if: steps.cache-contracts.outputs.cache-hit != 'true'
         run: make sol-build
@@ -314,6 +326,17 @@ jobs:
         with:
           # See https://github.com/worldfnd/provekit, a specific nargo toolchain version is required
           toolchain: v1.0.0-beta.11
+
+      - name: Install contract dependencies
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          git_auth=$(printf 'x-access-token:%s' "$GH_TOKEN" | base64 -w0)
+          echo "::add-mask::$git_auth"
+          GIT_CONFIG_COUNT=1 \
+          GIT_CONFIG_KEY_0=http.https://github.com/.extraheader \
+          GIT_CONFIG_VALUE_0="AUTHORIZATION: basic $git_auth" \
+          forge install --root contracts
 
       - name: Build contracts
         run: |


### PR DESCRIPTION
GitHub intermittently challenges anonymous contract dependency clones on ARC with HTTP 401, causing `forge install` to fail with a username prompt. Install dependencies with the job's existing read-only `GITHUB_TOKEN` before building contracts in both Build Contracts and Local Setup Test.

The authorization header is masked and passed through environment-scoped Git configuration only for `forge install`, including its recursive Git subprocesses. Checkout still uses `persist-credentials: false`, and cached contract artifacts still skip dependency installation. No new secrets or diagnostic workflows are added.

Validation: YAML parsing, Bash syntax checks, and `git diff --check` pass. The investigation in #986 reproduced failures on ARC and verified authenticated requests and fresh clones succeed. This PR's CI will validate the complete installation and build on ARC.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change using the existing read-only GITHUB_TOKEN with masked credentials; no runtime or application behavior changes.
> 
> **Overview**
> Fixes intermittent **401 failures** when ARC runners clone Foundry contract deps during CI by running **`forge install --root contracts`** with the job’s read-only **`GITHUB_TOKEN`** before contract builds.
> 
> The new **Install contract dependencies** step is added in **Build Contracts** (only on cache miss, alongside Foundry install) and **Local Setup Test** (always, before `make sol-build`). Git auth is injected via scoped **`GIT_CONFIG_*`** env vars and a masked Basic **`Authorization`** header so nested Git subprocesses can reach GitHub without changing checkout’s **`persist-credentials: false`** or introducing new secrets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af477f91735e2960f330101f08896203d400db07. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->