### PR TITLE
feat: benchmark low, mid and high spec devices via repo device matrix

### DIFF
--- a/.github/workflows/mobile-bench-reusable.yml
+++ b/.github/workflows/mobile-bench-reusable.yml
@@ -37,7 +37,7 @@ on:
         type: string
         default: "both"
       device_profile:
-        description: "Device profile: low-spec, mid-spec, high-spec, custom"
+        description: "Device profile tag resolved against the caller's device-matrix.yaml (e.g. low-spec, mid-spec, high-spec, all)"
         required: false
         type: string
         default: "low-spec"
@@ -207,7 +207,7 @@ jobs:
       - name: Install XcodeGen
         run: brew install xcodegen
 
-      - name: Resolve iOS device
+      - name: Resolve iOS devices
         id: resolve_device
         working-directory: caller
         shell: bash
@@ -215,30 +215,36 @@ jobs:
           DEVICE_PROFILE: ${{ inputs.device_profile }}
           IOS_DEVICE_OVERRIDE: ${{ inputs.ios_device }}
           IOS_OS_VERSION_OVERRIDE: ${{ inputs.ios_os_version }}
+          CRATE_PATH: ${{ inputs.crate_path }}
         run: |
+          set -euo pipefail
           if [ -n "$IOS_DEVICE_OVERRIDE" ] && [ -n "$IOS_OS_VERSION_OVERRIDE" ]; then
-            echo "device_name=${IOS_DEVICE_OVERRIDE}" >> "$GITHUB_OUTPUT"
-            echo "os_version=${IOS_OS_VERSION_OVERRIDE}" >> "$GITHUB_OUTPUT"
-            echo "Using custom device: ${IOS_DEVICE_OVERRIDE} (${IOS_OS_VERSION_OVERRIDE})"
+            specs="${IOS_DEVICE_OVERRIDE}-${IOS_OS_VERSION_OVERRIDE}"
+            echo "Using custom device: ${specs}"
           else
-            PROFILE_TO_RESOLVE="${DEVICE_PROFILE}"
-            if [ "$PROFILE_TO_RESOLVE" = "low-spec" ]; then
-              PROFILE_TO_RESOLVE="mid-spec"
-              echo "::warning::Using iOS mid-spec profile because the current low-spec iOS profile is incompatible with the generated BrowserStack app bundle"
-            fi
+            # Profiles (including `all`) are tags in the repo-owned device matrix,
+            # which also encodes the BrowserStack-inventory workarounds.
             output=$(cargo-mobench devices resolve \
               --platform ios \
-              --profile "${PROFILE_TO_RESOLVE}" \
+              --profile "${DEVICE_PROFILE}" \
+              --device-matrix "${CRATE_PATH}/device-matrix.yaml" \
               --format json 2>&1) || {
-                echo "::error::Failed to resolve iOS device: $output"
+                echo "::error::Failed to resolve iOS devices: $output"
                 exit 1
               }
-            device_name=$(echo "$output" | jq -r '.device // .name')
-            os_version=$(echo "$output" | jq -r '.os_version')
-            echo "device_name=${device_name}" >> "$GITHUB_OUTPUT"
-            echo "os_version=${os_version}" >> "$GITHUB_OUTPUT"
-            echo "Resolved iOS device: ${device_name} (${os_version})"
+            specs=$(jq -r '.devices[].identifier' <<<"$output")
+            if [ -z "${specs}" ]; then
+              echo "::error::Profile ${DEVICE_PROFILE} resolved to no iOS devices"
+              exit 1
+            fi
+            echo "Resolved iOS devices:"
+            echo "${specs}"
           fi
