### PR TITLE
docs: publish mdBook with GitHub Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,45 @@
+name: Publish mdBook
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/docs.yml"
+      - "book.toml"
+      - "docs/**"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: github-pages
+  cancel-in-progress: true
+
+jobs:
+  publish:
+    name: Build and publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1 https://github.com/actions/checkout/releases/tag/v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install mdBook tools
+        uses: taiki-e/install-action@e24b8b7a939c6a537188f34a4163cb153dd85cf6 # v2.69.1 https://github.com/taiki-e/install-action/releases/tag/v2.69.1
+        with:
+          tool: mdbook@0.5.4,mdbook-mermaid@0.17.1
+
+      - name: Build documentation
+        run: |
+          mdbook build
+          touch book/.nojekyll
+
+      - name: Publish documentation
+        uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4 https://github.com/peaceiris/actions-gh-pages/releases/tag/v4
+        with:
+          github_token: ${{ github.token }}
+          publish_branch: gh-pages
+          publish_dir: ./book
+          force_orphan: true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,6 +7,8 @@ on:
       - ".github/workflows/docs.yml"
       - "book.toml"
       - "docs/**"
+      - "flake.lock"
+      - "flake.nix"
   workflow_dispatch:
 
 permissions:
@@ -26,14 +28,12 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install mdBook tools
-        uses: taiki-e/install-action@e24b8b7a939c6a537188f34a4163cb153dd85cf6 # v2.69.1 https://github.com/taiki-e/install-action/releases/tag/v2.69.1
-        with:
-          tool: mdbook@0.5.4,mdbook-mermaid@0.17.1
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22 https://github.com/DeterminateSystems/nix-installer-action/releases/tag/v22
 
       - name: Build documentation
         run: |
-          mdbook build
+          nix develop .#docs --command mdbook build
           touch book/.nojekyll
 
       - name: Publish documentation

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 # World ID
 
+[![Protocol documentation](https://github.com/worldcoin/world-id-protocol/actions/workflows/docs.yml/badge.svg)](https://worldcoin.github.io/world-id-protocol/)
+
 World ID is a protocol built to enable anonymous proof of human (PoH) at global scale and to complement existing identity systems. World ID allows individuals to prove things about themselves — like they are a real and unique human, not a bot — without revealing any personal information. [Read more about World ID][website].
 
 This repository contains the **core components of the World ID Protocol**, including the smart contracts, Rust libraries, and services that power the protocol.

--- a/book.toml
+++ b/book.toml
@@ -17,4 +17,4 @@ command = "mdbook-mermaid"
 additional-js = ["docs/mermaid.min.js", "docs/mermaid-init.js"]
 git-repository-url = "https://github.com/worldcoin/world-id-protocol"
 edit-url-template = "https://github.com/worldcoin/world-id-protocol/edit/main/{path}"
-site-url = "/"
+site-url = "/world-id-protocol/"

--- a/flake.nix
+++ b/flake.nix
@@ -27,19 +27,29 @@
           inherit nargo;
         };
 
-        devShells.default = pkgs.mkShell {
-          packages = [
-            rustToolchain
-            nargo
-            pkgs.foundry # forge / cast / anvil
-            pkgs.circom
-            pkgs.just
-            pkgs.mdbook
-            pkgs.mdbook-mermaid
-            pkgs.pkg-config
-            pkgs.python3
-            pkgs.openssl
-          ];
+        devShells = {
+          default = pkgs.mkShell {
+            packages = [
+              rustToolchain
+              nargo
+              pkgs.foundry # forge / cast / anvil
+              pkgs.circom
+              pkgs.just
+              pkgs.mdbook
+              pkgs.mdbook-mermaid
+              pkgs.pkg-config
+              pkgs.python3
+              pkgs.openssl
+            ];
+          };
+
+          docs = pkgs.mkShell {
+            packages = [
+              pkgs.mdbook
+              pkgs.mdbook-mermaid
+              pkgs.python3
+            ];
+          };
         };
       });
 }


### PR DESCRIPTION
## Summary

- build the protocol mdBook through a lightweight, flake-pinned Nix docs shell on documentation changes and manual dispatch
- force-publish the rendered output to an orphan `gh-pages` branch
- configure the project-page base path and add a README badge linking to the published docs

## Testing

- `nix flake check --no-build`
- `nix develop .#docs --command mdbook build`
- `actionlint .github/workflows/docs.yml`
- `git diff --check`

## Deployment

Merge this PR first so the workflow creates `gh-pages`; then apply the companion infrastructure PR worldcoin/infrastructure#48515, which selects `gh-pages:/` as the GitHub Pages source.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI, Nix dev shell, and documentation hosting configuration only; no runtime protocol, contract, or auth changes.
> 
> **Overview**
> Adds **automated GitHub Pages publishing** for the protocol mdBook. A new `docs.yml` workflow runs on `main` when documentation-related paths change (or on manual dispatch): it builds with `nix develop .#docs --command mdbook build`, adds `book/.nojekyll`, and force-publishes `./book` to an orphan `gh-pages` branch.
> 
> **Nix** gains a dedicated `docs` dev shell (mdbook, mdbook-mermaid, python3) separate from the full default shell. **mdBook** `site-url` is set to `/world-id-protocol/` for project-page hosting. The **README** gets a workflow badge linking to the published site.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d95d0787e10e96e6d0a01132428fa06cd46d98c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->