+          {
+            echo "device_specs<<SPECS_EOF"
+            echo "${specs}"
+            echo "SPECS_EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Debug target sysroot
         shell: bash
@@ -279,18 +285,21 @@ jobs:
           WARMUP: ${{ inputs.warmup }}
           FETCH_TIMEOUT_SECS: ${{ inputs.fetch_timeout_secs }}
           IOS_COMPLETION_TIMEOUT_SECS: ${{ inputs.ios_completion_timeout_secs }}
-          IOS_DEVICE: ${{ steps.resolve_device.outputs.device_name }}
-          IOS_OS_VERSION: ${{ steps.resolve_device.outputs.os_version }}
+          DEVICE_SPECS: ${{ steps.resolve_device.outputs.device_specs }}
           RELEASE_FLAG: ${{ inputs.build_release && '--release' || '' }}
           CRATE_PATH: ${{ inputs.crate_path }}
         run: |
           set -euo pipefail
-          device_spec="${IOS_DEVICE}-${IOS_OS_VERSION}"
+          device_args=()
+          while IFS= read -r spec; do
+            [ -n "${spec}" ] && device_args+=(--devices "${spec}")
+          done <<<"${DEVICE_SPECS}"
           functions_arg="${FUNCTIONS}"
           if [[ "${FUNCTIONS}" == \[* ]]; then
             functions_arg=$(jq -r 'join(",")' <<<"${FUNCTIONS}")
           fi
-          echo "Running iOS benchmarks on: ${device_spec}"
+          echo "Running iOS benchmarks on:"
+          echo "${DEVICE_SPECS}"
           echo "Resolved functions: ${functions_arg}"
 
           cargo-mobench ci run \
@@ -298,7 +307,7 @@ jobs:
             --functions "${functions_arg}" \
             --iterations "${ITERATIONS}" \
             --warmup "${WARMUP}" \
-            --devices "${device_spec}" \
+            "${device_args[@]}" \
             --crate-path "$CRATE_PATH" \
             $RELEASE_FLAG \
             --ios-completion-timeout-secs "${IOS_COMPLETION_TIMEOUT_SECS}" \
@@ -460,7 +469,7 @@ jobs:
           fi
           cargo install --path mobench-src/crates/mobench --locked
 
-      - name: Resolve Android device
+      - name: Resolve Android devices
         id: resolve_device
         working-directory: caller
         shell: bash
@@ -468,25 +477,36 @@ jobs:
           DEVICE_PROFILE: ${{ inputs.device_profile }}
           ANDROID_DEVICE_OVERRIDE: ${{ inputs.android_device }}
           ANDROID_OS_VERSION_OVERRIDE: ${{ inputs.android_os_version }}
+          CRATE_PATH: ${{ inputs.crate_path }}
         run: |
+          set -euo pipefail
           if [ -n "$ANDROID_DEVICE_OVERRIDE" ] && [ -n "$ANDROID_OS_VERSION_OVERRIDE" ]; then
-            echo "device_name=${ANDROID_DEVICE_OVERRIDE}" >> "$GITHUB_OUTPUT"
-            echo "os_version=${ANDROID_OS_VERSION_OVERRIDE}" >> "$GITHUB_OUTPUT"
-            echo "Using custom device: ${ANDROID_DEVICE_OVERRIDE} (${ANDROID_OS_VERSION_OVERRIDE})"
+            specs="${ANDROID_DEVICE_OVERRIDE}-${ANDROID_OS_VERSION_OVERRIDE}"
+            echo "Using custom device: ${specs}"
           else
+            # Profiles (including `all`) are tags in the repo-owned device matrix,
+            # which also encodes the BrowserStack-inventory workarounds.
             output=$(cargo-mobench devices resolve \
               --platform android \
               --profile "${DEVICE_PROFILE}" \
+              --device-matrix "${CRATE_PATH}/device-matrix.yaml" \
               --format json 2>&1) || {
-                echo "::error::Failed to resolve Android device: $output"
+                echo "::error::Failed to resolve Android devices: $output"
                 exit 1
               }
-            device_name=$(echo "$output" | jq -r '.device // .name')
-            os_version=$(echo "$output" | jq -r '.os_version')
-            echo "device_name=${device_name}" >> "$GITHUB_OUTPUT"
-            echo "os_version=${os_version}" >> "$GITHUB_OUTPUT"
-            echo "Resolved Android device: ${device_name} (${os_version})"
+            specs=$(jq -r '.devices[].identifier' <<<"$output")
+            if [ -z "${specs}" ]; then
+              echo "::error::Profile ${DEVICE_PROFILE} resolved to no Android devices"
+              exit 1
+            fi
+            echo "Resolved Android devices:"
+            echo "${specs}"
           fi
+          {
+            echo "device_specs<<SPECS_EOF"
+            echo "${specs}"
+            echo "SPECS_EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Build Android artifacts
         working-directory: caller
@@ -507,18 +527,21 @@ jobs:
           ITERATIONS: ${{ inputs.iterations }}
           WARMUP: ${{ inputs.warmup }}
           FETCH_TIMEOUT_SECS: ${{ inputs.fetch_timeout_secs }}
-          ANDROID_DEVICE: ${{ steps.resolve_device.outputs.device_name }}
-          ANDROID_OS_VERSION: ${{ steps.resolve_device.outputs.os_version }}
+          DEVICE_SPECS: ${{ steps.resolve_device.outputs.device_specs }}
           RELEASE_FLAG: ${{ inputs.build_release && '--release' || '' }}
           CRATE_PATH: ${{ inputs.crate_path }}
         run: |
           set -euo pipefail
-          device_spec="${ANDROID_DEVICE}-${ANDROID_OS_VERSION}"
+          device_args=()
+          while IFS= read -r spec; do
+            [ -n "${spec}" ] && device_args+=(--devices "${spec}")
+          done <<<"${DEVICE_SPECS}"
           functions_arg="${FUNCTIONS}"
           if [[ "${FUNCTIONS}" == \[* ]]; then
             functions_arg=$(jq -r 'join(",")' <<<"${FUNCTIONS}")
           fi
-          echo "Running Android benchmarks on: ${device_spec}"
+          echo "Running Android benchmarks on:"
+          echo "${DEVICE_SPECS}"
           echo "Resolved functions: ${functions_arg}"
 
           cargo-mobench ci run \
@@ -526,7 +549,7 @@ jobs:
             --functions "${functions_arg}" \
             --iterations "${ITERATIONS}" \
             --warmup "${WARMUP}" \
-            --devices "${device_spec}" \
+            "${device_args[@]}" \
             --crate-path "$CRATE_PATH" \
             $RELEASE_FLAG \
             --fetch \
@@ -965,25 +988,21 @@ jobs:
           timestamp=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
           run_url="https://github.com/${GH_REPO}/actions/runs/${GITHUB_RUN_ID}"
 
-          extract_device() {
+          # summary.json's `devices` is a list of device identifiers; a snapshot run may carry several.
+          extract_devices() {
             local summary="$1"
             if [ ! -f "${summary}" ]; then
               echo ""
               return 0
             fi
             jq -r '
-              (.device // .devices[0].device // .devices[0].name // .runs[0].device // .platform.device // empty)
-              as $d
-              | (.os_version // .devices[0].os_version // .runs[0].os_version // .platform.os_version // empty)
-              as $os
-              | if ($d|length) > 0 then
-                  if ($os|length) > 0 then "\($d) (\($os))" else $d end
-                else empty end
+              [(.devices // [])[] | if type == "string" then . else (.device // .name // empty) end]
+              | join(", ")
             ' "${summary}" 2>/dev/null || true
           }
 
-          ios_device=$(extract_device "${ios_summary}")
-          android_device=$(extract_device "${android_summary}")
+          ios_device=$(extract_devices "${ios_summary}")
+          android_device=$(extract_devices "${android_summary}")
 
           jq -n \
             --arg schema "mobench-results-v1" \
@@ -1026,10 +1045,10 @@ jobs:
             echo "- **Iterations / warmup:** ${ITERATIONS} / ${WARMUP}"
             echo "- **Device profile:** ${DEVICE_PROFILE}"
             if [ -n "${ios_device}" ]; then
-              echo "- **iOS device:** ${ios_device}"
+              echo "- **iOS devices:** ${ios_device}"
             fi
             if [ -n "${android_device}" ]; then
-              echo "- **Android device:** ${android_device}"
+              echo "- **Android devices:** ${android_device}"
             fi
             echo
             if [ -f rendered/ios/github-summary.md ]; then

--- a/.github/workflows/mobile-bench.yml
+++ b/.github/workflows/mobile-bench.yml
@@ -13,7 +13,7 @@ on:
           - ios
           - both
       device_profile:
-        description: "Device profile: low-spec, mid-spec, high-spec, custom"
+        description: "Device profile: low-spec, mid-spec, high-spec, all (full tier spread; use for open_results_pr snapshots), custom"
         required: false
         type: choice
         default: low-spec
@@ -21,6 +21,7 @@ on:
           - low-spec
           - mid-spec
           - high-spec
+          - all
           - custom
       ios_device:
         description: "Custom iOS device name"
@@ -144,11 +145,10 @@ jobs:
       device_profile: ${{ inputs.device_profile }}
       ios_device: ${{ inputs.ios_device }}
       ios_os_version: ${{ inputs.ios_os_version }}
-      # mobench's low-spec profile still resolves to Moto G9 Play-10.0, which
-      # the current BrowserStack inventory no longer exposes. Keep manual
-      # overrides intact and use the available low-spec replacement by default.
-      android_device: ${{ inputs.android_device != '' && inputs.android_device || 'Motorola Moto G71 5G' }}
-      android_os_version: ${{ inputs.android_os_version != '' && inputs.android_os_version || '11.0' }}
+      # BrowserStack-inventory workarounds (e.g. the dead Moto G9 Play low-spec
+      # device) live in crates/zk-mobile-bench/device-matrix.yaml, not here.
+      android_device: ${{ inputs.android_device }}
+      android_os_version: ${{ inputs.android_os_version }}
       iterations: ${{ inputs.iterations }}
       warmup: ${{ inputs.warmup }}
       fetch_timeout_secs: ${{ inputs.fetch_timeout_secs }}

--- a/crates/zk-mobile-bench/device-matrix.yaml
+++ b/crates/zk-mobile-bench/device-matrix.yaml
@@ -1,0 +1,31 @@
+# Device matrix for mobile ZK benchmarks (consumed by `cargo-mobench devices resolve`).
+#
+# Profiles are tags: resolving a profile returns every device carrying that tag.
+# `all` runs the full tier spread and is the profile snapshot runs should use.
+#
+# Deviations from mobench's built-in matrix:
+# - Android low-spec is Motorola Moto G71 5G: the built-in Moto G9 Play is no
+#   longer in BrowserStack's inventory.
+# - iOS low-spec is iPhone 14: the built-in iPhone SE 2020 is incompatible with
+#   the generated BrowserStack app bundle.
+devices:
+  - name: Motorola Moto G71 5G
+    os: android
+    os_version: "11.0"
+    tags: [low-spec, all]
+  - name: Google Pixel 7
+    os: android
+    os_version: "13.0"
+    tags: [mid-spec, all, default]
+  - name: Samsung Galaxy S24
+    os: android
+    os_version: "14.0"
+    tags: [high-spec, all]
+  - name: iPhone 14
+    os: ios
+    os_version: "16"
+    tags: [low-spec, mid-spec, all, default]
+  - name: iPhone 16 Pro
+    os: ios
+    os_version: "18"
+    tags: [high-spec, all]

--- a/crates/zk-mobile-bench/docs/README.md
+++ b/crates/zk-mobile-bench/docs/README.md
@@ -67,14 +67,15 @@ Benchmark reports also preserve optional semantic `phases` emitted by
 - **PR comment**: `/mobench platform=both iterations=30 warmup=5`
 - **PR label**: Add the `bench` label (dispatches after compile gate passes)
 - **Manual**: Actions > "Mobile Benchmarks" > Run workflow
-- **Publish results**: same manual workflow on `main`, set **open_results_pr=true** (leave `pr_number` empty)
+- **Publish results**: same manual workflow on `main`, set **open_results_pr=true** and **device_profile=all** (leave `pr_number` empty)
 
 ## Results
 
 Checked-in BrowserStack results live in
 [`../results/`](../results/) ([`LATEST.md`](../results/LATEST.md)).
 
-- **Refresh**: Actions → Mobile Benchmarks on `main` with `open_results_pr=true` (and empty `pr_number`). On success the workflow opens a PR that updates these files; merge it to adopt the new snapshot.
+- **Refresh**: Actions → Mobile Benchmarks on `main` with `open_results_pr=true` and `device_profile=all` (and empty `pr_number`). On success the workflow opens a PR that updates these files; merge it to adopt the new snapshot.
+- **Devices**: profiles are tags in [`../device-matrix.yaml`](../device-matrix.yaml); `all` covers the low/mid/high tiers, so summaries and plots compare devices side by side.
 - **PR runs** (`/mobench`, `bench` label) post sticky comments with their own results; they do not modify the checked-in snapshot.
 
 ## Benchmark Functions

--- a/crates/zk-mobile-bench/results/LATEST.md
+++ b/crates/zk-mobile-bench/results/LATEST.md
@@ -2,6 +2,6 @@
 
 Status: **placeholder** — no BrowserStack results committed yet.
 
-Populate by running **Actions → Mobile Benchmarks** on `main` with **`open_results_pr=true`** (leave `pr_number` empty). On success the workflow opens a PR that updates this file plus `ios/summary.json` and `android/summary.json`; merge that PR to adopt the numbers.
+Populate by running **Actions → Mobile Benchmarks** on `main` with **`open_results_pr=true`** and **`device_profile=all`** (leave `pr_number` empty). On success the workflow opens a PR that updates this file plus `ios/summary.json` and `android/summary.json`; merge that PR to adopt the numbers.
 
 See [README.md](README.md) for refresh policy.

--- a/crates/zk-mobile-bench/results/README.md
+++ b/crates/zk-mobile-bench/results/README.md
@@ -11,6 +11,6 @@ Checked-in BrowserStack results for the seven `zk-mobile-bench` functions.
 
 ## When these update
 
-Run **Actions → Mobile Benchmarks** on `main` with **`open_results_pr=true`** (leave `pr_number` empty). On success the workflow opens a PR that refreshes these files; merge that PR to adopt the new snapshot.
+Run **Actions → Mobile Benchmarks** on `main` with **`open_results_pr=true`**, **`device_profile=all`** (leave `pr_number` empty). The `all` profile runs the low/mid/high tiers from [`../device-matrix.yaml`](../device-matrix.yaml) so the snapshot and its plots cover the full device spread. On success the workflow opens a PR that refreshes these files; merge that PR to adopt the new snapshot.
 
 PR `/mobench` and `bench`-label runs post their own results in a sticky comment; they do **not** modify these files.


### PR DESCRIPTION
- Adds `crates/zk-mobile-bench/device-matrix.yaml`; device profiles now resolve as tags against it via `--device-matrix`, and the BrowserStack-inventory workarounds (dead Moto G9 Play, incompatible iPhone SE 2020) move from workflow shell / caller defaults into the matrix.
- New `device_profile=all` runs the full tier spread — 3 Android + 2 iOS devices — in a single `ci run` per platform, so summaries and sina plots compare tiers side by side.
- Resolve steps emit a device-spec list; bench steps pass repeated `--devices` args. Custom device overrides unchanged.
- `meta.json`/`LATEST.md` record all devices of a snapshot run; docs now tell snapshot runs to use `device_profile=all`.
- Verified against mobench v0.2.0 built from source: every profile (incl. `all`) resolves to the intended devices; all 26 workflow scripts pass `bash -n`. BrowserStack cost only grows when `all` is explicitly selected.